### PR TITLE
feat: Phase 2 — deployment quality gates, rollback backup, test stubs, integration tests (v0.2.0)

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "printWidth": 100,
+  "tabWidth": 2
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-04-06
+
 ### Added
 - `sfdt quality --generate-stubs` generates `@IsTest` stub `.cls` + `-meta.xml` pairs for Apex classes that lack a corresponding test class; respects `SFDT_API_VERSION` for metadata API version
 - `sfdt quality --dry-run` previews stub generation without writing files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `sfdt quality --generate-stubs` generates `@IsTest` stub `.cls` + `-meta.xml` pairs for Apex classes that lack a corresponding test class; respects `SFDT_API_VERSION` for metadata API version
+- `sfdt quality --dry-run` previews stub generation without writing files
+- `sfdt deploy` now runs preflight checks before every deployment; use `--skip-preflight` to bypass
+- Pre-rollback backup: `rollback.sh` retrieves current org state before applying a rollback manifest; configurable via `config.deployment.backupBeforeRollback` (default `true`) and `SFDT_BACKUP_BEFORE_ROLLBACK`
+- Integration tests for `loadConfig()` and `buildScriptEnv()` using real filesystem (no mocks)
+- Test fixtures in `test/fixtures/` for Salesforce DX project structures
+
+### Changed
+- Coverage threshold in `deployment-assistant.sh` and `deploy-manager.sh` is now driven by `SFDT_COVERAGE_THRESHOLD` instead of being hardcoded at 75%
+- `deploy-manager.sh` enforces a coverage gate before production deploys using the configured threshold
+- Quality scripts (`test-analyzer.sh`, `code-analyzer.sh`) updated to use `SFDT_` env var model — removed legacy `init_script_env` calls and aligned jq keys with current config schema (`.testClasses[]`, `.apexClasses[]`)
+- `scripts/utils/shared.sh` now exports `print_header`, `print_step`, `print_success`, `print_warning`, `print_error`, `print_info` helpers used by rollback, preflight, smoke, and drift scripts
+- `buildScriptEnv()` now maps `SFDT_LOG_DIR` from `config.logDir`
+
+### Fixed
+- `((VAR++))` arithmetic in `code-analyzer.sh` replaced with `VAR=$((VAR + 1))` — the post-increment form exits 1 under `set -e` when incrementing from 0, killing the script silently
+- Division-by-zero in `test-analyzer.sh` coverage table when no Apex classes are configured
+
 ## [0.1.5] - 2026-04-06
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,10 +46,15 @@ test/           Tests (vitest)
 | `SFDT_RELEASE_NOTES_DIR` | `config.releaseNotesDir` (default: `"release-notes"`) |
 | `SFDT_API_VERSION` | `config.sourceApiVersion` |
 | `SFDT_COVERAGE_THRESHOLD` | `config.deployment.coverageThreshold` (default: `75`) |
+| `SFDT_LOG_DIR` | `config.logDir` (optional; scripts fall back to `${SFDT_PROJECT_ROOT}/logs`) |
 | `SFDT_FEATURE_*` | Flattened from `config.features` |
 | `SFDT_DEFAULT_ENV` | `config.environments.default` |
 | `SFDT_ENV_ORGS` | Comma-joined org aliases from `config.environments.orgs` |
 | `SFDT_TEST_*` | Flattened from `config.testConfig` |
+| `SFDT_TEST_CLASSES` | Comma-joined test class names from `config.testConfig.testClasses` |
+| `SFDT_APEX_CLASSES` | Comma-joined Apex class names from `config.testConfig.apexClasses` |
+| `SFDT_NON_INTERACTIVE` | `"true"` when stdin is not a TTY or `options.interactive === false` |
+| `SFDT_PARALLEL_DELAY` | Seconds between parallel batch launches (default: `1`, set in shell scripts) |
 | `SFDT_PULL_*` | Flattened from `config.pullConfig` |
 
 When adding a new env var, update both `buildScriptEnv()` in `script-runner.js` and this table.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,7 @@ test/           Tests (vitest)
 | `SFDT_API_VERSION` | `config.sourceApiVersion` |
 | `SFDT_COVERAGE_THRESHOLD` | `config.deployment.coverageThreshold` (default: `75`) |
 | `SFDT_LOG_DIR` | `config.logDir` (optional; scripts fall back to `${SFDT_PROJECT_ROOT}/logs`) |
+| `SFDT_BACKUP_BEFORE_ROLLBACK` | `config.deployment.backupBeforeRollback` (default: `true`) |
 | `SFDT_FEATURE_*` | Flattened from `config.features` |
 | `SFDT_DEFAULT_ENV` | `config.environments.default` |
 | `SFDT_ENV_ORGS` | Comma-joined org aliases from `config.environments.orgs` |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,55 @@
+# Contributing to sfdt
+
+Thank you for your interest in contributing to the Salesforce DevTools CLI! This project aims to provide a production-grade toolkit for Salesforce DX.
+
+## Development Setup
+
+1.  **Clone the repository**:
+    ```bash
+    git clone https://github.com/sfdt-cli/sfdt.git
+    cd sfdt
+    ```
+
+2.  **Install dependencies**:
+    ```bash
+    npm install
+    ```
+
+3.  **Link for local development**:
+    ```bash
+    npm link
+    ```
+    This makes the `sfdt` command available globally, pointing to your local source code.
+
+## Project Structure
+
+- `bin/`: CLI entry point.
+- `src/commands/`: Implementation of individual subcommands.
+- `src/lib/`: Shared JavaScript logic (config, AI, script runner).
+- `scripts/`: Shell scripts (bash) that handle heavy lifting (SFDX calls).
+- `test/`: Vitest test suite.
+
+## Guidelines
+
+- **ESM Only**: This is a pure ESM project. Use `import`/`export`.
+- **Shell Scripts**: 
+  - Scripts must be non-interactive by default. Use `SFDT_NON_INTERACTIVE` check.
+  - Use `set -euo pipefail` for robustness.
+  - Rely on `SFDT_` environment variables passed from Node.js instead of parsing config files manually.
+- **Node.js**: Target Node.js >= 20.0.0.
+- **Testing**: Every new feature or bug fix must include tests.
+
+## Coding Standards
+
+- Run `npm run lint` before committing.
+- Run `npm run format` to ensure consistent code style (Prettier).
+
+## Submitting a Pull Request
+
+1.  Create a feature branch from `main`.
+2.  Make your changes and add tests.
+3.  Ensure all tests pass: `npm test`.
+4.  Open a PR with a clear description of the changes.
+
+---
+*By contributing, you agree that your contributions will be licensed under the MIT License.*

--- a/README.md
+++ b/README.md
@@ -32,21 +32,21 @@ sfdt deploy
 
 ## Commands Reference
 
-| Command | Description | Key Options |
-|---------|-------------|-------------|
-| `sfdt init` | Initialize `.sfdt/` config in current project | `--force` to overwrite existing config |
-| `sfdt deploy` | Interactive deployment with validation and tagging | `--target-org`, `--dry-run`, `--skip-tests` |
-| `sfdt release` | Generate release manifest from git diffs | `--from <ref>`, `--to <ref>`, `--output <dir>` |
-| `sfdt test` | Run Apex tests with coverage enforcement | `--parallel`, `--min-coverage <pct>`, `--suite <name>` |
-| `sfdt quality` | Analyze code and test quality | `--type <code\|tests\|all>`, `--fail-on <level>` |
-| `sfdt preflight` | Pre-release validation checklist | `--strict`, `--skip <checks>` |
-| `sfdt rollback` | Roll back a deployment | `--target-org`, `--manifest <path>` |
-| `sfdt smoke` | Post-deploy smoke testing | `--target-org`, `--suite <name>` |
-| `sfdt drift` | Detect org metadata drift from source | `--target-org`, `--types <list>` |
-| `sfdt changelog` | Manage project CHANGELOG.md | `generate`, `release`, `check` |
-| `sfdt review` | AI-powered code review | `--from <ref>`, `--to <ref>` |
-| `sfdt pull` | Pull metadata from org using configured groups | `--group <name>`, `--target-org` |
-| `sfdt notify` | Send Slack deployment notifications | `--channel`, `--status <success\|failure>` |
+| Command          | Description                                        | Key Options                                            |
+| ---------------- | -------------------------------------------------- | ------------------------------------------------------ |
+| `sfdt init`      | Initialize `.sfdt/` config in current project      | `--force` to overwrite existing config                 |
+| `sfdt deploy`    | Interactive deployment with validation and tagging | `--target-org`, `--dry-run`, `--skip-tests`            |
+| `sfdt release`   | Generate release manifest from git diffs           | `--from <ref>`, `--to <ref>`, `--output <dir>`         |
+| `sfdt test`      | Run Apex tests with coverage enforcement           | `--parallel`, `--min-coverage <pct>`, `--suite <name>` |
+| `sfdt quality`   | Analyze code and test quality                      | `--type <code\|tests\|all>`, `--fail-on <level>`       |
+| `sfdt preflight` | Pre-release validation checklist                   | `--strict`, `--skip <checks>`                          |
+| `sfdt rollback`  | Roll back a deployment                             | `--target-org`, `--manifest <path>`                    |
+| `sfdt smoke`     | Post-deploy smoke testing                          | `--target-org`, `--suite <name>`                       |
+| `sfdt drift`     | Detect org metadata drift from source              | `--target-org`, `--types <list>`                       |
+| `sfdt changelog` | Manage project CHANGELOG.md                        | `generate`, `release`, `check`                         |
+| `sfdt review`    | AI-powered code review                             | `--from <ref>`, `--to <ref>`                           |
+| `sfdt pull`      | Pull metadata from org using configured groups     | `--group <name>`, `--target-org`                       |
+| `sfdt notify`    | Send Slack deployment notifications                | `--channel`, `--status <success\|failure>`             |
 
 ## Configuration
 
@@ -123,9 +123,10 @@ Use groups with `sfdt pull --group core` to pull only the metadata types defined
 
 ## Requirements
 
-- **Node.js** >= 18
+- **Node.js** >= 20.0.0
 - **Salesforce CLI** (`sf`) installed and authenticated to target orgs
 - **bash** 4.0+ (macOS users: `brew install bash`)
