### PR TITLE
fix: replace gh-release action to resolve Node.js 20 deprecation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,9 +74,7 @@ jobs:
         run: npx npm@latest publish --provenance --access public
       - name: Create GitHub Release
         if: steps.version.outputs.changed == 'true'
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: v${{ steps.version.outputs.version }}
-          generate_release_notes: true
-          draft: false
-          prerelease: false
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: gh release create "v${VERSION}" --generate-notes


### PR DESCRIPTION
## Summary
- Replaced `softprops/action-gh-release@v2` with `gh release create` CLI command to eliminate Node.js 20 deprecation warning
- No behavior change — still creates a GitHub release with auto-generated notes

## Test plan
- [x] Verified `gh release create` syntax is correct for GitHub Actions runners