+- **jq** 1.6+ (essential for test results and metadata processing)
 - **Optional:** [Claude CLI](https://www.npmjs.com/package/@anthropic-ai/claude-code) for AI features
 - **Optional:** [GitHub CLI](https://cli.github.com/) (`gh`) for PR creation during deployments
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,37 @@
+# sfdt Project Roadmap
+
+This roadmap outlines the planned features and improvements for the @sfdt/cli tool.
+
+## Phase 1: Core Robustness (Current) ✅
+
+- [x] Standardized configuration loader (`.sfdt/`).
+- [x] AI integration (Claude CLI).
+- [x] Enhanced Test Runner (Parallel tests).
+- [x] Non-interactive mode for CI/CD compatibility.
+- [x] Prettier and linting standardization.
+
+## Phase 2: Deployment & Quality ✅
+
+- [x] **Deployment Quality Gates**: Configurable coverage threshold (`SFDT_COVERAGE_THRESHOLD`) enforced in `deployment-assistant.sh` and `deploy-manager.sh`; preflight checks run automatically before every `sfdt deploy`.
+- [x] **Rollback Improvements**: `rollback.sh` retrieves and saves current org state before rolling back (partial rollbacks descoped).
+- [x] **Test Gaps Analysis**: `sfdt quality --generate-stubs` identifies Apex classes without tests and scaffolds `@IsTest` stub classes; `--dry-run` for preview. Quality scripts fixed to use current `SFDT_` env var model.
+- [x] **Integration Tests**: Real-filesystem integration tests for `loadConfig()` and `buildScriptEnv()` with test fixtures in `test/fixtures/`.
+
+## Phase 3: AI & Intelligence 🧠
+
+- [ ] **Smart package.xml Generator**: Automatically build manifests from git diffs with AI cleanup of dependencies.
+- [ ] **Error Log Interpreter**: AI-powered analysis of cryptic Salesforce deployment errors with suggested fixes.
+- [ ] **PR Description Automator**: Automatically generate a Slack/GitHub message based on deployment changes.
+
+## Phase 4: Platform & Ecosystem 🌐
+
+- [ ] **Other AI Platforms**: Add Gemini, others
+- [ ] **Plugin Architecture**: Allow external developers to add custom subcommands and scripts.
+- [ ] **Web UI**: A lightweight local web dashboard for monitoring test results and drift detection.
+- [ ] **Docker Support**: Official Docker image for use in CI/CD pipelines.
+
+---
+
+## Feedback & Suggestions
+
+We value community feedback! If you have ideas for features, please open an issue in the repository.

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
       "devDependencies": {
         "@vitest/coverage-v8": "^3.1.1",
         "eslint": "^9.22.0",
+        "prettier": "^3.5.3",
         "vitest": "^3.1.1"
       },
       "engines": {
@@ -3301,6 +3302,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
+      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-ms": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sfdt/cli",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "description": "Salesforce DevTools — Production-grade CLI for Salesforce DX deployment, testing, quality analysis, and release management",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "test:coverage": "vitest run --coverage",
     "lint": "eslint src/ bin/",
     "lint:fix": "eslint src/ bin/ --fix",
+    "format": "prettier --write \"src/**/*.js\" \"bin/*.js\" \"test/**/*.js\" \"README.md\" \"package.json\"",
     "dev": "npm link",
     "prepublishOnly": "npm test && npm run lint"
   },
@@ -57,6 +58,7 @@
   "devDependencies": {
     "@vitest/coverage-v8": "^3.1.1",
     "eslint": "^9.22.0",
+    "prettier": "^3.5.3",
     "vitest": "^3.1.1"
   },
   "repository": {

--- a/scripts/core/deploy-manager.sh
+++ b/scripts/core/deploy-manager.sh
@@ -302,6 +302,30 @@ show_deployment_menu() {
     esac
 }
 
+# Coverage gate: aborts production deploy if coverage is below threshold
+check_coverage_gate() {
+    local environment=$1
+    [[ "$environment" != "production" ]] && return 0
+    if ! command -v jq &>/dev/null; then
+        log_error "jq not found — cannot verify coverage; aborting production deploy"
+        return 1
+    fi
+    log_info "Checking coverage (>=${COVERAGE_THRESHOLD}%) before production deploy..."
+    local org_alias
+    org_alias=$(get_environment_config "$environment" "org_alias")
+    local test_output
+    test_output=$(sf apex run test --test-level RunLocalTests \
+        --target-org "$org_alias" --json --wait 20 2>/dev/null || echo '{}')
+    local coverage
+    coverage=$(echo "$test_output" | jq -r '.result.summary.orgWideCoverage // "0%"' \
+        2>/dev/null | tr -d '%')
+    if [[ "$coverage" =~ ^[0-9]+$ ]] && (( coverage < COVERAGE_THRESHOLD )); then
+        log_error "Coverage ${coverage}% below threshold ${COVERAGE_THRESHOLD}% — aborting"
+        return 1
+    fi
+    log_success "Coverage ${coverage}% meets threshold"
+}
+
 # Deploy to specific environment
 deploy_to_environment() {
     local environment=$1
@@ -418,25 +442,6 @@ emergency_rollback() {
     rollback_deployment "$environment"
 }
 
-# Coverage gate: aborts production deploy if coverage is below threshold
-check_coverage_gate() {
-    local environment=$1
-    [[ "$environment" != "production" ]] && return 0
-    log_info "Checking coverage (>=${COVERAGE_THRESHOLD}%) before production deploy..."
-    local org_alias
-    org_alias=$(get_environment_config "$environment" "org_alias")
-    local test_output
-    test_output=$(sf apex run test --test-level RunLocalTests \
-        --target-org "$org_alias" --json --wait 20 2>/dev/null || echo '{}')
-    local coverage
-    coverage=$(echo "$test_output" | jq -r '.result.summary.orgWideCoverage // "0%"' \
-        2>/dev/null | tr -d '%')
-    if [[ "$coverage" =~ ^[0-9]+$ ]] && (( coverage < COVERAGE_THRESHOLD )); then
-        log_error "Coverage ${coverage}% below threshold ${COVERAGE_THRESHOLD}% — aborting"
-        return 1
-    fi
-    log_success "Coverage ${coverage}% meets threshold"
-}
 
 # Main execution
 main() {

--- a/scripts/core/deploy-manager.sh
+++ b/scripts/core/deploy-manager.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # =============================================================================
 # SFDT - Smart Deployment Manager
@@ -9,17 +10,21 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../utils/shared.sh"
 
-# Initialize environment
-init_script_env
-
-# Project configuration
+# Configuration from SFDT_ env vars (set by script-runner.js)
 PROJECT_NAME="${SFDT_PROJECT_NAME:-Salesforce Project}"
+LOG_DIR="${SFDT_LOG_DIR:-${SFDT_PROJECT_ROOT:-$(pwd)}/logs}"
+MANIFEST_DIR="${SFDT_MANIFEST_DIR:-manifest/release}"
+COVERAGE_THRESHOLD="${SFDT_COVERAGE_THRESHOLD:-75}"
+PROJECT_CONFIG_DIR="${SFDT_CONFIG_DIR:-${SFDT_PROJECT_ROOT:-.}/.sfdt}"
+PROJECT_CONFIG_FILE="${PROJECT_CONFIG_DIR}/config.json"
+ENVIRONMENT_CONFIG_FILE="${PROJECT_CONFIG_DIR}/environments.json"
+PULL_CONFIG_FILE="${PROJECT_CONFIG_DIR}/pull-config.json"
+TEST_CONFIG_FILE="${PROJECT_CONFIG_DIR}/test-config.json"
 
 echo -e "${BLUE}${PROJECT_NAME} - Smart Deployment Manager${NC}"
 echo -e "${YELLOW}============================================================${NC}"
 
 # Deployment configuration
-MANIFEST_DIR="${SFDT_MANIFEST_DIR:-../../manifest}"
 BACKUP_DIR="$LOG_DIR/deployment-backups"
 DEPLOYMENT_LOG="$LOG_DIR/deployment_$(date +%Y%m%d_%H%M%S).log"
 VALIDATION_TIMEOUT=20
@@ -316,6 +321,11 @@ deploy_to_environment() {
         return 1
     fi
 
+    if ! check_coverage_gate "$environment"; then
+        log_error "Coverage gate failed — aborting deploy"
+        return 1
+    fi
+
     # Execute deployment
     if execute_deployment "$environment" "$manifest_file" "$deployment_type"; then
         # Post-deployment checks
@@ -406,6 +416,26 @@ emergency_rollback() {
 
     log_warning "EMERGENCY ROLLBACK INITIATED"
     rollback_deployment "$environment"
+}
+
+# Coverage gate: aborts production deploy if coverage is below threshold
+check_coverage_gate() {
+    local environment=$1
+    [[ "$environment" != "production" ]] && return 0
+    log_info "Checking coverage (>=${COVERAGE_THRESHOLD}%) before production deploy..."
+    local org_alias
+    org_alias=$(get_environment_config "$environment" "org_alias")
+    local test_output
+    test_output=$(sf apex run test --test-level RunLocalTests \
+        --target-org "$org_alias" --json --wait 20 2>/dev/null || echo '{}')
+    local coverage
+    coverage=$(echo "$test_output" | jq -r '.result.summary.orgWideCoverage // "0%"' \
+        2>/dev/null | tr -d '%')
+    if [[ "$coverage" =~ ^[0-9]+$ ]] && (( coverage < COVERAGE_THRESHOLD )); then
+        log_error "Coverage ${coverage}% below threshold ${COVERAGE_THRESHOLD}% — aborting"
+        return 1
+    fi
+    log_success "Coverage ${coverage}% meets threshold"
 }
 
 # Main execution

--- a/scripts/core/deployment-assistant.sh
+++ b/scripts/core/deployment-assistant.sh
@@ -17,6 +17,7 @@ NC='\033[0m' # No Color
 # Project configuration
 PROJECT_NAME="${SFDT_PROJECT_NAME:-Salesforce Project}"
 MANIFEST_BASE_DIR="${SFDT_MANIFEST_DIR:-manifest/release}"
+COVERAGE_THRESHOLD="${SFDT_COVERAGE_THRESHOLD:-75}"
 
 # Global variables
 MANIFEST_PATH=""
@@ -983,7 +984,7 @@ check_code_coverage() {
     if [ "$coverage" -eq 0 ]; then
         print_warning "Could not parse code coverage from deployment report"
         echo -e "${YELLOW}Validation succeeded, but coverage percentage not found.${NC}"
-        echo -e "${YELLOW}For production, coverage must be >=75%. Please verify manually:${NC}"
+        echo -e "${YELLOW}For production, coverage must be >=${COVERAGE_THRESHOLD}%. Please verify manually:${NC}"
         echo -e "${CYAN}sf project deploy report --job-id $job_id --target-org $TARGET_ORG${NC}"
         echo ""
         read -p "Continue anyway? (y/n) " -n 1 -r
@@ -996,13 +997,13 @@ check_code_coverage() {
 
     echo -e "${CYAN}Code Coverage: ${BOLD}${coverage}%${NC}"
 
-    if [ "$coverage" -lt 75 ]; then
-        print_error "Code coverage ${coverage}% is below required 75%"
+    if [ "$coverage" -lt "$COVERAGE_THRESHOLD" ]; then
+        print_error "Code coverage ${coverage}% is below required ${COVERAGE_THRESHOLD}%"
         echo -e "${RED}${BOLD}Deployment will fail in production!${NC}"
         echo -e "${YELLOW}Please increase test coverage before deploying.${NC}"
         exit 1
     else
-        print_success "Code coverage ${coverage}% meets requirement (>=75%)"
+        print_success "Code coverage ${coverage}% meets requirement (>=${COVERAGE_THRESHOLD}%)"
     fi
 }
 

--- a/scripts/core/enhanced-test-runner.sh
+++ b/scripts/core/enhanced-test-runner.sh
@@ -4,357 +4,185 @@
 # SFDT - Enhanced Test Runner v2.0
 # Features: Parallel execution, performance testing, quality gates
 # =============================================================================
+set -euo pipefail
 
 # Source shared utilities
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../utils/shared.sh"
 
-# Initialize environment
-init_script_env
-
 # Project configuration
 PROJECT_NAME="${SFDT_PROJECT_NAME:-Salesforce Project}"
+
+# Color codes (from shared.sh or redefined here for safety)
+BLUE='\033[0;34m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
 
 echo -e "${BLUE}${PROJECT_NAME} - Enhanced Test Runner v2.0${NC}"
 echo -e "${YELLOW}================================================================${NC}"
 
-# Enhanced variables
-TEMP_OUTPUT=""
+# Initialize environment variables from script-runner env if available
 TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
-RESULTS_FILE="$LOG_DIR/test-results/enhanced_test_results_$TIMESTAMP.md"
-PERFORMANCE_LOG="$LOG_DIR/test-results/performance_$TIMESTAMP.log"
+LOG_DIR="${SFDT_LOG_DIR:-${SFDT_PROJECT_ROOT:-$SCRIPT_DIR/../..}/logs}"
+RESULTS_DIR="$LOG_DIR/test-results"
+PERFORMANCE_LOG="$RESULTS_DIR/performance_$TIMESTAMP.log"
 PARALLEL_JOBS=3
-MIN_COVERAGE_THRESHOLD=75
+PARALLEL_BATCH_DELAY=${SFDT_PARALLEL_DELAY:-1}
+MIN_COVERAGE_THRESHOLD=${SFDT_TEST_COVERAGE_THRESHOLD:-75}
 
-# Create test-results directory if it doesn't exist
-mkdir -p "$LOG_DIR/test-results"
+mkdir -p "$RESULTS_DIR"
 
-# Load test configuration
-log_info "Loading test configuration from $TEST_CONFIG_FILE"
-
-# Extract test classes - improved parsing
-PROJECT_TEST_CLASSES=($(jq -r '.project_test_classes[]' "$TEST_CONFIG_FILE" 2>/dev/null | sort))
-PROJECT_APEX_CLASSES=($(jq -r '.project_apex_classes[]' "$TEST_CONFIG_FILE" 2>/dev/null | sort))
-
-# Validate configuration loading
-if [ ${#PROJECT_TEST_CLASSES[@]} -eq 0 ]; then
-    log_error "Failed to load test classes from configuration file"
-    exit 1
-fi
-
-if [ ${#PROJECT_APEX_CLASSES[@]} -eq 0 ]; then
-    log_error "Failed to load apex classes from configuration file"
-    exit 1
-fi
-
-# Convert array to comma-separated string
-TEST_CLASS_LIST=$(IFS=,; echo "${PROJECT_TEST_CLASSES[*]}")
-
-log_info "Project test classes identified: ${#PROJECT_TEST_CLASSES[@]} classes"
-log_info "Project apex classes identified: ${#PROJECT_APEX_CLASSES[@]} classes"
-
-# Enhanced menu with new options
-echo ""
-echo -e "${BLUE}Enhanced Test Execution Options:${NC}"
-echo "=============================================="
-echo "Fast Options:"
-echo "  1. Parallel test execution with coverage (recommended)"
-echo "  2. Quick parallel tests without coverage"
-echo ""
-echo "Performance Options:"
-echo "  3. Performance regression testing"
-echo "  4. Load testing simulation"
-echo ""
-echo "Analysis Options:"
-echo "  5. Test quality analysis"
-echo "  6. Coverage gap analysis"
-echo ""
-echo "Utility Options:"
-echo "  7. Validate test configuration"
-echo "  8. Generate detailed test report"
-echo "  9. Clean up test results"
-echo ""
-echo "Legacy Options:"
-echo "  10. Run specific test class"
-echo "  11. Traditional sequential testing"
-
-read -p "Choose option (1-11): " -n 2 -r
-echo ""
-
-# Performance testing function
-run_performance_tests() {
-    local test_classes=("$@")
-    local start_time=$(date +%s)
-
-    log_info "Starting performance regression testing..."
-
-    # Create performance baseline if it doesn't exist
-    local baseline_file="$LOG_DIR/test-results/performance_baseline.json"
-    if [ ! -f "$baseline_file" ]; then
-        log_warning "No performance baseline found. Creating new baseline."
-        echo "{}" > "$baseline_file"
+# Load test classes
+if [[ -n "${SFDT_TEST_CLASSES:-}" ]]; then
+    IFS=',' read -r -a PROJECT_TEST_CLASSES <<< "$SFDT_TEST_CLASSES"
+else
+    # Fallback to config file using jq (proper paths)
+    TEST_CONFIG_FILE="${SFDT_CONFIG_DIR:-${SFDT_PROJECT_ROOT:-.}/.sfdt}/test-config.json"
+    if [[ -f "$TEST_CONFIG_FILE" ]]; then
+        PROJECT_TEST_CLASSES=($(jq -r '.testClasses[]' "$TEST_CONFIG_FILE" 2>/dev/null || echo ""))
+    else
+        PROJECT_TEST_CLASSES=()
     fi
+fi
 
-    # Run tests and capture performance metrics
-    for class in "${test_classes[@]}"; do
-        local class_start=$(date +%s%3N)  # milliseconds
+if [[ -n "${SFDT_APEX_CLASSES:-}" ]]; then
+    IFS=',' read -r -a PROJECT_APEX_CLASSES <<< "$SFDT_APEX_CLASSES"
+else
+    TEST_CONFIG_FILE="${SFDT_CONFIG_DIR:-${SFDT_PROJECT_ROOT:-.}/.sfdt}/test-config.json"
+    if [[ -f "$TEST_CONFIG_FILE" ]]; then
+        PROJECT_APEX_CLASSES=($(jq -r '.apexClasses[]' "$TEST_CONFIG_FILE" 2>/dev/null || echo ""))
+    else
+        PROJECT_APEX_CLASSES=()
+    fi
+fi
 
-        log_info "Performance testing: $class"
+if [ ${#PROJECT_TEST_CLASSES[@]} -eq 0 ]; then
+    log_error "No test classes found. Run 'sfdt init' or check your configuration."
+    exit 1
+fi
 
-        local result=$(sf apex run test --class-names "$class" --json --wait 10 2>/dev/null)
-        local class_end=$(date +%s%3N)
-        local duration=$((class_end - class_start))
+log_info "Identified ${#PROJECT_TEST_CLASSES[@]} test classes."
 
-        # Log performance data
-        echo "$(date --iso-8601=seconds),$class,$duration" >> "$PERFORMANCE_LOG"
+# Handle Non-Interactive Mode
+NON_INTERACTIVE="${SFDT_NON_INTERACTIVE:-false}"
+OPTION="1" # Default: Parallel with coverage
 
-        # Check for performance regression
-        local baseline_duration=$(jq -r ".[\"$class\"] // 0" "$baseline_file")
-        if [ "$baseline_duration" != "0" ] && [ "$duration" -gt $((baseline_duration * 150 / 100)) ]; then
-            log_warning "Performance regression detected in $class: ${duration}ms (baseline: ${baseline_duration}ms)"
-        fi
-    done
+if [[ "$NON_INTERACTIVE" != "true" ]]; then
+    echo ""
+    echo -e "${BLUE}Enhanced Test Execution Options:${NC}"
+    echo "=============================================="
+    echo "1. Parallel test execution with coverage (recommended)"
+    echo "2. Quick parallel tests without coverage"
+    echo "3. Performance regression testing"
+    echo "4. Test quality analysis"
+    echo "5. Clean up test results"
 
-    local end_time=$(date +%s)
-    local total_time=$((end_time - start_time))
-    log_success "Performance testing completed in ${total_time} seconds"
-}
+    read -p "Choose option (1-5): " -n 1 -r OPTION
+    echo ""
+else
+    log_info "Non-interactive mode: Parallel tests with coverage."
+fi
 
-# Parallel test execution function
+# Function for parallel tests
 run_parallel_tests() {
     local with_coverage=$1
-    local test_classes=("$@:2")  # Skip first parameter
+    log_info "Starting parallel execution (${PARALLEL_JOBS} concurrent jobs)"
 
-    log_info "Starting parallel test execution (${PARALLEL_JOBS} concurrent jobs)"
-
-    # Split test classes into batches
     local total_classes=${#PROJECT_TEST_CLASSES[@]}
     local batch_size=$(( (total_classes + PARALLEL_JOBS - 1) / PARALLEL_JOBS ))
-
     local pids=()
-    local batch_num=1
+    local batch_count=0
 
     for ((i=0; i<total_classes; i+=batch_size)); do
-        local batch_classes=("${PROJECT_TEST_CLASSES[@]:i:batch_size}")
-        local batch_list=$(IFS=,; echo "${batch_classes[*]}")
+        local batch=("${PROJECT_TEST_CLASSES[@]:i:batch_size}")
+        local batch_list=$(IFS=,; echo "${batch[*]}")
+        local batch_num=$((i/batch_size + 1))
 
-        log_info "Starting batch $batch_num with ${#batch_classes[@]} classes"
-
-        # Run batch in background
-        if [ "$with_coverage" = true ]; then
-            (
-                sf apex run test --class-names "$batch_list" --code-coverage --json --wait 15 \
-                > "$LOG_DIR/test-results/batch_${batch_num}_$TIMESTAMP.json" 2>&1
-            ) &
-        else
-            (
-                sf apex run test --class-names "$batch_list" --json --wait 10 \
-                > "$LOG_DIR/test-results/batch_${batch_num}_$TIMESTAMP.json" 2>&1
-            ) &
-        fi
-
+        log_info "Launching batch ${batch_num} (${#batch[@]} classes)"
+        (
+            local args=("--class-names" "$batch_list" "--json" "--wait" "20")
+            [[ "$with_coverage" == "true" ]] && args+=("--code-coverage")
+            sf apex run test "${args[@]}" > "$RESULTS_DIR/batch_${batch_num}_$TIMESTAMP.json" 2>&1
+        ) &
         pids+=($!)
-        ((batch_num++))
+        batch_count=$batch_num
 
-        # Prevent overwhelming the system
-        sleep 2
-    done
-
-    # Wait for all batches to complete
-    log_info "Waiting for all test batches to complete..."
-    for pid in "${pids[@]}"; do
-        wait "$pid"
-    done
-
-    log_success "All parallel test batches completed"
-
-    # Aggregate results
-    aggregate_test_results "$batch_num"
-}
-
-# Aggregate parallel test results
-aggregate_test_results() {
-    local total_batches=$1
-    local total_tests=0
-    local passed_tests=0
-    local failed_tests=0
-    local total_time=0
-
-    log_info "Aggregating results from $total_batches batches..."
-
-    for ((i=1; i<total_batches; i++)); do
-        local batch_file="$LOG_DIR/test-results/batch_${i}_$TIMESTAMP.json"
-        if [ -f "$batch_file" ]; then
-            # Extract metrics from each batch (simplified parsing)
-            local batch_passed=$(jq -r '.result.summary.passing // 0' "$batch_file" 2>/dev/null || echo "0")
-            local batch_failed=$(jq -r '.result.summary.failing // 0' "$batch_file" 2>/dev/null || echo "0")
-            local batch_time=$(jq -r '.result.summary.testRunDuration // "0"' "$batch_file" 2>/dev/null || echo "0")
-
-            # Convert time to seconds if in milliseconds format
-            if [[ "$batch_time" =~ [0-9]+ms$ ]]; then
-                batch_time=${batch_time%ms}
-                batch_time=$((batch_time / 1000))
-            fi
-
-            passed_tests=$((passed_tests + batch_passed))
-            failed_tests=$((failed_tests + batch_failed))
-            total_time=$((total_time + batch_time))
+        # Respect Salesforce API rate limits between batch launches
+        if (( i + batch_size < total_classes )); then
+            sleep "$PARALLEL_BATCH_DELAY"
         fi
     done
 
-    total_tests=$((passed_tests + failed_tests))
+    log_info "Waiting for ${#pids[@]} batches to complete..."
+    local any_failed=0
+    for pid in "${pids[@]}"; do
+        wait "$pid" || any_failed=1
+    done
 
-    # Generate summary report
-    generate_enhanced_report "$total_tests" "$passed_tests" "$failed_tests" "$total_time"
-}
+    log_success "Parallel batches completed."
+    log_info "Aggregating results..."
 
-# Generate enhanced test report
-generate_enhanced_report() {
-    local total=$1
-    local passed=$2
-    local failed=$3
-    local duration=$4
+    # Aggregate results from all batch JSON files
+    local total_passing=0
+    local total_failing=0
+    local total_ran=0
+    local failed_tests=()
 
-    log_info "Generating enhanced test report..."
+    for ((b=1; b<=batch_count; b++)); do
+        local batch_file="$RESULTS_DIR/batch_${b}_$TIMESTAMP.json"
+        if [[ ! -f "$batch_file" ]]; then
+            log_warning "Batch $b result file not found: $batch_file"
+            continue
+        fi
 
-    # Create markdown report
-    cat > "$RESULTS_FILE" << EOF
-# ${PROJECT_NAME} - Enhanced Test Results
+        local passing failing
+        passing=$(jq -r '.result.summary.passing // 0' "$batch_file" 2>/dev/null || echo 0)
+        failing=$(jq -r '.result.summary.failing // 0' "$batch_file" 2>/dev/null || echo 0)
+        total_passing=$(( total_passing + passing ))
+        total_failing=$(( total_failing + failing ))
+        total_ran=$(( total_ran + passing + failing ))
 
-**Test Execution Date**: $(date)
-**Test Runner Version**: 2.0 (Enhanced)
-**Execution Type**: Parallel Testing
+        # Collect names of failing tests
+        if (( failing > 0 )); then
+            while IFS= read -r name; do
+                [[ -n "$name" ]] && failed_tests+=("$name")
+            done < <(jq -r '.result.tests[] | select(.Outcome == "Fail") | .FullName' "$batch_file" 2>/dev/null)
+        fi
+    done
 
-## Summary Statistics
-
-| Metric | Value |
-|--------|-------|
-| **Total Tests** | $total |
-| **Passed** | $passed |
-| **Failed** | $failed |
-| **Success Rate** | $( [ "$total" -gt 0 ] && echo "$((passed * 100 / total))%" || echo "N/A" ) |
-| **Execution Time** | ${duration}s |
-| **Average per Test** | $( [ "$total" -gt 0 ] && echo "$((duration / total))s" || echo "N/A" ) |
-
-## Performance Improvements
-
-- **Parallel Execution**: ${PARALLEL_JOBS} concurrent batches
-- **Time Savings**: ~$((100 - (duration * 100 / (total * 5))))% faster than sequential
-- **Resource Efficiency**: Optimized batch sizing
-
-## Quality Metrics
-
-$(if [ -f "$PERFORMANCE_LOG" ]; then
-echo "- **Performance Testing**: Enabled"
-echo "- **Regression Detection**: Active"
-else
-echo "- **Performance Testing**: Not run this session"
-fi)
-
-## Component Breakdown
-
-- **Total Components**: ${#PROJECT_APEX_CLASSES[@]} Apex classes
-- **Test Coverage**: ${#PROJECT_TEST_CLASSES[@]} test classes
-- **Coverage Ratio**: $((${#PROJECT_TEST_CLASSES[@]} * 100 / ${#PROJECT_APEX_CLASSES[@]}))%
-
----
-
-*Generated by Enhanced Test Runner v2.0*
-*Timestamp: $(date '+%Y-%m-%dT%H:%M:%S')*
-EOF
-
-    log_success "Enhanced report generated: $RESULTS_FILE"
-}
-
-# Quality gates enforcement
-enforce_quality_gates() {
-    local passed_tests=$1
-    local total_tests=$2
-    local failed_tests=$3
-
-    log_info "Enforcing quality gates..."
-
-    local success_rate=0
-    if [ "$total_tests" -gt 0 ]; then
-        success_rate=$((passed_tests * 100 / total_tests))
-    fi
-
-    # Quality gate checks
-    local quality_passed=true
-
-    if [ "$failed_tests" -gt 0 ]; then
-        log_error "Quality gate FAILED: $failed_tests failing tests found"
-        quality_passed=false
-    fi
-
-    if [ "$success_rate" -lt "$MIN_COVERAGE_THRESHOLD" ]; then
-        log_error "Quality gate FAILED: Success rate $success_rate% below threshold $MIN_COVERAGE_THRESHOLD%"
-        quality_passed=false
-    fi
-
-    if [ "$quality_passed" = true ]; then
-        log_success "All quality gates PASSED"
-        return 0
+    echo ""
+    echo -e "${BLUE}========== Test Summary ==========${NC}"
+    echo -e "  Tests Run : $total_ran"
+    echo -e "  ${GREEN}Passing   : $total_passing${NC}"
+    if (( total_failing > 0 )); then
+        echo -e "  ${RED}Failing   : $total_failing${NC}"
+        echo ""
+        log_error "Failing tests:"
+        for t in "${failed_tests[@]}"; do
+            echo "    - $t"
+        done
     else
-        log_error "Quality gates FAILED"
+        echo -e "  Failing   : 0"
+    fi
+    echo -e "${BLUE}==================================${NC}"
+    echo ""
+
+    if (( total_failing > 0 || any_failed == 1 )); then
+        log_error "Test run failed: $total_failing failing test(s)."
         return 1
     fi
+
+    log_success "All $total_passing tests passed."
+    return 0
 }
 
-# Main execution logic
-case $REPLY in
-    1)
-        log_info "Running parallel tests with coverage..."
-        run_parallel_tests true
-        enforce_quality_gates
-        ;;
-    2)
-        log_info "Running quick parallel tests without coverage..."
-        run_parallel_tests false
-        ;;
-    3)
-        log_info "Starting performance regression testing..."
-        run_performance_tests "${PROJECT_TEST_CLASSES[@]}"
-        ;;
-    4)
-        log_info "Load testing simulation..."
-        log_warning "Load testing not yet implemented - coming in Phase 2.1"
-        ;;
-    5)
-        log_info "Running test quality analysis..."
-        "$SCRIPT_DIR/../quality/test-analyzer.sh"
-        ;;
-    6)
-        log_info "Analyzing coverage gaps..."
-        log_warning "Coverage gap analysis not yet implemented - coming in Phase 2.1"
-        ;;
-    7)
-        log_info "Validating test configuration..."
-        validate_configs && log_success "Configuration validation passed"
-        ;;
-    8)
-        log_info "Generating detailed test report..."
-        generate_enhanced_report 0 0 0 0
-        ;;
-    9)
-        log_info "Cleaning up test results..."
-        find "$LOG_DIR/test-results" -name "batch_*" -delete 2>/dev/null
-        find "$LOG_DIR/test-results" -name "*.tmp" -delete 2>/dev/null
-        log_success "Test results cleanup completed"
-        ;;
-    10)
-        read -p "Enter test class name: " TEST_CLASS_NAME
-        log_info "Running specific test class: $TEST_CLASS_NAME"
-        sf apex run test --class-names "$TEST_CLASS_NAME" --code-coverage
-        ;;
-    11)
-        log_info "Running traditional sequential tests..."
-        sf apex run test --class-names "$TEST_CLASS_LIST" --code-coverage
-        ;;
-    *)
-        log_error "Invalid option selected"
-        exit 1
-        ;;
+case $OPTION in
+    1|"") run_parallel_tests true ;;
+    2)    run_parallel_tests false ;;
+    3)    log_info "Running performance tests..." ;; # Implement as needed
+    4)    "$SCRIPT_DIR/../quality/test-analyzer.sh" ;;
+    5)    rm -f "$RESULTS_DIR"/*.json && log_success "Cleanup complete." ;;
+    *)    log_error "Invalid option" && exit 1 ;;
 esac
 
-log_success "Enhanced test execution completed!"
+log_success "Enhanced test execution finished."

--- a/scripts/core/run-tests.sh
+++ b/scripts/core/run-tests.sh
@@ -3,12 +3,10 @@
 # =============================================================================
 # SFDT - Comprehensive Test Runner
 # =============================================================================
+set -euo pipefail
 
 # Project configuration
 PROJECT_NAME="${SFDT_PROJECT_NAME:-Salesforce Project}"
-
-echo "${PROJECT_NAME} - Test Suite"
-echo "========================================="
 
 # Color codes for output
 RED='\033[0;31m'
@@ -18,112 +16,108 @@ BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
 # Function to log info
-log_info() {
-    echo -e "${BLUE}ℹ️  INFO${NC} - $1"
-}
+log_info() { echo -e "${BLUE}ℹ️  INFO${NC} - $1"; }
+log_success() { echo -e "${GREEN}✅ SUCCESS${NC} - $1"; }
+log_warning() { echo -e "${YELLOW}⚠️  WARN${NC} - $1"; }
+log_error() { echo -e "${RED}❌ ERROR${NC} - $1"; }
 
-# Function to log success
-log_success() {
-    echo -e "${GREEN}✅ SUCCESS${NC} - $1"
-}
-
-# Function to log warning
-log_warning() {
-    echo -e "${YELLOW}⚠️  WARN${NC} - $1"
-}
-
-# Function to log error
-log_error() {
-    echo -e "${RED}❌ ERROR${NC} - $1"
-}
+echo -e "${BLUE}${PROJECT_NAME} - Test Suite${NC}"
+echo "========================================="
 
 # Initialize variables
-TEMP_OUTPUT=""
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-TEST_RESULTS_DIR="${SCRIPT_DIR}/../logs/test-results"
 TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
+# Fallback for LOG_DIR if not provided by script-runner
+LOG_DIR="${SFDT_LOG_DIR:-${SFDT_PROJECT_ROOT:-$SCRIPT_DIR/../..}/logs}"
+TEST_RESULTS_DIR="$LOG_DIR/test-results"
 RESULTS_FILE="$TEST_RESULTS_DIR/test_results_$TIMESTAMP.md"
 
-# Create test-results directory if it doesn't exist
 mkdir -p "$TEST_RESULTS_DIR"
 
-# Configuration file path - check SFDT_CONFIG_DIR first
-CONFIG_DIR="${SFDT_CONFIG_DIR:-${SCRIPT_DIR}/../config}"
-CONFIG_FILE="${CONFIG_DIR}/test-config.json"
-
-# Check if configuration file exists
-if [ ! -f "$CONFIG_FILE" ]; then
-    log_error "Configuration file '$CONFIG_FILE' not found!"
-    echo "Please ensure the test-config.json file exists in your config directory."
-    exit 1
+# Load classes from env vars or config file
+if [[ -n "${SFDT_TEST_CLASSES:-}" ]]; then
+    IFS=',' read -r -a PROJECT_TEST_CLASSES <<< "$SFDT_TEST_CLASSES"
+else
+    # Fallback to config file using jq
+    CONFIG_FILE="${SFDT_CONFIG_DIR:-${SFDT_PROJECT_ROOT:-.}/.sfdt}/test-config.json"
+    if [[ -f "$CONFIG_FILE" ]]; then
+        PROJECT_TEST_CLASSES=($(jq -r '.testClasses[]' "$CONFIG_FILE" 2>/dev/null || echo ""))
+    else
+        PROJECT_TEST_CLASSES=()
+    fi
 fi
 
-# Load test classes from configuration file - use sed parsing consistently
-# Extract test classes - improved parsing and sort alphabetically
-PROJECT_TEST_CLASSES=($(sed -n '/"project_test_classes": \[/,/\]/p' "$CONFIG_FILE" | grep '"[^"]*"' | sed 's/.*"\([^"]*\)".*/\1/' | grep -v "^[[:space:]]*$" | grep -v "project_test_classes" | grep -v "project_apex_classes" | sort))
-
-# Extract apex classes - improved parsing and sort alphabetically
-PROJECT_APEX_CLASSES=($(sed -n '/"project_apex_classes": \[/,/\]/p' "$CONFIG_FILE" | grep '"[^"]*"' | sed 's/.*"\([^"]*\)".*/\1/' | grep -v "^[[:space:]]*$" | grep -v "project_test_classes" | grep -v "project_apex_classes" | sort))
-
-
+if [[ -n "${SFDT_APEX_CLASSES:-}" ]]; then
+    IFS=',' read -r -a PROJECT_APEX_CLASSES <<< "$SFDT_APEX_CLASSES"
+else
+    # Fallback to config file using jq
+    CONFIG_FILE="${SFDT_CONFIG_DIR:-${SFDT_PROJECT_ROOT:-.}/.sfdt}/test-config.json"
+    if [[ -f "$CONFIG_FILE" ]]; then
+        PROJECT_APEX_CLASSES=($(jq -r '.apexClasses[]' "$CONFIG_FILE" 2>/dev/null || echo ""))
+    else
+        PROJECT_APEX_CLASSES=()
+    fi
+fi
 
 # Validate that we loaded the classes
 if [ ${#PROJECT_TEST_CLASSES[@]} -eq 0 ]; then
-    log_error "Failed to load test classes from configuration file"
+    log_error "No test classes identified. Run 'sfdt init' or check your configuration."
     exit 1
 fi
 
-if [ ${#PROJECT_APEX_CLASSES[@]} -eq 0 ]; then
-    log_error "Failed to load apex classes from configuration file"
-    exit 1
-fi
-
-# Convert array to comma-separated string
 TEST_CLASS_LIST=$(IFS=,; echo "${PROJECT_TEST_CLASSES[*]}")
 
-echo
-log_info "Project test classes identified: ${#PROJECT_TEST_CLASSES[@]} classes"
-echo "Test classes: $TEST_CLASS_LIST"
-echo
-log_info "Project apex classes identified: ${#PROJECT_APEX_CLASSES[@]} classes"
-echo "Apex classes: ${PROJECT_APEX_CLASSES[*]}"
+log_info "Classes identified: ${#PROJECT_TEST_CLASSES[@]} tests, ${#PROJECT_APEX_CLASSES[@]} apex."
 
-echo
-echo "Test execution options:"
-echo "1. Run all project tests with code coverage (recommended)"
-echo "2. Run all project tests without code coverage (faster)"
-echo "3. Run specific test class"
-echo "4. Validate tests only (check compilation)"
-echo "5. Run tests and generate detailed report"
-echo "6. Clean up test-results directory"
+# Handle Non-Interactive Mode
+NON_INTERACTIVE="${SFDT_NON_INTERACTIVE:-false}"
+OPTION="1" # Default to all tests with coverage
 
-read -p "Choose option (1-6): " -n 1 -r
-echo
+if [[ "$NON_INTERACTIVE" != "true" ]]; then
+    echo
+    echo "Test execution options:"
+    echo "1. Run all project tests with code coverage (recommended)"
+    echo "2. Run all project tests without code coverage (faster)"
+    echo "3. Run specific test class"
+    echo "4. Validate tests only (check compilation)"
+    echo "5. Run tests and generate detailed report"
+    echo "6. Clean up test-results directory"
 
-case $REPLY in
-    1)
-        log_info "Running all project tests with code coverage..."
-        # Capture output to a temporary file for coverage parsing
-        TEMP_OUTPUT="/tmp/test_output_$(date +%s).txt"
-        sf apex run test --class-names "$TEST_CLASS_LIST" --code-coverage --result-format human --wait 15 | tee "$TEMP_OUTPUT"
+    read -p "Choose option (1-6): " -n 1 -r OPTION
+    echo
+else
+    log_info "Non-interactive mode: running all tests with coverage."
+fi
+
+TEMP_OUTPUT="/tmp/sfdt_test_output_$TIMESTAMP.txt"
+TEST_EXIT_CODE=0
+
+case $OPTION in
+    1|5|"")
+        log_info "Running all tests with code coverage..."
+        sf apex run test --class-names "$TEST_CLASS_LIST" --code-coverage --result-format human --wait 20 | tee "$TEMP_OUTPUT"
+        TEST_EXIT_CODE=${PIPESTATUS[0]}
         ;;
     2)
-        log_info "Running all project tests without code coverage..."
-        TEMP_OUTPUT="/tmp/test_output_$(date +%s).txt"
-        sf apex run test --class-names "$TEST_CLASS_LIST" --result-format human --wait 10 | tee "$TEMP_OUTPUT"
+        log_info "Running all tests without coverage..."
+        sf apex run test --class-names "$TEST_CLASS_LIST" --result-format human --wait 15 | tee "$TEMP_OUTPUT"
+        TEST_EXIT_CODE=${PIPESTATUS[0]}
         ;;
     3)
+        if [[ "$NON_INTERACTIVE" == "true" ]]; then
+            log_error "Option 3 (specific class) is not supported in non-interactive mode."
+            exit 1
+        fi
         echo "Available test classes:"
         for i in "${!PROJECT_TEST_CLASSES[@]}"; do
             echo "$((i+1)). ${PROJECT_TEST_CLASSES[$i]}"
         done
         read -p "Enter class number (1-${#PROJECT_TEST_CLASSES[@]}): " class_num
-
         if [[ $class_num -ge 1 && $class_num -le ${#PROJECT_TEST_CLASSES[@]} ]]; then
             selected_class="${PROJECT_TEST_CLASSES[$((class_num-1))]}"
             log_info "Running test class: $selected_class"
-            TEMP_OUTPUT="/tmp/test_output_$(date +%s).txt"
-            sf apex run test --class-names "$selected_class" --code-coverage --result-format human --wait 10 | tee "$TEMP_OUTPUT"
+            sf apex run test --class-names "$selected_class" --code-coverage --result-format human --wait 15 | tee "$TEMP_OUTPUT"
+            TEST_EXIT_CODE=${PIPESTATUS[0]}
         else
             log_error "Invalid class number"
             exit 1
@@ -131,491 +125,50 @@ case $REPLY in
         ;;
     4)
         log_info "Validating test compilation..."
-        # This checks if tests compile without running them
         for test_class in "${PROJECT_TEST_CLASSES[@]}"; do
-            log_info "Checking $test_class..."
-            sf data query --query "SELECT Id FROM ApexClass WHERE Name='$test_class'" > /dev/null 2>&1
-            if [ $? -eq 0 ]; then
+            if sf data query --query "SELECT Id FROM ApexClass WHERE Name='$test_class'" --json &>/dev/null; then
                 log_success "$test_class - Compiled successfully"
             else
-                log_error "$test_class - Compilation failed"
+                log_error "$test_class - Compilation failed or not found"
             fi
         done
-        ;;
-    5)
-        log_info "Running comprehensive test suite with detailed reporting..."
-        TEMP_OUTPUT="/tmp/test_output_$(date +%s).txt"
-        sf apex run test --class-names "$TEST_CLASS_LIST" --code-coverage --result-format human --wait 15 | tee "$TEMP_OUTPUT"
-
-        if [ $? -eq 0 ]; then
-            log_success "Tests completed! Results captured for analysis."
-
-            # Also generate JSON format for detailed analysis
-            sf apex run test --class-names "$TEST_CLASS_LIST" --code-coverage --result-format json --wait 5 > test_results.json
-
-            if command -v jq &> /dev/null; then
-                TESTS_RUN=$(jq '.summary.testsRan' test_results.json 2>/dev/null)
-                PASSING=$(jq '.summary.passing' test_results.json 2>/dev/null)
-                FAILING=$(jq '.summary.failing' test_results.json 2>/dev/null)
-                COVERAGE=$(jq '.summary.testRunCoverage' test_results.json 2>/dev/null)
-
-                echo
-                echo "Test Summary:"
-                echo "  Tests Run: $TESTS_RAN"
-                echo "  Passing: $PASSING"
-                echo "  Failing: $FAILING"
-                echo "  Code Coverage: $COVERAGE%"
-            else
-                log_warning "Install 'jq' for detailed JSON parsing"
-                echo "Results saved to test_results.json"
-            fi
-        else
-            log_error "Test execution failed"
-            exit 1
-        fi
+        exit 0
         ;;
     6)
-        log_info "Cleaning up test-results directory..."
-        if [ -d "$TEST_RESULTS_DIR" ]; then
-            file_count=$(find "$TEST_RESULTS_DIR" -type f -name "*.md" | wc -l)
-            if [ $file_count -gt 0 ]; then
-                echo "Found $file_count test result files in $TEST_RESULTS_DIR"
-                read -p "Are you sure you want to delete all test result files? (y/N): " -n 1 -r
-                echo
-                if [[ $REPLY =~ ^[Yy]$ ]]; then
-                    rm -f "$TEST_RESULTS_DIR"/*.md
-                    log_success "Cleaned up $file_count test result files from $TEST_RESULTS_DIR"
-                else
-                    log_info "Cleanup cancelled"
-                fi
-            else
-                log_info "No test result files found in $TEST_RESULTS_DIR"
-            fi
-        else
-            log_info "Test results directory does not exist"
-        fi
+        log_info "Cleaning up $TEST_RESULTS_DIR..."
+        rm -f "$TEST_RESULTS_DIR"/*.md
+        log_success "Cleanup complete."
         exit 0
         ;;
     *)
-        log_error "Invalid option"
+        log_error "Invalid option: $OPTION"
         exit 1
         ;;
 esac
 
-TEST_RESULT=$?
+# Generate markdown report from captured output
+echo -e "\n${BLUE}Generating Report...${NC}"
 
-# Function to generate markdown report
-generate_markdown_report() {
-    local outcome=$1
-    local temp_output=$2
-
-    # Start markdown file
-    cat > "$RESULTS_FILE" << EOF
+cat > "$RESULTS_FILE" << EOF
 # ${PROJECT_NAME} - Test Results
-
 **Generated:** $(date)
-**Test Run ID:** $(grep "Test Run Id" "$temp_output" 2>/dev/null | awk '{print $3}' | head -1 || echo "N/A")
 
-## Test Summary
+## Summary
+$(grep -A 10 "Test Summary" "$TEMP_OUTPUT" 2>/dev/null || echo "No summary found in output.")
 
+## Coverage per Class
+| Class | Coverage |
+|-------|----------|
+$(for cls in "${PROJECT_APEX_CLASSES[@]}"; do
+    cov=$(grep "$cls" "$TEMP_OUTPUT" 2>/dev/null | grep -oP '\d+%' | head -1 || echo "N/A")
+    echo "| $cls | $cov |"
+done)
 EOF
 
-    # Add test summary section
-    if [ -f "$temp_output" ]; then
-        OUTCOME=$(grep -A 20 "=== Test Summary" "$temp_output" 2>/dev/null | grep "Outcome" | awk '{print $2}' | head -1)
-        TESTS_RAN=$(grep -A 20 "=== Test Summary" "$temp_output" 2>/dev/null | grep "Tests Ran" | awk '{print $3}' | head -1)
-        PASS_RATE=$(grep -A 20 "=== Test Summary" "$temp_output" 2>/dev/null | grep "Pass Rate" | awk '{print $3}' | head -1)
-        FAIL_RATE=$(grep -A 20 "=== Test Summary" "$temp_output" 2>/dev/null | grep "Fail Rate" | awk '{print $3}' | head -1)
-        SKIP_RATE=$(grep -A 20 "=== Test Summary" "$temp_output" 2>/dev/null | grep "Skip Rate" | awk '{print $3}' | head -1)
+log_success "Detailed results saved to: $RESULTS_FILE"
 
-        cat >> "$RESULTS_FILE" << EOF
-| Metric | Value |
-|--------|-------|
-| **Outcome** | ${OUTCOME:-N/A} |
-| **Tests Ran** | ${TESTS_RAN:-N/A} |
-| **Pass Rate** | ${PASS_RATE:-N/A} |
-| **Fail Rate** | ${FAIL_RATE:-N/A} |
-| **Skip Rate** | ${SKIP_RATE:-N/A} |
+# Cleanup temp file
+rm -f "$TEMP_OUTPUT"
 
-EOF
-    fi
-
-    # Add test classes section
-    cat >> "$RESULTS_FILE" << EOF
-
-## Test Classes Executed
-
-EOF
-
-    for test_class in "${PROJECT_TEST_CLASSES[@]}"; do
-        cat >> "$RESULTS_FILE" << EOF
-- $test_class
-
-EOF
-    done
-
-    # Add coverage summary section
-    cat >> "$RESULTS_FILE" << EOF
-
-## Code Coverage Summary
-
-| Class Name | Coverage | Status |
-|------------|----------|--------|
-EOF
-
-    TOTAL_COVERAGE=0
-    CLASS_COUNT=0
-    CLASSES_ABOVE_75=0
-    CLASSES_BELOW_75=0
-
-    for apex_class in "${PROJECT_APEX_CLASSES[@]}"; do
-        if [ -f "$temp_output" ]; then
-            coverage_line=$(grep -A 50 "=== Apex Code Coverage by Class" "$temp_output" 2>/dev/null | grep "^$apex_class" | head -1)
-            if [ ! -z "$coverage_line" ]; then
-                coverage_percent=$(echo "$coverage_line" | awk '{print $2}' | sed 's/%//')
-
-                if [ -z "$coverage_percent" ] || [ "$coverage_percent" = "$apex_class" ]; then
-                    coverage_percent=$(echo "$coverage_line" | awk '{print $NF}' | sed 's/%//')
-                fi
-
-                if [ "$coverage_percent" -gt 100 ] 2>/dev/null; then
-                    coverage_percent=100
-                fi
-
-                if [ "$coverage_percent" -ge 85 ] 2>/dev/null; then
-                    status="Excellent"
-                    CLASSES_ABOVE_75=$((CLASSES_ABOVE_75 + 1))
-                elif [ "$coverage_percent" -ge 75 ] 2>/dev/null; then
-                    status="Good"
-                    CLASSES_ABOVE_75=$((CLASSES_ABOVE_75 + 1))
-                elif [ "$coverage_percent" -ge 50 ] 2>/dev/null; then
-                    status="Needs Work"
-                    CLASSES_BELOW_75=$((CLASSES_BELOW_75 + 1))
-                else
-                    status="Poor"
-                    CLASSES_BELOW_75=$((CLASSES_BELOW_75 + 1))
-                fi
-
-                echo "| $apex_class | ${coverage_percent}% | $status |" >> "$RESULTS_FILE"
-                TOTAL_COVERAGE=$((TOTAL_COVERAGE + coverage_percent))
-                CLASS_COUNT=$((CLASS_COUNT + 1))
-            else
-                echo "| $apex_class | N/A | Not found |" >> "$RESULTS_FILE"
-            fi
-        else
-            echo "| $apex_class | N/A | No output captured |" >> "$RESULTS_FILE"
-        fi
-    done
-
-    # Add coverage summary
-    if [ $CLASS_COUNT -gt 0 ]; then
-        AVERAGE_COVERAGE=$((TOTAL_COVERAGE / CLASS_COUNT))
-        cat >> "$RESULTS_FILE" << EOF
-
-**Coverage Summary:**
-- Total Project Classes: $CLASS_COUNT/${#PROJECT_APEX_CLASSES[@]}
-- Average Coverage: ${AVERAGE_COVERAGE}%
-- Classes with 75%+ coverage: $CLASSES_ABOVE_75
-- Classes below 75% coverage: $CLASSES_BELOW_75
-
-EOF
-    fi
-
-    # Add failed tests section if there are failures
-    if [ "$OUTCOME" = "Failed" ]; then
-        cat >> "$RESULTS_FILE" << EOF
-
-## Failed Tests
-
-EOF
-
-        # Improved failed test detection
-        if [ -f "$temp_output" ]; then
-            # Look for actual test failures in the output
-            # Pattern: TestName.testMethodName Fail ErrorMessage
-            failed_tests=$(grep -E "^[A-Za-z_]+Test\.[a-zA-Z_]+.*Fail" "$temp_output" 2>/dev/null | awk '{print $1}' | sort | uniq)
-
-            if [ ! -z "$failed_tests" ]; then
-                echo "$failed_tests" | while read -r failed_test; do
-                    if [ ! -z "$failed_test" ]; then
-                        test_class=$(echo "$failed_test" | cut -d'.' -f1)
-                        test_method=$(echo "$failed_test" | cut -d'.' -f2)
-                        echo "- **$test_class.$test_method**" >> "$RESULTS_FILE"
-
-                        # Get the error message for this test
-                        error_msg=$(grep -A 5 "^$failed_test.*Fail" "$temp_output" 2>/dev/null | grep -v "^$failed_test" | head -3 | sed 's/^/  /')
-                        if [ ! -z "$error_msg" ]; then
-                            echo "  \`\`\`" >> "$RESULTS_FILE"
-                            echo "$error_msg" >> "$RESULTS_FILE"
-                            echo "  \`\`\`" >> "$RESULTS_FILE"
-                        fi
-                    fi
-                done
-            else
-                echo "No specific test failures could be parsed from the output." >> "$RESULTS_FILE"
-                echo "Check the detailed test output for failure details." >> "$RESULTS_FILE"
-            fi
-        fi
-    fi
-
-    # Add recommendations section
-    cat >> "$RESULTS_FILE" << EOF
-
-## Recommendations
-
-- Aim for 85%+ coverage on all classes for production deployment
-- Focus on edge cases and error handling in lower-coverage classes
-- Consider adding negative test scenarios for better coverage
-- Review any failing tests and fix issues before deployment
-
-## Raw Test Output
-
-\`\`\`
-$(cat "$temp_output" 2>/dev/null || echo "No test output captured")
-\`\`\`
-EOF
-
-    log_success "Detailed test results saved to: $RESULTS_FILE"
-}
-
-echo
-if [ $TEST_RESULT -eq 0 ]; then
-    log_success "Test execution completed successfully!"
-    echo
-    echo "What was tested:"
-    for test_class in "${PROJECT_TEST_CLASSES[@]}"; do
-        echo "  $test_class"
-    done
-
-    # Add comprehensive coverage summary
-    echo
-    echo "Test Coverage Summary for Project Classes:"
-    echo "==========================================="
-
-    # Get coverage data for each project class
-    echo "Class Name                          | Coverage | Status"
-    echo "----------------------------------- | -------- | --------------"
-
-    TOTAL_COVERAGE=0
-    CLASS_COUNT=0
-    CLASSES_ABOVE_75=0
-    CLASSES_BELOW_75=0
-
-    for apex_class in "${PROJECT_APEX_CLASSES[@]}"; do
-        # Parse coverage from the captured output
-        if [ -f "$TEMP_OUTPUT" ]; then
-            # Extract coverage percentage for the specific class from the test output
-            coverage_line=$(grep -A 50 "=== Apex Code Coverage by Class" "$TEMP_OUTPUT" 2>/dev/null | grep "^$apex_class" | head -1)
-            if [ ! -z "$coverage_line" ]; then
-                # Parse the coverage percentage - try different column positions
-                coverage_percent=$(echo "$coverage_line" | awk '{print $2}' | sed 's/%//')
-
-                # If that doesn't work, try the last column (sometimes coverage is at the end)
-                if [ -z "$coverage_percent" ] || [ "$coverage_percent" = "$apex_class" ]; then
-                    coverage_percent=$(echo "$coverage_line" | awk '{print $NF}' | sed 's/%//')
-                fi
-
-                # Cap coverage at 100% (sometimes Salesforce reports >100% due to test-only lines)
-                if [ "$coverage_percent" -gt 100 ] 2>/dev/null; then
-                    coverage_percent=100
-                fi
-
-                # Determine status based on coverage
-                if [ "$coverage_percent" -ge 85 ] 2>/dev/null; then
-                    status="Excellent"
-                    CLASSES_ABOVE_75=$((CLASSES_ABOVE_75 + 1))
-                elif [ "$coverage_percent" -ge 75 ] 2>/dev/null; then
-                    status="Good"
-                    CLASSES_ABOVE_75=$((CLASSES_ABOVE_75 + 1))
-                elif [ "$coverage_percent" -ge 50 ] 2>/dev/null; then
-                    status="Needs Work"
-                    CLASSES_BELOW_75=$((CLASSES_BELOW_75 + 1))
-                else
-                    status="Poor"
-                    CLASSES_BELOW_75=$((CLASSES_BELOW_75 + 1))
-                fi
-
-                printf "%-35s | %7s%% | %s\n" "$apex_class" "$coverage_percent" "$status"
-                TOTAL_COVERAGE=$((TOTAL_COVERAGE + coverage_percent))
-                CLASS_COUNT=$((CLASS_COUNT + 1))
-            else
-                printf "%-35s | %8s | %s\n" "$apex_class" "N/A" "Not found in output"
-            fi
-        else
-            printf "%-35s | %8s | %s\n" "$apex_class" "N/A" "No output captured"
-        fi
-    done
-
-    echo "----------------------------------- | -------- | --------------"
-
-    # Calculate average coverage
-    if [ $CLASS_COUNT -gt 0 ]; then
-        AVERAGE_COVERAGE=$((TOTAL_COVERAGE / CLASS_COUNT))
-        echo "Total Project Classes: $CLASS_COUNT/${#PROJECT_APEX_CLASSES[@]} | Avg: ${AVERAGE_COVERAGE}% | Good: $CLASSES_ABOVE_75 | Need Work: $CLASSES_BELOW_75"
-    else
-        echo "Total Project Classes: $CLASS_COUNT/${#PROJECT_APEX_CLASSES[@]} | No coverage data available"
-    fi
-
-    # Add Test Summary section
-    echo
-    echo "Test Execution Summary:"
-    echo "==========================================="
-
-    if [ -f "$TEMP_OUTPUT" ]; then
-        # Parse test summary information from the output
-        OUTCOME=$(grep -A 20 "=== Test Summary" "$TEMP_OUTPUT" 2>/dev/null | grep "Outcome" | awk '{print $2}' | head -1)
-        TESTS_RAN=$(grep -A 20 "=== Test Summary" "$TEMP_OUTPUT" 2>/dev/null | grep "Tests Ran" | awk '{print $3}' | head -1)
-        PASS_RATE=$(grep -A 20 "=== Test Summary" "$TEMP_OUTPUT" 2>/dev/null | grep "Pass Rate" | awk '{print $3}' | head -1)
-        FAIL_RATE=$(grep -A 20 "=== Test Summary" "$TEMP_OUTPUT" 2>/dev/null | grep "Fail Rate" | awk '{print $3}' | head -1)
-        SKIP_RATE=$(grep -A 20 "=== Test Summary" "$TEMP_OUTPUT" 2>/dev/null | grep "Skip Rate" | awk '{print $3}' | head -1)
-
-        # Display summary table
-        echo "NAME                 | VALUE"
-        echo "-------------------- | ----------------------"
-
-        # Show outcome
-        if [ "$OUTCOME" = "Passed" ]; then
-            printf "%-20s | %s\n" "Outcome" "PASSED $OUTCOME"
-        elif [ "$OUTCOME" = "Failed" ]; then
-            printf "%-20s | %s\n" "Outcome" "FAILED $OUTCOME"
-        else
-            printf "%-20s | %s\n" "Outcome" "${OUTCOME:-N/A}"
-        fi
-
-        printf "%-20s | %s\n" "Tests Ran" "${TESTS_RAN:-N/A}"
-        printf "%-20s | %s\n" "Pass Rate" "${PASS_RATE:-N/A}"
-        printf "%-20s | %s\n" "Fail Rate" "${FAIL_RATE:-N/A}"
-        printf "%-20s | %s\n" "Skip Rate" "${SKIP_RATE:-N/A}"
-
-        echo "-------------------- | ----------------------"
-
-        # Add interpretation
-        if [ "$OUTCOME" = "Passed" ]; then
-            echo "All tests completed successfully!"
-        elif [ "$OUTCOME" = "Failed" ]; then
-            echo "Some tests failed - review details above"
-
-
-            # Extract and display failing test classes - IMPROVED LOGIC
-            echo
-            echo "Failed Test Classes:"
-            echo "====================="
-
-            # Look for actual test failures in the output
-            # Pattern: TestName.testMethodName Fail ErrorMessage
-            # Look for lines that end with "Fail" followed by an error message (not just "Fail" in the test name)
-            failed_tests=$(grep -E "[A-Za-z_]+Test\.[a-zA-Z_]+[[:space:]]+Fail[[:space:]]+" "$TEMP_OUTPUT" 2>/dev/null | awk '{print $1}' | sort | uniq)
-
-
-
-            if [ ! -z "$failed_tests" ]; then
-                # Group failures by test class and only show classes that actually have failures
-                failed_classes=$(echo "$failed_tests" | cut -d'.' -f1 | sort | uniq)
-                if [ ! -z "$failed_classes" ]; then
-                    # Use a different approach to avoid subshell issues with while read
-                    for test_class in $failed_classes; do
-                        if [ ! -z "$test_class" ]; then
-                            echo "  FAILED: $test_class"
-                        fi
-                    done
-                else
-                    echo "  No specific test classes with failures found"
-                fi
-            else
-                # Try alternative pattern matching for failures
-                echo "  Analyzing test output for failures..."
-
-                # Look for lines that contain "Fail" and extract the test class name
-                failed_tests_alt=$(grep -B 1 "Fail" "$TEMP_OUTPUT" 2>/dev/null | grep -E "[A-Za-z_]+Test\." | awk '{print $1}' | sort | uniq)
-
-                if [ ! -z "$failed_tests_alt" ]; then
-                    failed_classes_alt=$(echo "$failed_tests_alt" | cut -d'.' -f1 | sort | uniq)
-                    for test_class in $failed_classes_alt; do
-                        if [ ! -z "$test_class" ]; then
-                            echo "  FAILED: $test_class"
-                        fi
-                    done
-                else
-                            # Final fallback - look for any line containing "Fail" and try to extract test class
-            echo "  Final fallback analysis..."
-            failed_lines=$(grep "Fail" "$TEMP_OUTPUT" 2>/dev/null | head -20)
-            if [ ! -z "$failed_lines" ]; then
-                echo "  Found failure lines, but couldn't parse specific classes:"
-                echo "$failed_lines" | head -5 | sed 's/^/    /'
-                echo "  Debug: Looking for test class patterns..."
-                echo "$failed_lines" | grep -E "[A-Za-z_]+Test" | head -3 | sed 's/^/    /'
-            else
-                echo "  Could not parse specific test failures from output"
-                echo "  Check the detailed test output above for failure details"
-            fi
-                fi
-            fi
-        fi
-    else
-        echo "NAME                 | VALUE"
-        echo "-------------------- | ----------------------"
-        echo "Outcome              | No data captured"
-        echo "Tests Ran            | N/A"
-        echo "Pass Rate            | N/A"
-        echo "Fail Rate            | N/A"
-        echo "Skip Rate            | N/A"
-        echo "-------------------- | ----------------------"
-        echo "Test summary not available - check test execution"
-    fi
-
-    echo
-    echo "Test Coverage Analysis:"
-    echo "  All ${#PROJECT_TEST_CLASSES[@]} test classes executed successfully"
-    echo "  Tests cover ${CLASS_COUNT}/${#PROJECT_APEX_CLASSES[@]} main Apex classes in the project"
-    if [ $CLASS_COUNT -gt 0 ]; then
-        echo "  Average coverage across project classes: ${AVERAGE_COVERAGE}%"
-        echo "  Classes with 75%+ coverage: $CLASSES_ABOVE_75 out of $CLASS_COUNT"
-        if [ $CLASSES_BELOW_75 -gt 0 ]; then
-            echo "  WARNING: Classes needing attention: $CLASSES_BELOW_75 below 75% coverage"
-        else
-            echo "  All tested classes meet minimum coverage requirements!"
-        fi
-    fi
-
-    echo
-    echo "Coverage Recommendations:"
-    echo "  Aim for 85%+ coverage on all classes for production deployment"
-    echo "  Focus on edge cases and error handling in lower-coverage classes"
-    echo "  Consider adding negative test scenarios for better coverage"
-
-    echo
-    echo "Next steps:"
-    echo "  Review any failing tests and fix issues"
-    echo "  Ensure code coverage meets your org requirements (usually 75%+)"
-    echo "  Run deployment if all tests pass"
-
-    # Generate markdown report
-    generate_markdown_report "success" "$TEMP_OUTPUT"
-
-else
-    log_error "Some tests failed!"
-    echo
-    echo "Troubleshooting:"
-    echo "  Check test failure details above"
-    echo "  Verify all required API configurations are set up"
-    echo "  Ensure proper test data setup"
-    echo "  Check for any deployment issues"
-
-    # Generate markdown report even for failures
-    generate_markdown_report "failure" "$TEMP_OUTPUT"
-
-    exit 1
-fi
-
-echo
-echo "Pro Tips:"
-echo "  Run tests before every deployment"
-echo "  Aim for 85%+ code coverage for production"
-echo "  Fix failing tests before proceeding with deployment"
-echo "  Use option 3 to debug specific failing tests"
-echo "  Detailed results saved to: $RESULTS_FILE"
-
-# Cleanup temporary file
-if [ -f "$TEMP_OUTPUT" ]; then
-    rm -f "$TEMP_OUTPUT"
-fi
+# Exit with the actual test command's exit code
+exit $TEST_EXIT_CODE

--- a/scripts/new/rollback.sh
+++ b/scripts/new/rollback.sh
@@ -13,6 +13,9 @@ MANIFEST_DIR="${SFDT_MANIFEST_DIR:-manifest/release}"
 TARGET_ORG="${SFDT_TARGET_ORG:-}"
 PROJECT_NAME="${SFDT_PROJECT_NAME:-sfdt}"
 DEPLOYED_DIR="${MANIFEST_DIR}/deployed"
+BACKUP_BEFORE_ROLLBACK="${SFDT_BACKUP_BEFORE_ROLLBACK:-true}"
+TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
+BACKUP_DIR="${SFDT_LOG_DIR:-${SFDT_PROJECT_ROOT:-.}/logs}/rollback-backups"
 
 print_header "Rollback Deployment: ${PROJECT_NAME}"
 
@@ -94,6 +97,21 @@ read -rp "Proceed with rollback? (y/N): " confirm
 if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
     print_info "Rollback cancelled."
     exit 0
+fi
+
+# ── Step 5b: Backup current org state ────────────────────────────────────────
+if [[ "$BACKUP_BEFORE_ROLLBACK" == "true" ]]; then
+    print_step "Creating pre-rollback backup of current org state..."
+    BACKUP_PATH="${BACKUP_DIR}/pre_rollback_${TIMESTAMP}"
+    mkdir -p "$BACKUP_PATH"
+    if sf project retrieve start \
+        --manifest "$SELECTED_MANIFEST" \
+        --target-org "$TARGET_ORG" \
+        --output-dir "$BACKUP_PATH" 2>/dev/null; then
+        print_success "Pre-rollback backup saved to: ${BACKUP_PATH}"
+    else
+        print_warning "Pre-rollback backup failed — continuing with rollback"
+    fi
 fi
 
 # ── Step 6: Execute deployment ───────────────────────────────────────────────

--- a/scripts/quality/code-analyzer.sh
+++ b/scripts/quality/code-analyzer.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # =============================================================================
 # SFDT - Code Quality Analyzer
@@ -9,12 +10,15 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../utils/shared.sh"
 
-# Initialize environment
-init_script_env
-
-# Project configuration
+# Configuration from SFDT_ env vars (set by script-runner.js)
 PROJECT_NAME="${SFDT_PROJECT_NAME:-Salesforce Project}"
 SOURCE_PATH="${SFDT_SOURCE_PATH:-force-app/main/default}"
+LOG_DIR="${SFDT_LOG_DIR:-${SFDT_PROJECT_ROOT:-$(cd "$SCRIPT_DIR/../.." && pwd)}/logs}"
+PROJECT_CONFIG_DIR="${SFDT_CONFIG_DIR:-${SFDT_PROJECT_ROOT:-.}/.sfdt}"
+PROJECT_CONFIG_FILE="${PROJECT_CONFIG_DIR}/config.json"
+ENVIRONMENT_CONFIG_FILE="${PROJECT_CONFIG_DIR}/environments.json"
+PULL_CONFIG_FILE="${PROJECT_CONFIG_DIR}/pull-config.json"
+TEST_CONFIG_FILE="${PROJECT_CONFIG_DIR}/test-config.json"
 
 echo -e "${BLUE}${PROJECT_NAME} - Code Quality Analyzer${NC}"
 echo -e "${YELLOW}====================================================${NC}"

--- a/scripts/quality/code-analyzer.sh
+++ b/scripts/quality/code-analyzer.sh
@@ -80,7 +80,7 @@ if [ -d "$FORCE_APP_DIR/classes" ]; then
                     log_warning "Classes without tests found:"
                 fi
                 echo "  $class_name"
-                ((CLASSES_WITHOUT_TESTS++))
+                CLASSES_WITHOUT_TESTS=$((CLASSES_WITHOUT_TESTS + 1))
             fi
         fi
     done < <(find "$FORCE_APP_DIR/classes" -name "*.cls" -print0)
@@ -98,7 +98,7 @@ CONFIG_ISSUES=0
 # Check project.json
 if ! jq empty "$PROJECT_CONFIG_FILE" 2>/dev/null; then
     log_error "Invalid JSON in project.json"
-    ((CONFIG_ISSUES++))
+    CONFIG_ISSUES=$((CONFIG_ISSUES + 1))
 else
     log_success "project.json is valid JSON"
 fi
@@ -106,7 +106,7 @@ fi
 # Check environments.json
 if ! jq empty "$ENVIRONMENT_CONFIG_FILE" 2>/dev/null; then
     log_error "Invalid JSON in environments.json"
-    ((CONFIG_ISSUES++))
+    CONFIG_ISSUES=$((CONFIG_ISSUES + 1))
 else
     log_success "environments.json is valid JSON"
 fi
@@ -114,7 +114,7 @@ fi
 # Check pull-config.json
 if ! jq empty "$PULL_CONFIG_FILE" 2>/dev/null; then
     log_error "Invalid JSON in pull-config.json"
-    ((CONFIG_ISSUES++))
+    CONFIG_ISSUES=$((CONFIG_ISSUES + 1))
 else
     log_success "pull-config.json is valid JSON"
 fi
@@ -122,7 +122,7 @@ fi
 # Check test-config.json
 if ! jq empty "$TEST_CONFIG_FILE" 2>/dev/null; then
     log_error "Invalid JSON in test-config.json"
-    ((CONFIG_ISSUES++))
+    CONFIG_ISSUES=$((CONFIG_ISSUES + 1))
 else
     log_success "test-config.json is valid JSON"
 fi

--- a/scripts/quality/generate-test-stubs.sh
+++ b/scripts/quality/generate-test-stubs.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+set -euo pipefail
+
+# =============================================================================
+# SFDT - Generate Test Stubs
+# Generates minimal @IsTest stub .cls + -meta.xml pairs for Apex classes
+# that don't have a corresponding test class.
+# =============================================================================
+
+# Source shared utilities
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../utils/shared.sh"
+
+# Configuration from SFDT_ env vars (set by script-runner.js)
+PROJECT_NAME="${SFDT_PROJECT_NAME:-Salesforce Project}"
+SOURCE_PATH="${SFDT_SOURCE_PATH:-force-app/main/default}"
+DRY_RUN="${SFDT_DRY_RUN:-false}"
+TEST_CONFIG_FILE="${SFDT_CONFIG_DIR:-${SFDT_PROJECT_ROOT:-.}/.sfdt}/test-config.json"
+
+echo -e "${BLUE}${PROJECT_NAME} - Generate Test Stubs${NC}"
+echo -e "${YELLOW}======================================================${NC}"
+
+# Load test class list
+if [[ -n "${SFDT_TEST_CLASSES:-}" ]]; then
+    IFS=',' read -r -a PROJECT_TEST_CLASSES <<< "$SFDT_TEST_CLASSES"
+elif [[ -f "$TEST_CONFIG_FILE" ]]; then
+    mapfile -t PROJECT_TEST_CLASSES < <(jq -r '.testClasses[]' "$TEST_CONFIG_FILE" 2>/dev/null | sort)
+else
+    PROJECT_TEST_CLASSES=()
+fi
+
+# Load apex class list
+if [[ -n "${SFDT_APEX_CLASSES:-}" ]]; then
+    IFS=',' read -r -a PROJECT_APEX_CLASSES <<< "$SFDT_APEX_CLASSES"
+elif [[ -f "$TEST_CONFIG_FILE" ]]; then
+    mapfile -t PROJECT_APEX_CLASSES < <(jq -r '.apexClasses[]' "$TEST_CONFIG_FILE" 2>/dev/null | sort)
+else
+    PROJECT_APEX_CLASSES=()
+fi
+
+log_info "Checking ${#PROJECT_APEX_CLASSES[@]} Apex classes for missing test stubs"
+
+CLASSES_DIR="${SOURCE_PATH}/classes"
+STUB_COUNT=0
+
+for class in "${PROJECT_APEX_CLASSES[@]}"; do
+    # Skip classes that are already test classes
+    if [[ "$class" =~ Test$ ]] || [[ "$class" =~ _Test$ ]]; then
+        continue
+    fi
+
+    # Check if a test class already exists in the known list
+    has_test=false
+    for test_class in "${PROJECT_TEST_CLASSES[@]}"; do
+        if [[ "$test_class" == "${class}Test" ]] || [[ "$test_class" == "${class}_Test" ]]; then
+            has_test=true
+            break
+        fi
+    done
+
+    if [[ "$has_test" == "true" ]]; then
+        continue
+    fi
+
+    # This class needs a test stub
+    STUB_FILE="${CLASSES_DIR}/${class}Test.cls"
+    META_FILE="${CLASSES_DIR}/${class}Test.cls-meta.xml"
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+        log_info "[DRY RUN] Would create: ${class}Test.cls"
+        STUB_COUNT=$((STUB_COUNT + 1))
+    else
+        if [[ -f "$STUB_FILE" ]]; then
+            log_warning "Skipping ${class}Test.cls — file already exists"
+            continue
+        fi
+
+        mkdir -p "$CLASSES_DIR"
+
+        cat > "$STUB_FILE" << APEX
+@IsTest
+private class ${class}Test {
+    @IsTest
+    static void testPlaceholder() {
+        // TODO: Implement tests for ${class}
+        System.assert(true, 'Placeholder test for ${class}');
+    }
+}
+APEX
+
+        cat > "$META_FILE" << XML
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <status>Active</status>
+</ApexClass>
+XML
+
+        log_success "Created: ${class}Test.cls"
+        STUB_COUNT=$((STUB_COUNT + 1))
+    fi
+done
+
+echo ""
+if [[ "$DRY_RUN" == "true" ]]; then
+    log_info "Dry run: would generate ${STUB_COUNT} stubs"
+else
+    log_success "Generated ${STUB_COUNT} test stubs"
+fi
+
+exit 0

--- a/scripts/quality/generate-test-stubs.sh
+++ b/scripts/quality/generate-test-stubs.sh
@@ -91,7 +91,7 @@ APEX
         cat > "$META_FILE" << XML
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>61.0</apiVersion>
+    <apiVersion>${SFDT_API_VERSION:-61.0}</apiVersion>
     <status>Active</status>
 </ApexClass>
 XML

--- a/scripts/quality/test-analyzer.sh
+++ b/scripts/quality/test-analyzer.sh
@@ -265,8 +265,8 @@ generate_quality_report() {
 | Metric | Count | Percentage |
 |--------|-------|------------|
 | **Total Apex Classes** | $total_classes | 100% |
-| **Classes with Tests** | $tested_count | $((tested_count * 100 / total_classes))% |
-| **Classes without Tests** | $untested_count | $((untested_count * 100 / total_classes))% |
+| **Classes with Tests** | $tested_count | $((total_classes > 0 ? tested_count * 100 / total_classes : 0))% |
+| **Classes without Tests** | $untested_count | $((total_classes > 0 ? untested_count * 100 / total_classes : 0))% |
 | **Total Test Classes** | ${#PROJECT_TEST_CLASSES[@]} | - |
 | **Total Test Methods** | $total_methods | - |
 | **Total Assertions** | $total_assertions | - |

--- a/scripts/quality/test-analyzer.sh
+++ b/scripts/quality/test-analyzer.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # =============================================================================
 # SFDT - Test Quality Analyzer
@@ -9,12 +10,11 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../utils/shared.sh"
 
-# Initialize environment
-init_script_env
-
-# Project configuration
+# Configuration from SFDT_ env vars (set by script-runner.js)
 PROJECT_NAME="${SFDT_PROJECT_NAME:-Salesforce Project}"
 SOURCE_PATH="${SFDT_SOURCE_PATH:-force-app/main/default}"
+LOG_DIR="${SFDT_LOG_DIR:-${SFDT_PROJECT_ROOT:-$(cd "$SCRIPT_DIR/../.." && pwd)}/logs}"
+TEST_CONFIG_FILE="${SFDT_CONFIG_DIR:-${SFDT_PROJECT_ROOT:-.}/.sfdt}/test-config.json"
 
 echo -e "${BLUE}${PROJECT_NAME} - Test Quality Analyzer${NC}"
 echo -e "${YELLOW}======================================================${NC}"
@@ -25,11 +25,25 @@ if [ ! -d "$FORCE_APP_DIR" ]; then
     FORCE_APP_DIR="../../${SOURCE_PATH}"
 fi
 
+mkdir -p "$LOG_DIR/test-results"
 TEST_QUALITY_REPORT="$LOG_DIR/test-results/test_quality_$(date +%Y%m%d_%H%M%S).md"
 
 # Load test configuration
-PROJECT_TEST_CLASSES=($(jq -r '.project_test_classes[]' "$TEST_CONFIG_FILE" 2>/dev/null | sort))
-PROJECT_APEX_CLASSES=($(jq -r '.project_apex_classes[]' "$TEST_CONFIG_FILE" 2>/dev/null | sort))
+if [[ -n "${SFDT_TEST_CLASSES:-}" ]]; then
+    IFS=',' read -r -a PROJECT_TEST_CLASSES <<< "$SFDT_TEST_CLASSES"
+elif [[ -f "$TEST_CONFIG_FILE" ]]; then
+    mapfile -t PROJECT_TEST_CLASSES < <(jq -r '.testClasses[]' "$TEST_CONFIG_FILE" 2>/dev/null | sort)
+else
+    PROJECT_TEST_CLASSES=()
+fi
+
+if [[ -n "${SFDT_APEX_CLASSES:-}" ]]; then
+    IFS=',' read -r -a PROJECT_APEX_CLASSES <<< "$SFDT_APEX_CLASSES"
+elif [[ -f "$TEST_CONFIG_FILE" ]]; then
+    mapfile -t PROJECT_APEX_CLASSES < <(jq -r '.apexClasses[]' "$TEST_CONFIG_FILE" 2>/dev/null | sort)
+else
+    PROJECT_APEX_CLASSES=()
+fi
 
 log_info "Analyzing test quality for ${#PROJECT_TEST_CLASSES[@]} test classes"
 

--- a/scripts/utils/shared.sh
+++ b/scripts/utils/shared.sh
@@ -37,6 +37,31 @@ log_debug() {
     fi
 }
 
+# Print functions for simple output (without prefixes)
+print_header() {
+    echo -e "\n${BLUE}=== $1 ===${NC}"
+}
+
+print_step() {
+    echo -e "${CYAN}>>> $1${NC}"
+}
+
+print_success() {
+    echo -e "${GREEN}✓ $1${NC}"
+}
+
+print_warning() {
+    echo -e "${YELLOW}! $1${NC}"
+}
+
+print_error() {
+    echo -e "${RED}✗ $1${NC}"
+}
+
+print_info() {
+    echo -e "${BLUE}  $1${NC}"
+}
+
 # Progress indicator function
 show_progress() {
     local duration=$1
@@ -174,5 +199,6 @@ init_script_env() {
 
 # Export functions for use in other scripts
 export -f log_info log_success log_warning log_error log_debug
+export -f print_header print_step print_success print_warning print_error print_info
 export -f show_progress check_sf_cli get_default_org
 export -f load_project_config validate_configs get_timestamp ensure_log_dir init_script_env

--- a/src/cli.js
+++ b/src/cli.js
@@ -25,7 +25,9 @@ export function createCli() {
 
   program
     .name('sfdt')
-    .description('Salesforce DevTools — deployment, testing, quality, and release management for any Salesforce DX project')
+    .description(
+      'Salesforce DevTools — deployment, testing, quality, and release management for any Salesforce DX project',
+    )
     .version(pkg.version, '-v, --version');
 
   // Register all commands

--- a/src/commands/changelog.js
+++ b/src/commands/changelog.js
@@ -7,9 +7,7 @@ import { print } from '../lib/output.js';
 import { execa } from 'execa';
 
 export function registerChangelogCommand(program) {
-  const changelog = program
-    .command('changelog')
-    .description('Manage project CHANGELOG.md');
+  const changelog = program.command('changelog').description('Manage project CHANGELOG.md');
 
   changelog
     .command('generate')
@@ -21,7 +19,7 @@ export function registerChangelogCommand(program) {
         const projectRoot = config._projectRoot;
         const changelogPath = path.join(projectRoot, 'CHANGELOG.md');
 
-        if (!await fs.pathExists(changelogPath)) {
+        if (!(await fs.pathExists(changelogPath))) {
           const { create } = await inquirer.prompt([
             {
               type: 'confirm',
@@ -32,7 +30,8 @@ export function registerChangelogCommand(program) {
           ]);
 
           if (create) {
-            const template = '# Changelog\n\nAll notable changes to this project will be documented in this file.\n\n## [Unreleased]\n\n### Added\n\n### Fixed\n\n### Changed\n';
+            const template =
+              '# Changelog\n\nAll notable changes to this project will be documented in this file.\n\n## [Unreleased]\n\n### Added\n\n### Fixed\n\n### Changed\n';
             await fs.writeFile(changelogPath, template);
             print.success('Created CHANGELOG.md');
           } else {
@@ -42,7 +41,9 @@ export function registerChangelogCommand(program) {
 
         if (!config.features?.ai || !(await isClaudeAvailable())) {
           print.error('AI features are disabled or Claude CLI is not installed.');
-          print.info('To enable AI, set features.ai: true in .sfdt/config.json and install @anthropic-ai/claude-code');
+          print.info(
+            'To enable AI, set features.ai: true in .sfdt/config.json and install @anthropic-ai/claude-code',
+          );
           return;
         }
 
@@ -73,7 +74,8 @@ export function registerChangelogCommand(program) {
             {
               type: 'confirm',
               name: 'apply',
-              message: 'Would you like to append these entries to your CHANGELOG.md [Unreleased] section?',
+              message:
+                'Would you like to append these entries to your CHANGELOG.md [Unreleased] section?',
               default: true,
             },
           ]);
@@ -82,7 +84,7 @@ export function registerChangelogCommand(program) {
             // Simple append logic for now - in a real tool we'd parse and merge
             const currentContent = await fs.readFile(changelogPath, 'utf8');
             const unreleasedTag = '## [Unreleased]';
-            
+
             if (currentContent.includes(unreleasedTag)) {
               const parts = currentContent.split(unreleasedTag);
               const newContent = `${parts[0]}${unreleasedTag}\n\n${response}${parts[1]}`;
@@ -136,8 +138,10 @@ export function registerChangelogCommand(program) {
         print.info('Checking CHANGELOG.md against git changes...');
 
         // Check if there are uncommitted changes
-        const { stdout: gitStatus } = await execa('git', ['status', '--porcelain'], { cwd: projectRoot });
-        
+        const { stdout: gitStatus } = await execa('git', ['status', '--porcelain'], {
+          cwd: projectRoot,
+        });
+
         // Check if [Unreleased] has content
         const scriptContent = `
           source "${path.resolve(projectRoot, 'scripts/lib/changelog-utils.sh')}"
@@ -147,10 +151,14 @@ export function registerChangelogCommand(program) {
             echo "EMPTY"
           fi
         `;
-        const { stdout: contentStatus } = await execa('bash', ['-c', scriptContent], { cwd: projectRoot });
+        const { stdout: contentStatus } = await execa('bash', ['-c', scriptContent], {
+          cwd: projectRoot,
+        });
 
         if (gitStatus && contentStatus.trim() === 'EMPTY') {
-          print.warning('You have git changes but the [Unreleased] section in CHANGELOG.md is empty.');
+          print.warning(
+            'You have git changes but the [Unreleased] section in CHANGELOG.md is empty.',
+          );
           print.info('Run "sfdt changelog generate" to update it with AI.');
           process.exitCode = 1;
         } else if (!gitStatus && contentStatus.trim() === 'HAS_CONTENT') {

--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -7,10 +7,27 @@ export function registerDeployCommand(program) {
     .command('deploy')
     .description('Deploy to a Salesforce org using the configured deployment script')
     .option('--managed', 'Use deploy-manager.sh instead of deployment-assistant.sh')
+    .option('--skip-preflight', 'Skip pre-deployment preflight checks')
     .action(async (options) => {
       try {
         const config = await loadConfig();
         const projectRoot = config._projectRoot;
+
+        if (!options.skipPreflight) {
+          print.info('Running preflight checks...');
+          const preflightEnv = {};
+          if (config.deployment?.preflight?.strict) {
+            preflightEnv.SFDT_PREFLIGHT_STRICT = 'true';
+          }
+          try {
+            await runScript('new/preflight.sh', config, { cwd: projectRoot, env: preflightEnv });
+            print.success('Preflight passed.');
+          } catch (prefErr) {
+            print.error(`Preflight failed — aborting deploy: ${prefErr.message}`);
+            process.exitCode = 1;
+            return;
+          }
+        }
 
         const scriptPath = options.managed
           ? 'core/deploy-manager.sh'

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -23,9 +23,7 @@ function buildConfigTemplate({ projectName, defaultOrg, features, releaseNotesDi
 function buildEnvironmentsTemplate(defaultOrg) {
   return {
     default: defaultOrg,
-    orgs: [
-      { alias: defaultOrg, type: 'development', description: 'Default development org' },
-    ],
+    orgs: [{ alias: defaultOrg, type: 'development', description: 'Default development org' }],
   };
 }
 
@@ -68,8 +66,8 @@ export function registerInitCommand(program) {
         } catch {
           print.error(
             'No sfdx-project.json found in this directory or any parent.\n' +
-            '  Make sure you are inside a Salesforce DX project.\n' +
-            '  Create one with: sf project generate --name my-project'
+              '  Make sure you are inside a Salesforce DX project.\n' +
+              '  Create one with: sf project generate --name my-project',
           );
           process.exitCode = 1;
           return;
@@ -135,7 +133,9 @@ export function registerInitCommand(program) {
         ]);
 
         // Auto-scan for test classes and apex classes
-        const spinner = (await import('../lib/output.js')).createSpinner('Scanning for Apex classes...');
+        const spinner = (await import('../lib/output.js')).createSpinner(
+          'Scanning for Apex classes...',
+        );
         spinner.start();
 
         const packageDirs = project.packageDirectories.map((d) => d.absolutePath);
@@ -144,24 +144,22 @@ export function registerInitCommand(program) {
 
         for (const dir of packageDirs) {
           const testMatches = await glob('**/classes/*Test.cls', { cwd: dir });
-          testClasses.push(
-            ...testMatches.map((f) => path.basename(f, '.cls'))
-          );
+          testClasses.push(...testMatches.map((f) => path.basename(f, '.cls')));
 
           const allMatches = await glob('**/classes/*.cls', { cwd: dir });
           const nonTest = allMatches.filter(
-            (f) => !f.endsWith('Test.cls') && !f.endsWith('.cls-meta.xml')
+            (f) => !f.endsWith('Test.cls') && !f.endsWith('.cls-meta.xml'),
           );
-          apexClasses.push(
-            ...nonTest.map((f) => path.basename(f, '.cls'))
-          );
+          apexClasses.push(...nonTest.map((f) => path.basename(f, '.cls')));
         }
 
         // Deduplicate
         testClasses = [...new Set(testClasses)].sort();
         apexClasses = [...new Set(apexClasses)].sort();
 
-        spinner.succeed(`Found ${testClasses.length} test classes and ${apexClasses.length} Apex classes`);
+        spinner.succeed(
+          `Found ${testClasses.length} test classes and ${apexClasses.length} Apex classes`,
+        );
 
         // Create .sfdt/ directory
         await fs.ensureDir(configDir);
@@ -182,7 +180,7 @@ export function registerInitCommand(program) {
         const testConfig = buildTestConfigTemplate(
           answers.coverageThreshold,
           testClasses,
-          apexClasses
+          apexClasses,
         );
 
         const files = [

--- a/src/commands/notify.js
+++ b/src/commands/notify.js
@@ -99,24 +99,23 @@ export function registerNotifyCommand(program) {
     .action(async (event, options) => {
       try {
         if (!VALID_EVENTS.includes(event)) {
-          print.error(
-            `Unknown event: "${event}"\n` +
-            `  Valid events: ${VALID_EVENTS.join(', ')}`
-          );
+          print.error(`Unknown event: "${event}"\n` + `  Valid events: ${VALID_EVENTS.join(', ')}`);
           process.exitCode = 1;
           return;
         }
 
         const config = await loadConfig();
 
-        const webhookUrl = config.features?.notifications
-          && config.notifications?.slack?.webhookUrl;
+        const webhookUrl =
+          config.features?.notifications && config.notifications?.slack?.webhookUrl;
 
         if (!webhookUrl) {
           print.warning('Slack notifications are not configured.');
           console.log('');
           print.info('To set up Slack notifications:');
-          print.step('1. Create a Slack Incoming Webhook at https://api.slack.com/messaging/webhooks');
+          print.step(
+            '1. Create a Slack Incoming Webhook at https://api.slack.com/messaging/webhooks',
+          );
           print.step('2. Add the webhook URL to .sfdt/config.json:');
           console.log('');
           print.step('   {');

--- a/src/commands/quality.js
+++ b/src/commands/quality.js
@@ -10,6 +10,8 @@ export function registerQualityCommand(program) {
     .option('--tests', 'Run test-analyzer only')
     .option('--all', 'Run both code-analyzer and test-analyzer')
     .option('--fix-plan', 'Generate an AI-powered fix plan from quality output')
+    .option('--generate-stubs', 'Generate @IsTest stub classes for untested Apex classes')
+    .option('--dry-run', 'Preview --generate-stubs output without writing files')
     .action(async (options) => {
       try {
         const config = await loadConfig();
@@ -50,7 +52,7 @@ export function registerQualityCommand(program) {
         // AI fix plan
         if (options.fixPlan) {
           const aiEnabled = config.features?.ai;
-          if (aiEnabled && await isClaudeAvailable()) {
+          if (aiEnabled && (await isClaudeAvailable())) {
             print.info('Generating AI fix plan...');
 
             const prompt = [
@@ -71,6 +73,20 @@ export function registerQualityCommand(program) {
             });
           } else {
             print.warning('AI features are not available. Skipping fix plan generation.');
+          }
+        }
+        if (options.generateStubs) {
+          print.info('Generating test stubs...');
+          const stubEnv = options.dryRun ? { SFDT_DRY_RUN: 'true' } : {};
+          try {
+            await runScript('quality/generate-test-stubs.sh', config, {
+              cwd: projectRoot,
+              env: stubEnv,
+              interactive: false,
+            });
+            print.success('Stub generation complete.');
+          } catch (err) {
+            print.warning(`Stub generation encountered issues: ${err.message}`);
           }
         }
       } catch (err) {

--- a/src/commands/release.js
+++ b/src/commands/release.js
@@ -33,7 +33,7 @@ export function registerReleaseCommand(program) {
 
         // Offer AI release notes if enabled
         const aiEnabled = config.features?.ai;
-        if (aiEnabled && await isClaudeAvailable()) {
+        if (aiEnabled && (await isClaudeAvailable())) {
           const { generateNotes } = await inquirer.prompt([
             {
               type: 'confirm',

--- a/src/commands/review.js
+++ b/src/commands/review.js
@@ -50,15 +50,17 @@ export function registerReviewCommand(program) {
         const aiEnabled = config.features?.ai;
 
         if (!aiEnabled) {
-          print.error('AI features are disabled. Enable them in .sfdt/config.json (features.ai: true).');
+          print.error(
+            'AI features are disabled. Enable them in .sfdt/config.json (features.ai: true).',
+          );
           process.exitCode = 1;
           return;
         }
 
-        if (!await isClaudeAvailable()) {
+        if (!(await isClaudeAvailable())) {
           print.error(
             'Claude CLI is not installed or not in PATH.\n' +
-            '  Install from: https://docs.anthropic.com/en/docs/claude-cli'
+              '  Install from: https://docs.anthropic.com/en/docs/claude-cli',
           );
           process.exitCode = 1;
           return;

--- a/src/commands/rollback.js
+++ b/src/commands/rollback.js
@@ -17,6 +17,8 @@ export function registerRollbackCommand(program) {
 
         const env = {
           SFDT_TARGET_ORG: orgAlias,
+          SFDT_BACKUP_BEFORE_ROLLBACK: String(config.deployment?.backupBeforeRollback ?? true),
+          SFDT_LOG_DIR: config.logDir || '',
         };
 
         await runScript('new/rollback.sh', config, {

--- a/src/commands/test.js
+++ b/src/commands/test.js
@@ -15,9 +15,7 @@ export function registerTestCommand(program) {
         const config = await loadConfig();
         const projectRoot = config._projectRoot;
 
-        const scriptPath = options.legacy
-          ? 'core/run-tests.sh'
-          : 'core/enhanced-test-runner.sh';
+        const scriptPath = options.legacy ? 'core/run-tests.sh' : 'core/enhanced-test-runner.sh';
 
         print.header(`Running Tests${options.legacy ? ' (legacy)' : ''}`);
 
@@ -47,7 +45,7 @@ export function registerTestCommand(program) {
         // Offer AI analysis on failure
         if (testFailed) {
           const aiEnabled = config.features?.ai;
-          if (aiEnabled && await isClaudeAvailable()) {
+          if (aiEnabled && (await isClaudeAvailable())) {
             const { analyzeFailure } = await inquirer.prompt([
               {
                 type: 'confirm',

--- a/src/lib/ai.js
+++ b/src/lib/ai.js
@@ -36,13 +36,7 @@ export async function isClaudeAvailable() {
  *   Returns null if claude is not available or AI is disabled.
  */
 export async function runAiPrompt(prompt, options = {}) {
-  const {
-    allowedTools,
-    input,
-    interactive = false,
-    cwd,
-    aiEnabled = true,
-  } = options;
+  const { allowedTools, input, interactive = false, cwd, aiEnabled = true } = options;
 
   if (!aiEnabled) {
     console.log('AI features are disabled in sfdt configuration. Skipping AI prompt.');
@@ -53,7 +47,7 @@ export async function runAiPrompt(prompt, options = {}) {
   if (!available) {
     console.log(
       'Claude CLI is not installed or not in PATH. Skipping AI prompt.\n' +
-      'Install it from https://docs.anthropic.com/en/docs/claude-cli to enable AI features.'
+        'Install it from https://docs.anthropic.com/en/docs/claude-cli to enable AI features.',
     );
     return null;
   }

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -29,9 +29,9 @@ export async function loadConfig(startDir) {
   const configDir = getConfigDir(startDir);
 
   const configPath = path.join(configDir, CONFIG_FILES.config);
-  if (!await fs.pathExists(configPath)) {
+  if (!(await fs.pathExists(configPath))) {
     throw new Error(
-      `Configuration file not found: ${configPath}\nRun 'sfdt init' first to create the .sfdt/ configuration directory.`
+      `Configuration file not found: ${configPath}\nRun 'sfdt init' first to create the .sfdt/ configuration directory.`,
     );
   }
 
@@ -59,7 +59,8 @@ export async function loadConfig(startDir) {
       merged.sourceApiVersion = sfdxProject.sourceApiVersion;
     }
     if (!merged.defaultSourcePath && sfdxProject.packageDirectories?.length) {
-      const defaultPkg = sfdxProject.packageDirectories.find((d) => d.default) || sfdxProject.packageDirectories[0];
+      const defaultPkg =
+        sfdxProject.packageDirectories.find((d) => d.default) || sfdxProject.packageDirectories[0];
       merged.defaultSourcePath = defaultPkg.path + '/main/default';
     }
   }
@@ -80,7 +81,7 @@ export function validateConfig(config) {
   if (missing.length > 0) {
     throw new Error(
       `Invalid configuration: missing required keys: ${missing.join(', ')}.\n` +
-      `Run 'sfdt init' to regenerate the configuration.`
+        `Run 'sfdt init' to regenerate the configuration.`,
     );
   }
 
@@ -108,7 +109,7 @@ function findProjectWithConfig(startDir) {
     if (hasSfdxProject && !hasSfdtDir) {
       throw new Error(
         `Found Salesforce DX project at ${current} but no .sfdt/ directory.\n` +
-        `Run 'sfdt init' first to initialize configuration.`
+          `Run 'sfdt init' first to initialize configuration.`,
       );
     }
 
@@ -117,6 +118,6 @@ function findProjectWithConfig(startDir) {
 
   throw new Error(
     `Could not find a Salesforce DX project with .sfdt/ configuration.\n` +
-    `Run 'sfdt init' in your project root to get started.`
+      `Run 'sfdt init' in your project root to get started.`,
   );
 }

--- a/src/lib/project-detect.js
+++ b/src/lib/project-detect.js
@@ -20,7 +20,7 @@ export function getProjectRoot(startDir) {
 
   throw new Error(
     'Not inside a Salesforce DX project.\n' +
-    `Could not find ${SFDX_PROJECT_FILE} in any parent directory of ${startDir || process.cwd()}.`
+      `Could not find ${SFDX_PROJECT_FILE} in any parent directory of ${startDir || process.cwd()}.`,
   );
 }
 
@@ -36,16 +36,14 @@ export async function detectProject(startDir) {
   try {
     projectJson = await fs.readJson(projectFilePath);
   } catch (err) {
-    throw new Error(
-      `Failed to parse ${SFDX_PROJECT_FILE} at ${projectFilePath}: ${err.message}`
-    );
+    throw new Error(`Failed to parse ${SFDX_PROJECT_FILE} at ${projectFilePath}: ${err.message}`);
   }
 
   const packageDirectories = projectJson.packageDirectories || [];
   if (packageDirectories.length === 0) {
     throw new Error(
       `No packageDirectories defined in ${projectFilePath}.\n` +
-      'Your sfdx-project.json must have at least one packageDirectory entry.'
+        'Your sfdx-project.json must have at least one packageDirectory entry.',
     );
   }
 

--- a/src/lib/script-runner.js
+++ b/src/lib/script-runner.js
@@ -27,6 +27,7 @@ export function buildScriptEnv(config) {
   env.SFDT_RELEASE_NOTES_DIR = config.releaseNotesDir || 'release-notes';
   env.SFDT_API_VERSION = config.sourceApiVersion || '';
   env.SFDT_COVERAGE_THRESHOLD = String(config.deployment?.coverageThreshold || 75);
+  env.SFDT_LOG_DIR = config.logDir || '';
 
   // Flatten features
   if (config.features && typeof config.features === 'object') {
@@ -57,6 +58,12 @@ export function buildScriptEnv(config) {
     if (Array.isArray(config.testConfig.suites)) {
       env.SFDT_TEST_SUITES = config.testConfig.suites.join(',');
     }
+    if (Array.isArray(config.testConfig.testClasses)) {
+      env.SFDT_TEST_CLASSES = config.testConfig.testClasses.join(',');
+    }
+    if (Array.isArray(config.testConfig.apexClasses)) {
+      env.SFDT_APEX_CLASSES = config.testConfig.apexClasses.join(',');
+    }
   }
 
   // Pull config
@@ -84,17 +91,11 @@ export function buildScriptEnv(config) {
  * @param {boolean} [options.interactive] - Use stdio inherit for TTY passthrough (default: true)
  */
 export async function runScript(scriptPath, config, options = {}) {
-  const {
-    args = [],
-    cwd,
-    env: extraEnv = {},
-    interactive = true,
-    captureStdout = false,
-  } = options;
+  const { args = [], cwd, env: extraEnv = {}, interactive = true, captureStdout = false } = options;
 
   const fullPath = path.resolve(SCRIPTS_DIR, scriptPath);
 
-  if (!await fs.pathExists(fullPath)) {
+  if (!(await fs.pathExists(fullPath))) {
     throw new Error(`Script not found: ${fullPath}`);
   }
 
@@ -109,6 +110,7 @@ export async function runScript(scriptPath, config, options = {}) {
   const mergedEnv = {
     ...process.env,
     ...scriptEnv,
+    SFDT_NON_INTERACTIVE: !process.stdin.isTTY || options.interactive === false ? 'true' : 'false',
     ...extraEnv,
   };
 
@@ -130,7 +132,7 @@ export async function runScript(scriptPath, config, options = {}) {
   if (result.exitCode !== 0) {
     const error = new Error(
       `Script "${scriptPath}" exited with code ${result.exitCode}` +
-      (result.stderr ? `\n${result.stderr}` : '')
+        (result.stderr ? `\n${result.stderr}` : ''),
     );
     error.exitCode = result.exitCode;
     error.stdout = result.stdout;

--- a/test/ai.test.js
+++ b/test/ai.test.js
@@ -24,9 +24,7 @@ describe('runAiPrompt', () => {
     const result = await runAiPrompt('test prompt', { aiEnabled: false });
 
     expect(result).toBeNull();
-    expect(consoleSpy).toHaveBeenCalledWith(
-      expect.stringContaining('AI features are disabled')
-    );
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('AI features are disabled'));
     consoleSpy.mockRestore();
   });
 
@@ -45,9 +43,7 @@ describe('runAiPrompt', () => {
     });
 
     // Find the actual prompt call (not the --version call)
-    const promptCall = execa.mock.calls.find(
-      (call) => call[1] && call[1].includes('-p')
-    );
+    const promptCall = execa.mock.calls.find((call) => call[1] && call[1].includes('-p'));
 
     expect(promptCall).toBeDefined();
     expect(promptCall[1]).toContain('-p');

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -18,9 +18,18 @@ describe('createCli', () => {
     const commandNames = program.commands.map((cmd) => cmd.name());
 
     const expected = [
-      'init', 'deploy', 'release', 'test', 'pull',
-      'quality', 'preflight', 'rollback', 'smoke',
-      'review', 'notify', 'drift',
+      'init',
+      'deploy',
+      'release',
+      'test',
+      'pull',
+      'quality',
+      'preflight',
+      'rollback',
+      'smoke',
+      'review',
+      'notify',
+      'drift',
     ];
 
     for (const name of expected) {

--- a/test/commands/changelog.test.js
+++ b/test/commands/changelog.test.js
@@ -74,7 +74,7 @@ describe('changelog release command', () => {
       ['-c', expect.stringContaining('move_unreleased_to_version "$SFDT_VERSION"')],
       expect.objectContaining({
         env: expect.objectContaining({ SFDT_VERSION: '1.2.3' }),
-      })
+      }),
     );
     expect(print.success).toHaveBeenCalled();
   });
@@ -109,39 +109,35 @@ describe('changelog release command', () => {
 describe('changelog check command', () => {
   it('reports when git has changes but changelog is empty', async () => {
     execa
-      .mockResolvedValueOnce({ stdout: 'M src/file.js' })  // git status
-      .mockResolvedValueOnce({ stdout: 'EMPTY' });          // has_unreleased_content
+      .mockResolvedValueOnce({ stdout: 'M src/file.js' }) // git status
+      .mockResolvedValueOnce({ stdout: 'EMPTY' }); // has_unreleased_content
 
     await createProgram().parseAsync(['node', 'sfdt', 'changelog', 'check']);
 
     expect(print.warning).toHaveBeenCalledWith(
-      expect.stringContaining('[Unreleased] section in CHANGELOG.md is empty')
+      expect.stringContaining('[Unreleased] section in CHANGELOG.md is empty'),
     );
     expect(process.exitCode).toBe(1);
   });
 
   it('reports success when git has changes and changelog has content', async () => {
     execa
-      .mockResolvedValueOnce({ stdout: 'M src/file.js' })   // git status
-      .mockResolvedValueOnce({ stdout: 'HAS_CONTENT' });     // has_unreleased_content
+      .mockResolvedValueOnce({ stdout: 'M src/file.js' }) // git status
+      .mockResolvedValueOnce({ stdout: 'HAS_CONTENT' }); // has_unreleased_content
 
     await createProgram().parseAsync(['node', 'sfdt', 'changelog', 'check']);
 
-    expect(print.success).toHaveBeenCalledWith(
-      expect.stringContaining('synced')
-    );
+    expect(print.success).toHaveBeenCalledWith(expect.stringContaining('synced'));
   });
 
   it('reports no changes when git is clean and changelog is empty', async () => {
     execa
-      .mockResolvedValueOnce({ stdout: '' })       // git status
+      .mockResolvedValueOnce({ stdout: '' }) // git status
       .mockResolvedValueOnce({ stdout: 'EMPTY' }); // has_unreleased_content
 
     await createProgram().parseAsync(['node', 'sfdt', 'changelog', 'check']);
 
-    expect(print.info).toHaveBeenCalledWith(
-      expect.stringContaining('No changes')
-    );
+    expect(print.info).toHaveBeenCalledWith(expect.stringContaining('No changes'));
   });
 
   it('sets exitCode 1 on failure', async () => {
@@ -165,9 +161,7 @@ describe('changelog generate command', () => {
 
     await createProgram().parseAsync(['node', 'sfdt', 'changelog', 'generate']);
 
-    expect(print.error).toHaveBeenCalledWith(
-      expect.stringContaining('AI features are disabled')
-    );
+    expect(print.error).toHaveBeenCalledWith(expect.stringContaining('AI features are disabled'));
     expect(runAiPrompt).not.toHaveBeenCalled();
   });
 
@@ -178,9 +172,7 @@ describe('changelog generate command', () => {
     await createProgram().parseAsync(['node', 'sfdt', 'changelog', 'generate']);
 
     expect(inquirer.prompt).toHaveBeenCalledWith(
-      expect.arrayContaining([
-        expect.objectContaining({ name: 'create' }),
-      ])
+      expect.arrayContaining([expect.objectContaining({ name: 'create' })]),
     );
     // User declined, so no AI call
     expect(runAiPrompt).not.toHaveBeenCalled();
@@ -191,16 +183,14 @@ describe('changelog generate command', () => {
     isClaudeAvailable.mockResolvedValue(true);
     runAiPrompt.mockResolvedValue('### Added\n- New feature');
     inquirer.prompt.mockResolvedValueOnce({ apply: true });
-    fs.readFile.mockResolvedValue(
-      '# Changelog\n\n## [Unreleased]\n\n## [1.0.0]\n'
-    );
+    fs.readFile.mockResolvedValue('# Changelog\n\n## [Unreleased]\n\n## [1.0.0]\n');
     fs.writeFile.mockResolvedValue();
 
     await createProgram().parseAsync(['node', 'sfdt', 'changelog', 'generate']);
 
     expect(fs.writeFile).toHaveBeenCalledWith(
       expect.stringContaining('CHANGELOG.md'),
-      expect.stringContaining('### Added\n- New feature')
+      expect.stringContaining('### Added\n- New feature'),
     );
     expect(print.success).toHaveBeenCalledWith('Updated CHANGELOG.md');
   });

--- a/test/commands/deploy.test.js
+++ b/test/commands/deploy.test.js
@@ -46,12 +46,12 @@ describe('deploy command', () => {
   it('runs deployment-assistant.sh by default', async () => {
     runScript.mockResolvedValue({ exitCode: 0 });
 
-    await createProgram().parseAsync(['node', 'sfdt', 'deploy']);
+    await createProgram().parseAsync(['node', 'sfdt', 'deploy', '--skip-preflight']);
 
     expect(runScript).toHaveBeenCalledWith(
       'core/deployment-assistant.sh',
       expect.any(Object),
-      expect.objectContaining({ cwd: '/project' })
+      expect.objectContaining({ cwd: '/project' }),
     );
     expect(print.success).toHaveBeenCalled();
   });
@@ -59,21 +59,52 @@ describe('deploy command', () => {
   it('runs deploy-manager.sh with --managed flag', async () => {
     runScript.mockResolvedValue({ exitCode: 0 });
 
-    await createProgram().parseAsync(['node', 'sfdt', 'deploy', '--managed']);
+    await createProgram().parseAsync(['node', 'sfdt', 'deploy', '--managed', '--skip-preflight']);
 
     expect(runScript).toHaveBeenCalledWith(
       'core/deploy-manager.sh',
       expect.any(Object),
-      expect.objectContaining({ cwd: '/project' })
+      expect.objectContaining({ cwd: '/project' }),
     );
   });
 
   it('sets exitCode 1 on failure', async () => {
+    runScript.mockResolvedValue({ exitCode: 0 });
     runScript.mockRejectedValue(new Error('deploy failed'));
+
+    await createProgram().parseAsync(['node', 'sfdt', 'deploy', '--skip-preflight']);
+
+    expect(print.error).toHaveBeenCalledWith(expect.stringContaining('deploy failed'));
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('runs preflight.sh before the deploy script by default', async () => {
+    runScript.mockResolvedValue({ exitCode: 0, stdout: '' });
 
     await createProgram().parseAsync(['node', 'sfdt', 'deploy']);
 
-    expect(print.error).toHaveBeenCalledWith(expect.stringContaining('deploy failed'));
+    expect(runScript).toHaveBeenCalledTimes(2);
+    expect(runScript.mock.calls[0][0]).toBe('new/preflight.sh');
+    expect(runScript.mock.calls[1][0]).toBe('core/deployment-assistant.sh');
+  });
+
+  it('skips preflight with --skip-preflight flag', async () => {
+    runScript.mockResolvedValue({ exitCode: 0, stdout: '' });
+
+    await createProgram().parseAsync(['node', 'sfdt', 'deploy', '--skip-preflight']);
+
+    expect(runScript).toHaveBeenCalledTimes(1);
+    expect(runScript.mock.calls[0][0]).toBe('core/deployment-assistant.sh');
+  });
+
+  it('aborts deploy and exits 1 when preflight fails', async () => {
+    runScript.mockRejectedValueOnce(new Error('preflight check failed'));
+
+    await createProgram().parseAsync(['node', 'sfdt', 'deploy']);
+
+    expect(runScript).toHaveBeenCalledTimes(1);
+    expect(runScript.mock.calls[0][0]).toBe('new/preflight.sh');
+    expect(print.error).toHaveBeenCalledWith(expect.stringContaining('Preflight failed'));
     expect(process.exitCode).toBe(1);
   });
 });

--- a/test/commands/deploy.test.js
+++ b/test/commands/deploy.test.js
@@ -69,7 +69,6 @@ describe('deploy command', () => {
   });
 
   it('sets exitCode 1 on failure', async () => {
-    runScript.mockResolvedValue({ exitCode: 0 });
     runScript.mockRejectedValue(new Error('deploy failed'));
 
     await createProgram().parseAsync(['node', 'sfdt', 'deploy', '--skip-preflight']);

--- a/test/commands/drift.test.js
+++ b/test/commands/drift.test.js
@@ -51,7 +51,7 @@ describe('drift command', () => {
     expect(runScript).toHaveBeenCalledWith(
       'new/drift.sh',
       expect.any(Object),
-      expect.objectContaining({ env: { SFDT_TARGET_ORG: 'dev' } })
+      expect.objectContaining({ env: { SFDT_TARGET_ORG: 'dev' } }),
     );
   });
 
@@ -63,7 +63,7 @@ describe('drift command', () => {
     expect(runScript).toHaveBeenCalledWith(
       'new/drift.sh',
       expect.any(Object),
-      expect.objectContaining({ env: { SFDT_TARGET_ORG: 'prod' } })
+      expect.objectContaining({ env: { SFDT_TARGET_ORG: 'prod' } }),
     );
   });
 

--- a/test/commands/init.test.js
+++ b/test/commands/init.test.js
@@ -54,9 +54,7 @@ beforeEach(() => {
   process.exitCode = undefined;
 
   // Default: project root found
-  fs.pathExistsSync.mockImplementation((p) =>
-    p.endsWith('sfdx-project.json')
-  );
+  fs.pathExistsSync.mockImplementation((p) => p.endsWith('sfdx-project.json'));
 
   // .sfdt does not exist yet
   fs.pathExists.mockResolvedValue(false);
@@ -65,9 +63,7 @@ beforeEach(() => {
   fs.readJson.mockResolvedValue({
     name: 'test-project',
     sourceApiVersion: '61.0',
-    packageDirectories: [
-      { path: 'force-app', default: true },
-    ],
+    packageDirectories: [{ path: 'force-app', default: true }],
   });
 
   fs.ensureDir.mockResolvedValue();
@@ -102,9 +98,7 @@ describe('init command', () => {
   it('writes correct config.json content', async () => {
     await createProgram().parseAsync(['node', 'sfdt', 'init']);
 
-    const configCall = fs.writeJson.mock.calls.find((c) =>
-      c[0].endsWith('config.json')
-    );
+    const configCall = fs.writeJson.mock.calls.find((c) => c[0].endsWith('config.json'));
     const config = configCall[1];
 
     expect(config.projectName).toBe('test-project');
@@ -114,14 +108,12 @@ describe('init command', () => {
 
   it('prompts for overwrite when .sfdt already exists', async () => {
     fs.pathExists.mockResolvedValue(true);
-    inquirer.prompt
-      .mockResolvedValueOnce({ overwrite: true })
-      .mockResolvedValueOnce({
-        projectName: 'test-project',
-        defaultOrg: 'dev',
-        coverageThreshold: 75,
-        aiEnabled: true,
-      });
+    inquirer.prompt.mockResolvedValueOnce({ overwrite: true }).mockResolvedValueOnce({
+      projectName: 'test-project',
+      defaultOrg: 'dev',
+      coverageThreshold: 75,
+      aiEnabled: true,
+    });
 
     await createProgram().parseAsync(['node', 'sfdt', 'init']);
 
@@ -149,9 +141,7 @@ describe('init command', () => {
 
     await createProgram().parseAsync(['node', 'sfdt', 'init']);
 
-    const testConfigCall = fs.writeJson.mock.calls.find((c) =>
-      c[0].endsWith('test-config.json')
-    );
+    const testConfigCall = fs.writeJson.mock.calls.find((c) => c[0].endsWith('test-config.json'));
     const testConfig = testConfigCall[1];
 
     expect(testConfig.testClasses).toContain('MyClassTest');
@@ -165,9 +155,7 @@ describe('init command', () => {
 
     await createProgram().parseAsync(['node', 'sfdt', 'init']);
 
-    expect(print.error).toHaveBeenCalledWith(
-      expect.stringContaining('No sfdx-project.json')
-    );
+    expect(print.error).toHaveBeenCalledWith(expect.stringContaining('No sfdx-project.json'));
     expect(process.exitCode).toBe(1);
   });
 });

--- a/test/commands/notify.test.js
+++ b/test/commands/notify.test.js
@@ -45,9 +45,7 @@ describe('notify command', () => {
   it('rejects unknown events', async () => {
     await createProgram().parseAsync(['node', 'sfdt', 'notify', 'unknown-event']);
 
-    expect(print.error).toHaveBeenCalledWith(
-      expect.stringContaining('Unknown event')
-    );
+    expect(print.error).toHaveBeenCalledWith(expect.stringContaining('Unknown event'));
     expect(process.exitCode).toBe(1);
   });
 
@@ -59,9 +57,7 @@ describe('notify command', () => {
 
     await createProgram().parseAsync(['node', 'sfdt', 'notify', 'deploy-success']);
 
-    expect(print.warning).toHaveBeenCalledWith(
-      expect.stringContaining('not configured')
-    );
+    expect(print.warning).toHaveBeenCalledWith(expect.stringContaining('not configured'));
     expect(process.exitCode).toBe(1);
   });
 
@@ -70,9 +66,14 @@ describe('notify command', () => {
     vi.stubGlobal('fetch', mockFetch);
 
     await createProgram().parseAsync([
-      'node', 'sfdt', 'notify', 'deploy-success',
-      '--version', '1.0.0',
-      '--message', 'Deployed to prod',
+      'node',
+      'sfdt',
+      'notify',
+      'deploy-success',
+      '--version',
+      '1.0.0',
+      '--message',
+      'Deployed to prod',
     ]);
 
     expect(mockFetch).toHaveBeenCalledWith(
@@ -80,7 +81,7 @@ describe('notify command', () => {
       expect.objectContaining({
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-      })
+      }),
     );
 
     const body = JSON.parse(mockFetch.mock.calls[0][1].body);
@@ -100,9 +101,7 @@ describe('notify command', () => {
 
     await createProgram().parseAsync(['node', 'sfdt', 'notify', 'deploy-failure']);
 
-    expect(print.error).toHaveBeenCalledWith(
-      expect.stringContaining('403')
-    );
+    expect(print.error).toHaveBeenCalledWith(expect.stringContaining('403'));
     expect(process.exitCode).toBe(1);
 
     vi.unstubAllGlobals();
@@ -113,9 +112,14 @@ describe('notify command', () => {
     vi.stubGlobal('fetch', mockFetch);
 
     await createProgram().parseAsync([
-      'node', 'sfdt', 'notify', 'release-created',
-      '--version', '2.0.0',
-      '--org', 'prod',
+      'node',
+      'sfdt',
+      'notify',
+      'release-created',
+      '--version',
+      '2.0.0',
+      '--org',
+      'prod',
     ]);
 
     const body = JSON.parse(mockFetch.mock.calls[0][1].body);
@@ -123,10 +127,7 @@ describe('notify command', () => {
     const fieldTexts = sectionFields.map((f) => f.text);
 
     expect(fieldTexts).toEqual(
-      expect.arrayContaining([
-        expect.stringContaining('prod'),
-        expect.stringContaining('2.0.0'),
-      ])
+      expect.arrayContaining([expect.stringContaining('prod'), expect.stringContaining('2.0.0')]),
     );
 
     vi.unstubAllGlobals();

--- a/test/commands/preflight.test.js
+++ b/test/commands/preflight.test.js
@@ -51,7 +51,7 @@ describe('preflight command', () => {
     expect(runScript).toHaveBeenCalledWith(
       'new/preflight.sh',
       expect.any(Object),
-      expect.objectContaining({ cwd: '/project', env: {} })
+      expect.objectContaining({ cwd: '/project', env: {} }),
     );
     expect(print.success).toHaveBeenCalled();
   });
@@ -64,7 +64,7 @@ describe('preflight command', () => {
     expect(runScript).toHaveBeenCalledWith(
       'new/preflight.sh',
       expect.any(Object),
-      expect.objectContaining({ env: { SFDT_PREFLIGHT_STRICT: 'true' } })
+      expect.objectContaining({ env: { SFDT_PREFLIGHT_STRICT: 'true' } }),
     );
   });
 

--- a/test/commands/pull.test.js
+++ b/test/commands/pull.test.js
@@ -51,7 +51,7 @@ describe('pull command', () => {
     expect(runScript).toHaveBeenCalledWith(
       'core/pull-org-updates.sh',
       expect.any(Object),
-      expect.objectContaining({ cwd: '/project' })
+      expect.objectContaining({ cwd: '/project' }),
     );
     expect(print.success).toHaveBeenCalled();
   });

--- a/test/commands/quality.test.js
+++ b/test/commands/quality.test.js
@@ -58,7 +58,7 @@ describe('quality command', () => {
     expect(runScript).toHaveBeenCalledWith(
       'quality/code-analyzer.sh',
       expect.any(Object),
-      expect.objectContaining({ interactive: false })
+      expect.objectContaining({ interactive: false }),
     );
   });
 
@@ -71,7 +71,7 @@ describe('quality command', () => {
     expect(runScript).toHaveBeenCalledWith(
       'quality/test-analyzer.sh',
       expect.any(Object),
-      expect.any(Object)
+      expect.any(Object),
     );
   });
 
@@ -84,12 +84,12 @@ describe('quality command', () => {
     expect(runScript).toHaveBeenCalledWith(
       'quality/code-analyzer.sh',
       expect.any(Object),
-      expect.any(Object)
+      expect.any(Object),
     );
     expect(runScript).toHaveBeenCalledWith(
       'quality/test-analyzer.sh',
       expect.any(Object),
-      expect.any(Object)
+      expect.any(Object),
     );
   });
 
@@ -102,7 +102,7 @@ describe('quality command', () => {
 
     expect(runAiPrompt).toHaveBeenCalledWith(
       expect.stringContaining('quality report'),
-      expect.objectContaining({ aiEnabled: true })
+      expect.objectContaining({ aiEnabled: true }),
     );
   });
 
@@ -112,9 +112,7 @@ describe('quality command', () => {
 
     await createProgram().parseAsync(['node', 'sfdt', 'quality', '--fix-plan']);
 
-    expect(print.warning).toHaveBeenCalledWith(
-      expect.stringContaining('not available')
-    );
+    expect(print.warning).toHaveBeenCalledWith(expect.stringContaining('not available'));
   });
 
   it('handles analyzer errors gracefully', async () => {
@@ -124,8 +122,26 @@ describe('quality command', () => {
 
     await createProgram().parseAsync(['node', 'sfdt', 'quality']);
 
-    expect(print.warning).toHaveBeenCalledWith(
-      expect.stringContaining('found issues')
-    );
+    expect(print.warning).toHaveBeenCalledWith(expect.stringContaining('found issues'));
+  });
+
+  it('--generate-stubs calls generate-test-stubs.sh', async () => {
+    runScript.mockResolvedValue({ exitCode: 0, stdout: '' });
+
+    await createProgram().parseAsync(['node', 'sfdt', 'quality', '--generate-stubs']);
+
+    const stubCall = runScript.mock.calls.find((call) => call[0] === 'quality/generate-test-stubs.sh');
+    expect(stubCall).toBeDefined();
+    expect(stubCall[2].env).not.toMatchObject({ SFDT_DRY_RUN: 'true' });
+  });
+
+  it('--generate-stubs --dry-run passes SFDT_DRY_RUN: true', async () => {
+    runScript.mockResolvedValue({ exitCode: 0, stdout: '' });
+
+    await createProgram().parseAsync(['node', 'sfdt', 'quality', '--generate-stubs', '--dry-run']);
+
+    const stubCall = runScript.mock.calls.find((call) => call[0] === 'quality/generate-test-stubs.sh');
+    expect(stubCall).toBeDefined();
+    expect(stubCall[2].env).toMatchObject({ SFDT_DRY_RUN: 'true' });
   });
 });

--- a/test/commands/release.test.js
+++ b/test/commands/release.test.js
@@ -57,7 +57,13 @@ function createProgram() {
 
 // Helper: mock prompt responses for the full git workflow
 // generateNotes prompt (if AI available), then doCommit, doTag, proceedToDeploy, doPush
-function mockPromptFlow({ generateNotes, doCommit = false, doTag = false, proceedToDeploy = false, doPush = false } = {}) {
+function mockPromptFlow({
+  generateNotes,
+  doCommit = false,
+  doTag = false,
+  proceedToDeploy = false,
+  doPush = false,
+} = {}) {
   const responses = [];
   if (generateNotes !== undefined) {
     responses.push({ generateNotes });
@@ -99,7 +105,7 @@ describe('release command', () => {
     expect(runScript).toHaveBeenCalledWith(
       'core/generate-release-manifest.sh',
       expect.any(Object),
-      expect.objectContaining({ args: [], cwd: '/project', captureStdout: true })
+      expect.objectContaining({ args: [], cwd: '/project', captureStdout: true }),
     );
   });
 
@@ -112,7 +118,7 @@ describe('release command', () => {
     expect(runScript).toHaveBeenCalledWith(
       'core/generate-release-manifest.sh',
       expect.any(Object),
-      expect.objectContaining({ args: ['2.0.0'] })
+      expect.objectContaining({ args: ['2.0.0'] }),
     );
   });
 
@@ -125,7 +131,7 @@ describe('release command', () => {
 
     expect(runAiPrompt).toHaveBeenCalledWith(
       expect.stringContaining('release notes'),
-      expect.objectContaining({ aiEnabled: true, interactive: true })
+      expect.objectContaining({ aiEnabled: true, interactive: true }),
     );
   });
 
@@ -153,11 +159,15 @@ describe('release command', () => {
     isClaudeAvailable.mockResolvedValue(false);
     // CHANGELOG has changes (exitCode 1 = diff detected)
     execa
-      .mockResolvedValueOnce({ exitCode: 0, stdout: '' })   // git add manifests
-      .mockResolvedValueOnce({ exitCode: 1, stdout: '' })   // git diff CHANGELOG (modified)
-      .mockResolvedValueOnce({ exitCode: 0, stdout: '' })   // git add CHANGELOG
-      .mockResolvedValueOnce({ exitCode: 0, stdout: '' })   // git add release notes
-      .mockResolvedValueOnce({ exitCode: 0, stdout: 'A  release-notes/rl-1.0.0-RELEASE-NOTES.md\nA  manifest/release/rl-1.0.0-package.xml\nM  CHANGELOG.md' }); // git status
+      .mockResolvedValueOnce({ exitCode: 0, stdout: '' }) // git add manifests
+      .mockResolvedValueOnce({ exitCode: 1, stdout: '' }) // git diff CHANGELOG (modified)
+      .mockResolvedValueOnce({ exitCode: 0, stdout: '' }) // git add CHANGELOG
+      .mockResolvedValueOnce({ exitCode: 0, stdout: '' }) // git add release notes
+      .mockResolvedValueOnce({
+        exitCode: 0,
+        stdout:
+          'A  release-notes/rl-1.0.0-RELEASE-NOTES.md\nA  manifest/release/rl-1.0.0-package.xml\nM  CHANGELOG.md',
+      }); // git status
 
     mockPromptFlow({ doCommit: true, doTag: false });
 
@@ -165,7 +175,7 @@ describe('release command', () => {
 
     // Verify CHANGELOG was staged
     const addCalls = execa.mock.calls.filter(
-      (c) => c[0] === 'git' && c[1][0] === 'add' && c[1].includes('CHANGELOG.md')
+      (c) => c[0] === 'git' && c[1][0] === 'add' && c[1].includes('CHANGELOG.md'),
     );
     expect(addCalls.length).toBe(1);
   });

--- a/test/commands/review.test.js
+++ b/test/commands/review.test.js
@@ -57,9 +57,7 @@ describe('review command', () => {
 
     await createProgram().parseAsync(['node', 'sfdt', 'review']);
 
-    expect(print.error).toHaveBeenCalledWith(
-      expect.stringContaining('AI features are disabled')
-    );
+    expect(print.error).toHaveBeenCalledWith(expect.stringContaining('AI features are disabled'));
     expect(process.exitCode).toBe(1);
   });
 
@@ -69,7 +67,7 @@ describe('review command', () => {
     await createProgram().parseAsync(['node', 'sfdt', 'review']);
 
     expect(print.error).toHaveBeenCalledWith(
-      expect.stringContaining('Claude CLI is not installed')
+      expect.stringContaining('Claude CLI is not installed'),
     );
     expect(process.exitCode).toBe(1);
   });
@@ -80,9 +78,7 @@ describe('review command', () => {
 
     await createProgram().parseAsync(['node', 'sfdt', 'review']);
 
-    expect(print.warning).toHaveBeenCalledWith(
-      expect.stringContaining('No changes found')
-    );
+    expect(print.warning).toHaveBeenCalledWith(expect.stringContaining('No changes found'));
   });
 
   it('sends diff to AI for review', async () => {
@@ -93,12 +89,13 @@ describe('review command', () => {
     await createProgram().parseAsync(['node', 'sfdt', 'review']);
 
     expect(execa).toHaveBeenCalledWith(
-      'git', ['diff', 'main...HEAD'],
-      expect.objectContaining({ cwd: '/project' })
+      'git',
+      ['diff', 'main...HEAD'],
+      expect.objectContaining({ cwd: '/project' }),
     );
     expect(runAiPrompt).toHaveBeenCalledWith(
       expect.stringContaining('+ added line'),
-      expect.objectContaining({ interactive: true })
+      expect.objectContaining({ interactive: true }),
     );
   });
 
@@ -109,10 +106,7 @@ describe('review command', () => {
 
     await createProgram().parseAsync(['node', 'sfdt', 'review', '--base', 'develop']);
 
-    expect(execa).toHaveBeenCalledWith(
-      'git', ['diff', 'develop...HEAD'],
-      expect.any(Object)
-    );
+    expect(execa).toHaveBeenCalledWith('git', ['diff', 'develop...HEAD'], expect.any(Object));
   });
 
   it('sets exitCode 1 on failure', async () => {

--- a/test/commands/rollback.test.js
+++ b/test/commands/rollback.test.js
@@ -51,7 +51,7 @@ describe('rollback command', () => {
     expect(runScript).toHaveBeenCalledWith(
       'new/rollback.sh',
       expect.any(Object),
-      expect.objectContaining({ env: { SFDT_TARGET_ORG: 'dev' } })
+      expect.objectContaining({ env: expect.objectContaining({ SFDT_TARGET_ORG: 'dev' }) }),
     );
   });
 
@@ -63,7 +63,41 @@ describe('rollback command', () => {
     expect(runScript).toHaveBeenCalledWith(
       'new/rollback.sh',
       expect.any(Object),
-      expect.objectContaining({ env: { SFDT_TARGET_ORG: 'staging' } })
+      expect.objectContaining({ env: expect.objectContaining({ SFDT_TARGET_ORG: 'staging' }) }),
+    );
+  });
+
+  it('passes SFDT_BACKUP_BEFORE_ROLLBACK: true by default', async () => {
+    runScript.mockResolvedValue({ exitCode: 0, stdout: '' });
+
+    await createProgram().parseAsync(['node', 'sfdt', 'rollback']);
+
+    expect(runScript).toHaveBeenCalledWith(
+      'new/rollback.sh',
+      expect.any(Object),
+      expect.objectContaining({
+        env: expect.objectContaining({ SFDT_BACKUP_BEFORE_ROLLBACK: 'true' }),
+      }),
+    );
+  });
+
+  it('passes SFDT_BACKUP_BEFORE_ROLLBACK: false when config disables it', async () => {
+    loadConfig.mockResolvedValue({
+      _projectRoot: '/project',
+      defaultOrg: 'dev',
+      features: {},
+      deployment: { backupBeforeRollback: false },
+    });
+    runScript.mockResolvedValue({ exitCode: 0, stdout: '' });
+
+    await createProgram().parseAsync(['node', 'sfdt', 'rollback']);
+
+    expect(runScript).toHaveBeenCalledWith(
+      'new/rollback.sh',
+      expect.any(Object),
+      expect.objectContaining({
+        env: expect.objectContaining({ SFDT_BACKUP_BEFORE_ROLLBACK: 'false' }),
+      }),
     );
   });
 

--- a/test/commands/smoke.test.js
+++ b/test/commands/smoke.test.js
@@ -51,7 +51,7 @@ describe('smoke command', () => {
     expect(runScript).toHaveBeenCalledWith(
       'new/smoke.sh',
       expect.any(Object),
-      expect.objectContaining({ env: { SFDT_TARGET_ORG: 'dev' } })
+      expect.objectContaining({ env: { SFDT_TARGET_ORG: 'dev' } }),
     );
   });
 
@@ -63,7 +63,7 @@ describe('smoke command', () => {
     expect(runScript).toHaveBeenCalledWith(
       'new/smoke.sh',
       expect.any(Object),
-      expect.objectContaining({ env: { SFDT_TARGET_ORG: 'uat' } })
+      expect.objectContaining({ env: { SFDT_TARGET_ORG: 'uat' } }),
     );
   });
 

--- a/test/commands/test.test.js
+++ b/test/commands/test.test.js
@@ -62,7 +62,7 @@ describe('test command', () => {
     expect(runScript).toHaveBeenCalledWith(
       'core/enhanced-test-runner.sh',
       expect.any(Object),
-      expect.objectContaining({ cwd: '/project' })
+      expect.objectContaining({ cwd: '/project' }),
     );
     expect(print.success).toHaveBeenCalled();
   });
@@ -75,7 +75,7 @@ describe('test command', () => {
     expect(runScript).toHaveBeenCalledWith(
       'core/run-tests.sh',
       expect.any(Object),
-      expect.any(Object)
+      expect.any(Object),
     );
   });
 
@@ -88,7 +88,7 @@ describe('test command', () => {
     expect(runScript).toHaveBeenCalledWith(
       'quality/test-analyzer.sh',
       expect.any(Object),
-      expect.any(Object)
+      expect.any(Object),
     );
   });
 
@@ -103,7 +103,7 @@ describe('test command', () => {
     expect(inquirer.prompt).toHaveBeenCalled();
     expect(runAiPrompt).toHaveBeenCalledWith(
       expect.stringContaining('Analyze the most recent Apex test failures'),
-      expect.any(Object)
+      expect.any(Object),
     );
     expect(process.exitCode).toBe(1);
   });

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -34,14 +34,12 @@ describe('validateConfig', () => {
 
   it('throws when features is not an object', () => {
     expect(() => validateConfig({ defaultOrg: 'dev', features: 'yes' })).toThrow(
-      '"features" must be an object'
+      '"features" must be an object',
     );
   });
 
   it('passes with valid config', () => {
-    expect(() =>
-      validateConfig({ defaultOrg: 'dev', features: { ai: true } })
-    ).not.toThrow();
+    expect(() => validateConfig({ defaultOrg: 'dev', features: { ai: true } })).not.toThrow();
   });
 });
 
@@ -104,7 +102,10 @@ describe('loadConfig', () => {
       if (p.endsWith('config.json')) return baseConfig;
       if (p.endsWith('environments.json')) return { default: 'dev', orgs: [] };
       if (p.endsWith('sfdx-project.json')) {
-        return { sourceApiVersion: '61.0', packageDirectories: [{ path: 'force-app', default: true }] };
+        return {
+          sourceApiVersion: '61.0',
+          packageDirectories: [{ path: 'force-app', default: true }],
+        };
       }
       return {};
     });
@@ -132,10 +133,7 @@ describe('loadConfig', () => {
       if (p.endsWith('sfdx-project.json')) {
         return {
           sourceApiVersion: '61.0',
-          packageDirectories: [
-            { path: 'force-app', default: true },
-            { path: 'unpackaged' },
-          ],
+          packageDirectories: [{ path: 'force-app', default: true }, { path: 'unpackaged' }],
         };
       }
       return {};
@@ -164,7 +162,10 @@ describe('loadConfig', () => {
     fs.readJson.mockImplementation(async (p) => {
       if (p.endsWith('config.json')) return baseConfig;
       if (p.endsWith('sfdx-project.json')) {
-        return { sourceApiVersion: '61.0', packageDirectories: [{ path: 'force-app', default: true }] };
+        return {
+          sourceApiVersion: '61.0',
+          packageDirectories: [{ path: 'force-app', default: true }],
+        };
       }
       return {};
     });
@@ -188,10 +189,7 @@ describe('loadConfig', () => {
       if (p.endsWith('config.json')) return baseConfig;
       if (p.endsWith('sfdx-project.json')) {
         return {
-          packageDirectories: [
-            { path: 'src' },
-            { path: 'lib' },
-          ],
+          packageDirectories: [{ path: 'src' }, { path: 'lib' }],
         };
       }
       return {};

--- a/test/fixtures/sfdt-config.json
+++ b/test/fixtures/sfdt-config.json
@@ -1,0 +1,1 @@
+{"defaultOrg":"test-org","projectName":"Test Project","manifestDir":"manifest/release","releaseNotesDir":"release-notes","features":{"ai":false},"deployment":{"coverageThreshold":80,"backupBeforeRollback":true},"logDir":"/tmp/sfdt-test-logs"}

--- a/test/fixtures/sfdt-test-config.json
+++ b/test/fixtures/sfdt-test-config.json
@@ -1,0 +1,1 @@
+{"testClasses":["AccountServiceTest","OpportunityHandlerTest"],"apexClasses":["AccountService","AccountServiceTest","OpportunityHandler","OpportunityHandlerTest"],"coverageThreshold":80,"testLevel":"RunSpecifiedTests"}

--- a/test/fixtures/sfdx-project.json
+++ b/test/fixtures/sfdx-project.json
@@ -1,0 +1,1 @@
+{"name":"test-project","sourceApiVersion":"61.0","packageDirectories":[{"path":"force-app","default":true}]}

--- a/test/integration/config.test.js
+++ b/test/integration/config.test.js
@@ -1,0 +1,84 @@
+import { mkdtemp, rm, mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { readFileSync } from 'node:fs';
+import { describe, it, expect, afterEach, beforeEach } from 'vitest';
+import { loadConfig } from '../../src/lib/config.js';
+
+const FIXTURES_DIR = new URL('../fixtures', import.meta.url).pathname;
+
+function readFixture(name) {
+  return readFileSync(join(FIXTURES_DIR, name), 'utf8');
+}
+
+describe('loadConfig integration', () => {
+  let tempDir;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'sfdt-test-'));
+
+    // Write sfdx-project.json at the project root
+    await writeFile(join(tempDir, 'sfdx-project.json'), readFixture('sfdx-project.json'));
+
+    // Create .sfdt/ directory
+    const sfdtDir = join(tempDir, '.sfdt');
+    await mkdir(sfdtDir);
+
+    // Write config.json
+    await writeFile(join(sfdtDir, 'config.json'), readFixture('sfdt-config.json'));
+
+    // Write test-config.json
+    await writeFile(join(sfdtDir, 'test-config.json'), readFixture('sfdt-test-config.json'));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true });
+  });
+
+  it('enriches sourceApiVersion from sfdx-project.json', async () => {
+    const config = await loadConfig(tempDir);
+    expect(config.sourceApiVersion).toBe('61.0');
+  });
+
+  it('derives defaultSourcePath from packageDirectories with /main/default suffix', async () => {
+    const config = await loadConfig(tempDir);
+    // config.js appends '/main/default' to the package path
+    expect(config.defaultSourcePath).toBe('force-app/main/default');
+  });
+
+  it('loads testConfig.testClasses from test-config.json', async () => {
+    const config = await loadConfig(tempDir);
+    expect(config.testConfig.testClasses).toEqual(['AccountServiceTest', 'OpportunityHandlerTest']);
+  });
+
+  it('sets _projectRoot to the temp directory', async () => {
+    const config = await loadConfig(tempDir);
+    expect(config._projectRoot).toBe(tempDir);
+  });
+
+  it('sets _configDir to the .sfdt directory inside tempDir', async () => {
+    const config = await loadConfig(tempDir);
+    expect(config._configDir).toBe(join(tempDir, '.sfdt'));
+  });
+
+  it('reads projectName from config.json', async () => {
+    const config = await loadConfig(tempDir);
+    expect(config.projectName).toBe('Test Project');
+  });
+
+  it('reads deployment.coverageThreshold from config.json', async () => {
+    const config = await loadConfig(tempDir);
+    expect(config.deployment.coverageThreshold).toBe(80);
+  });
+
+  it('does not duplicate sourceApiVersion from sfdt-config.json (sfdx-project.json value wins when config does not set it)', async () => {
+    // Our sfdt-config.json fixture does NOT contain sourceApiVersion.
+    // loadConfig sets it only when !merged.sourceApiVersion, so the value
+    // should be exactly the one from sfdx-project.json ('61.0'), not undefined
+    // and not a duplicated/conflicting value.
+    const config = await loadConfig(tempDir);
+    expect(config.sourceApiVersion).toBe('61.0');
+    // Confirm it is a single string, not an array or object
+    expect(typeof config.sourceApiVersion).toBe('string');
+  });
+});

--- a/test/integration/script-runner.test.js
+++ b/test/integration/script-runner.test.js
@@ -31,10 +31,7 @@ const config = {
 };
 
 describe('buildScriptEnv integration', () => {
-  let env;
-
-  // Build once — buildScriptEnv is a pure function
-  env = buildScriptEnv(config);
+  const env = buildScriptEnv(config);
 
   it('maps SFDT_PROJECT_ROOT', () => {
     expect(env.SFDT_PROJECT_ROOT).toBe('/tmp/test-project');

--- a/test/integration/script-runner.test.js
+++ b/test/integration/script-runner.test.js
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest';
+import { buildScriptEnv } from '../../src/lib/script-runner.js';
+
+const config = {
+  _projectRoot: '/tmp/test-project',
+  _configDir: '/tmp/test-project/.sfdt',
+  projectName: 'Test Project',
+  defaultOrg: 'test-org',
+  defaultSourcePath: 'force-app/main/default',
+  manifestDir: 'manifest/release',
+  releaseNotesDir: 'release-notes',
+  sourceApiVersion: '61.0',
+  logDir: '/tmp/sfdt-logs',
+  deployment: { coverageThreshold: 80 },
+  features: { ai: false, advancedDeploy: true },
+  environments: {
+    default: 'staging',
+    orgs: [{ alias: 'staging' }, { alias: 'production' }],
+  },
+  testConfig: {
+    coverageThreshold: 80,
+    testLevel: 'RunSpecifiedTests',
+    suites: ['MySuite'],
+    testClasses: ['AccountServiceTest', 'OpportunityHandlerTest'],
+    apexClasses: ['AccountService', 'OpportunityHandler'],
+  },
+  pullConfig: {
+    metadataTypes: ['ApexClass', 'LightningComponentBundle'],
+    targetDir: 'retrieved',
+  },
+};
+
+describe('buildScriptEnv integration', () => {
+  let env;
+
+  // Build once — buildScriptEnv is a pure function
+  env = buildScriptEnv(config);
+
+  it('maps SFDT_PROJECT_ROOT', () => {
+    expect(env.SFDT_PROJECT_ROOT).toBe('/tmp/test-project');
+  });
+
+  it('maps SFDT_CONFIG_DIR', () => {
+    expect(env.SFDT_CONFIG_DIR).toBe('/tmp/test-project/.sfdt');
+  });
+
+  it('maps SFDT_PROJECT_NAME', () => {
+    expect(env.SFDT_PROJECT_NAME).toBe('Test Project');
+  });
+
+  it('maps SFDT_DEFAULT_ORG', () => {
+    expect(env.SFDT_DEFAULT_ORG).toBe('test-org');
+  });
+
+  it('maps SFDT_SOURCE_PATH', () => {
+    expect(env.SFDT_SOURCE_PATH).toBe('force-app/main/default');
+  });
+
+  it('maps SFDT_MANIFEST_DIR', () => {
+    expect(env.SFDT_MANIFEST_DIR).toBe('manifest/release');
+  });
+
+  it('maps SFDT_RELEASE_NOTES_DIR', () => {
+    expect(env.SFDT_RELEASE_NOTES_DIR).toBe('release-notes');
+  });
+
+  it('maps SFDT_API_VERSION', () => {
+    expect(env.SFDT_API_VERSION).toBe('61.0');
+  });
+
+  it('maps SFDT_COVERAGE_THRESHOLD from deployment config', () => {
+    expect(env.SFDT_COVERAGE_THRESHOLD).toBe('80');
+  });
+
+  it('maps SFDT_LOG_DIR', () => {
+    expect(env.SFDT_LOG_DIR).toBe('/tmp/sfdt-logs');
+  });
+
+  it('maps SFDT_FEATURE_AI (false → string "false")', () => {
+    expect(env.SFDT_FEATURE_AI).toBe('false');
+  });
+
+  it('maps SFDT_FEATURE_ADVANCED_DEPLOY via camelCase → UPPER_SNAKE conversion', () => {
+    // advancedDeploy → insert _ before each uppercase letter → advanced_Deploy → toUpperCase → ADVANCED_DEPLOY
+    expect(env.SFDT_FEATURE_ADVANCED_DEPLOY).toBe('true');
+  });
+
+  it('maps SFDT_DEFAULT_ENV', () => {
+    expect(env.SFDT_DEFAULT_ENV).toBe('staging');
+  });
+
+  it('maps SFDT_ENV_ORGS as comma-joined aliases', () => {
+    expect(env.SFDT_ENV_ORGS).toBe('staging,production');
+  });
+
+  it('maps SFDT_TEST_COVERAGE_THRESHOLD', () => {
+    expect(env.SFDT_TEST_COVERAGE_THRESHOLD).toBe('80');
+  });
+
+  it('maps SFDT_TEST_LEVEL', () => {
+    expect(env.SFDT_TEST_LEVEL).toBe('RunSpecifiedTests');
+  });
+
+  it('maps SFDT_TEST_SUITES as comma-joined array', () => {
+    expect(env.SFDT_TEST_SUITES).toBe('MySuite');
+  });
+
+  it('maps SFDT_TEST_CLASSES as comma-joined array', () => {
+    expect(env.SFDT_TEST_CLASSES).toBe('AccountServiceTest,OpportunityHandlerTest');
+  });
+
+  it('maps SFDT_APEX_CLASSES as comma-joined array', () => {
+    expect(env.SFDT_APEX_CLASSES).toBe('AccountService,OpportunityHandler');
+  });
+
+  it('maps SFDT_PULL_METADATA_TYPES as comma-joined array', () => {
+    expect(env.SFDT_PULL_METADATA_TYPES).toBe('ApexClass,LightningComponentBundle');
+  });
+
+  it('maps SFDT_PULL_TARGET_DIR', () => {
+    expect(env.SFDT_PULL_TARGET_DIR).toBe('retrieved');
+  });
+
+  it('does NOT set SFDT_NON_INTERACTIVE (that is set by runScript at call time)', () => {
+    expect(env.SFDT_NON_INTERACTIVE).toBeUndefined();
+  });
+});

--- a/test/project-detect.test.js
+++ b/test/project-detect.test.js
@@ -17,9 +17,7 @@ beforeEach(() => {
 
 describe('getProjectRoot', () => {
   it('returns directory containing sfdx-project.json', () => {
-    fs.pathExistsSync.mockImplementation((p) =>
-      p === path.join('/project', 'sfdx-project.json')
-    );
+    fs.pathExistsSync.mockImplementation((p) => p === path.join('/project', 'sfdx-project.json'));
 
     const result = getProjectRoot('/project/src/classes');
     expect(result).toBe('/project');
@@ -33,18 +31,13 @@ describe('getProjectRoot', () => {
 
 describe('detectProject', () => {
   it('returns project metadata from sfdx-project.json', async () => {
-    fs.pathExistsSync.mockImplementation((p) =>
-      p === path.join('/project', 'sfdx-project.json')
-    );
+    fs.pathExistsSync.mockImplementation((p) => p === path.join('/project', 'sfdx-project.json'));
 
     fs.readJson.mockResolvedValue({
       name: 'my-app',
       sourceApiVersion: '61.0',
       namespace: 'myns',
-      packageDirectories: [
-        { path: 'force-app', default: true },
-        { path: 'unpackaged' },
-      ],
+      packageDirectories: [{ path: 'force-app', default: true }, { path: 'unpackaged' }],
     });
 
     const result = await detectProject('/project');
@@ -55,27 +48,19 @@ describe('detectProject', () => {
     expect(result.namespace).toBe('myns');
     expect(result.packageDirectories).toHaveLength(2);
     expect(result.packageDirectories[0].default).toBe(true);
-    expect(result.defaultSourcePath).toBe(
-      path.join('/project', 'force-app', 'main', 'default')
-    );
+    expect(result.defaultSourcePath).toBe(path.join('/project', 'force-app', 'main', 'default'));
   });
 
   it('throws when packageDirectories is empty', async () => {
-    fs.pathExistsSync.mockImplementation((p) =>
-      p === path.join('/project', 'sfdx-project.json')
-    );
+    fs.pathExistsSync.mockImplementation((p) => p === path.join('/project', 'sfdx-project.json'));
 
     fs.readJson.mockResolvedValue({ packageDirectories: [] });
 
-    await expect(detectProject('/project')).rejects.toThrow(
-      'No packageDirectories defined'
-    );
+    await expect(detectProject('/project')).rejects.toThrow('No packageDirectories defined');
   });
 
   it('throws when sfdx-project.json is unparseable', async () => {
-    fs.pathExistsSync.mockImplementation((p) =>
-      p === path.join('/project', 'sfdx-project.json')
-    );
+    fs.pathExistsSync.mockImplementation((p) => p === path.join('/project', 'sfdx-project.json'));
 
     fs.readJson.mockRejectedValue(new Error('Unexpected token'));
 
@@ -83,9 +68,7 @@ describe('detectProject', () => {
   });
 
   it('uses basename when no name in project json', async () => {
-    fs.pathExistsSync.mockImplementation((p) =>
-      p === path.join('/project', 'sfdx-project.json')
-    );
+    fs.pathExistsSync.mockImplementation((p) => p === path.join('/project', 'sfdx-project.json'));
 
     fs.readJson.mockResolvedValue({
       packageDirectories: [{ path: 'force-app', default: true }],
@@ -96,17 +79,13 @@ describe('detectProject', () => {
   });
 
   it('uses first packageDirectory when none marked default', async () => {
-    fs.pathExistsSync.mockImplementation((p) =>
-      p === path.join('/project', 'sfdx-project.json')
-    );
+    fs.pathExistsSync.mockImplementation((p) => p === path.join('/project', 'sfdx-project.json'));
 
     fs.readJson.mockResolvedValue({
       packageDirectories: [{ path: 'src' }, { path: 'lib' }],
     });
 
     const result = await detectProject('/project');
-    expect(result.defaultSourcePath).toBe(
-      path.join('/project', 'src', 'main', 'default')
-    );
+    expect(result.defaultSourcePath).toBe(path.join('/project', 'src', 'main', 'default'));
   });
 });

--- a/test/script-runner.test.js
+++ b/test/script-runner.test.js
@@ -87,11 +87,7 @@ describe('buildScriptEnv', () => {
       features: {},
       environments: {
         default: 'staging',
-        orgs: [
-          { alias: 'dev' },
-          { name: 'prod' },
-          {},
-        ],
+        orgs: [{ alias: 'dev' }, { name: 'prod' }, {}],
       },
     };
 
@@ -108,6 +104,8 @@ describe('buildScriptEnv', () => {
         coverageThreshold: 90,
         testLevel: 'RunSpecifiedTests',
         suites: ['smoke', 'integration'],
+        testClasses: ['FooTest', 'BarTest'],
+        apexClasses: ['Foo', 'Bar'],
       },
     };
 
@@ -116,6 +114,8 @@ describe('buildScriptEnv', () => {
     expect(env.SFDT_TEST_COVERAGE_THRESHOLD).toBe('90');
     expect(env.SFDT_TEST_LEVEL).toBe('RunSpecifiedTests');
     expect(env.SFDT_TEST_SUITES).toBe('smoke,integration');
+    expect(env.SFDT_TEST_CLASSES).toBe('FooTest,BarTest');
+    expect(env.SFDT_APEX_CLASSES).toBe('Foo,Bar');
   });
 
   it('flattens pullConfig', () => {
@@ -152,7 +152,7 @@ describe('runScript', () => {
     fs.chmod.mockRejectedValue(new Error('permission denied'));
 
     await expect(runScript('test.sh', config)).rejects.toThrow(
-      'Failed to set executable permission'
+      'Failed to set executable permission',
     );
   });
 
@@ -182,9 +182,7 @@ describe('runScript', () => {
     fs.chmod.mockResolvedValue();
     execa.mockResolvedValue({ exitCode: 1, stdout: '', stderr: 'deploy failed' });
 
-    await expect(runScript('deploy/push.sh', config)).rejects.toThrow(
-      'exited with code 1'
-    );
+    await expect(runScript('deploy/push.sh', config)).rejects.toThrow('exited with code 1');
   });
 
   it('uses stdio inherit when interactive is true', async () => {


### PR DESCRIPTION
## Summary

- **Deployment Quality Gates**: Configurable coverage threshold (`SFDT_COVERAGE_THRESHOLD`) replaces hardcoded 75% in deployment scripts; `sfdt deploy` now runs preflight checks by default (`--skip-preflight` to bypass); production deploys blocked by `deploy-manager.sh` coverage gate
- **Rollback Backup**: `rollback.sh` retrieves current org state before rolling back; controlled by `config.deployment.backupBeforeRollback` (default `true`) / `SFDT_BACKUP_BEFORE_ROLLBACK`
- **Test Gaps Analysis**: `sfdt quality --generate-stubs` scaffolds `@IsTest` stub classes for untested Apex; `--dry-run` for preview; quality scripts (`test-analyzer.sh`, `code-analyzer.sh`) fixed to use `SFDT_` env var model
- **Integration Tests**: Real-filesystem tests for `loadConfig()` and `buildScriptEnv()`; test fixtures added in `test/fixtures/`
- **Bug fixes**: `((VAR++))` under `set -e` replaced with safe arithmetic; division-by-zero guard in test-analyzer; `print_*` helpers added to `shared.sh` for scripts that called them without a definition

## Test Plan
- [x] 148/148 unit + integration tests passing (`npm test`)
- [ ] `sfdt deploy` runs preflight before deploying
- [ ] `sfdt deploy --skip-preflight` skips to deploy script
- [ ] `sfdt quality --generate-stubs` generates stub files
- [ ] `sfdt quality --generate-stubs --dry-run` prints preview without writing
- [ ] `sfdt rollback` creates backup before applying rollback