### PR TITLE
fix: preflight regression fixes (0.2.1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,19 +45,17 @@ jobs:
       - name: Check for version bump
         id: version
         run: |
-          PACKAGE_VERSION=$(node -p "require('./package.json').version")
-          LATEST_TAG=$(git tag -l 'v*' --sort=-v:refname | head -1)
-          if [ -z "$LATEST_TAG" ]; then
-            echo "No existing tags — first publish"
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          elif [ "v${PACKAGE_VERSION}" != "$LATEST_TAG" ]; then
-            echo "Version bump detected: ${LATEST_TAG} → v${PACKAGE_VERSION}"
+          CURR_VERSION=$(node -p "require('./package.json').version")
+          PREV_VERSION=$(git show HEAD~1:package.json | node -p "JSON.parse(require('fs').readFileSync(0,'utf8')).version" 2>/dev/null || echo "0.0.0")
+          echo "Current: v${CURR_VERSION}, Previous: v${PREV_VERSION}"
+          if [ "${CURR_VERSION}" != "${PREV_VERSION}" ]; then
+            echo "Version bump detected: v${PREV_VERSION} → v${CURR_VERSION}"
             echo "changed=true" >> "$GITHUB_OUTPUT"
           else
-            echo "No version change (${LATEST_TAG})"
+            echo "No version change (${CURR_VERSION})"
             echo "changed=false" >> "$GITHUB_OUTPUT"
           fi
-          echo "version=${PACKAGE_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "version=${CURR_VERSION}" >> "$GITHUB_OUTPUT"
       - name: Create git tag
         if: steps.version.outputs.changed == 'true'
         env:
@@ -65,7 +63,10 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -a "v${RELEASE_VERSION}" -m "Release ${RELEASE_VERSION}"
+          # Remove pre-existing tag if present (e.g. created on a branch before merge)
+          git tag -d "v${RELEASE_VERSION}" 2>/dev/null || true
+          git push origin ":refs/tags/v${RELEASE_VERSION}" 2>/dev/null || true
+          git tag -a "v${RELEASE_VERSION}" -m "Release v${RELEASE_VERSION}"
           git push origin "v${RELEASE_VERSION}"
       - run: npm ci
         if: steps.version.outputs.changed == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,17 +2,15 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
   pull_request:
     branches: [main]
-
-permissions:
-  contents: write
-  id-token: write
 
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         node-version: [20, 22]
@@ -28,13 +26,18 @@ jobs:
         run: npm audit --audit-level=high
       - run: npm run lint
       - run: npm test
-      - run: npm publish --dry-run
+      - name: Publish dry-run (Node 22 only)
+        if: matrix.node-version == 22
+        run: npm publish --dry-run
 
   publish:
     needs: test
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     environment: production
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,32 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly scan — Mondays at 08:00 UTC
+    - cron: '0 8 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze (javascript)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: javascript
+          # security-extended adds ~30 extra checks on top of the default suite
+          queries: security-extended
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: /language:javascript

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -1,0 +1,35 @@
+name: License Check
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'package.json'
+      - 'package-lock.json'
+  push:
+    branches: [main]
+    paths:
+      - 'package.json'
+      - 'package-lock.json'
+
+jobs:
+  license-check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - name: Check dependency licenses
+        run: |
+          npx license-checker --production --onlyAllow \
+            "MIT;ISC;Apache-2.0;BSD-2-Clause;BSD-3-Clause;BlueOak-1.0.0;0BSD;CC0-1.0;CC-BY-3.0;CC-BY-4.0;Unlicense;Python-2.0" \
+            --excludePrivatePackages \
+            --summary

--- a/.github/workflows/scheduled-audit.yml
+++ b/.github/workflows/scheduled-audit.yml
@@ -1,0 +1,57 @@
+name: Scheduled Security Audit
+
+on:
+  schedule:
+    # Every Monday at 09:00 UTC — after Dependabot runs
+    - cron: '0 9 * * 1'
+  workflow_dispatch:
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - name: Run security audit
+        id: audit
+        run: |
+          npm audit --audit-level=moderate --json > audit-report.json 2>&1 || true
+          VULN_COUNT=$(node -e "
+            const r = require('./audit-report.json');
+            const meta = r.metadata?.vulnerabilities || {};
+            const total = (meta.critical||0) + (meta.high||0) + (meta.moderate||0);
+            console.log(total);
+          ")
+          echo "vuln_count=${VULN_COUNT}" >> "$GITHUB_OUTPUT"
+          if [ "${VULN_COUNT}" -gt 0 ]; then
+            echo "has_vulns=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_vulns=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Print audit summary
+        run: npm audit --audit-level=moderate || true
+
+      - name: Open issue if vulnerabilities found
+        if: steps.audit.outputs.has_vulns == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VULN_COUNT: ${{ steps.audit.outputs.vuln_count }}
+        run: |
+          EXISTING=$(gh issue list --label "security" --state open --json number --jq 'length')
+          if [ "${EXISTING}" -eq 0 ]; then
+            gh issue create \
+              --title "Security: ${VULN_COUNT} vulnerability(s) found in dependencies" \
+              --body "Automated weekly audit found **${VULN_COUNT}** moderate/high/critical vulnerability(s). Run \`npm audit\` locally for details and \`npm audit fix\` to attempt automatic remediation." \
+              --label "security"
+          fi

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,44 @@
+name: Stale Issues
+
+on:
+  schedule:
+    # Daily at 06:00 UTC
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v9
+        with:
+          # Issues
+          stale-issue-message: >
+            This issue has been inactive for 60 days and will be closed in 14 days
+            unless there is further activity. If this is still relevant, please comment
+            or remove the `stale` label.
+          close-issue-message: >
+            Closing due to inactivity. Feel free to reopen if this is still relevant.
+          days-before-issue-stale: 60
+          days-before-issue-close: 14
+          stale-issue-label: stale
+
+          # Pull requests
+          stale-pr-message: >
+            This PR has been inactive for 30 days and will be closed in 14 days
+            unless there is further activity.
+          close-pr-message: >
+            Closing due to inactivity. Feel free to reopen if you'd like to continue.
+          days-before-pr-stale: 30
+          days-before-pr-close: 14
+          stale-pr-label: stale
+
+          # Never mark issues with these labels as stale
+          exempt-issue-labels: 'pinned,security,bug,roadmap'
+          exempt-pr-labels: 'pinned,security'
+
+          # Limit operations per run to avoid rate-limit issues
+          operations-per-run: 100

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ npm-debug.log*
 # Skill eval workspaces
 sfdt-cli-workspace/
 skills/*/evals/
+
+# Git worktrees
+.worktrees/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-04-07
+
+### Fixed
+- `preflight.sh` called `changelog_has_unreleased` which does not exist; corrected to `has_unreleased_content` from `changelog-utils.sh`
+- Apex tests and coverage check now skipped by default in preflight — tests are handled interactively in the deployment assistant; running them unconditionally in preflight blocked users who had a default org configured but were not doing a full release
+
+### Added
+- `deployment.preflight.enforceTests` config flag: when `true`, preflight runs `RunLocalTests` as a hard gate before deploy (off by default)
+- `deployment.preflight.enforceBranchNaming` config flag: when `true`, branch naming check becomes a FAIL instead of a WARN (off by default)
+- `deployment.preflight.enforceChangelog` config flag: when `true`, missing or empty CHANGELOG becomes a FAIL instead of a WARN (off by default)
+- `sfdt init` now writes `deployment.preflight` block with all enforce flags defaulting to `false`
+- `src/templates/sfdt.config.json` is now the source of truth for config shape; `init.js` reads and merges from it so new config keys only need to be added in one place
+
 ## [0.2.0] - 2026-04-06
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,7 @@ src/
   commands/     Command modules (one file per command)
   lib/          Shared libraries (config, output, AI, script-runner, project-detect)
 scripts/        Shell scripts executed by commands (de-parameterized, use SFDT_ env vars)
+                Exception: scripts/postinstall.js is a Node.js ESM file run by npm on install
 test/           Tests (vitest)
 .sfdt/          Per-project config directory (created by `sfdt init` in target projects)
 ```
@@ -26,7 +27,7 @@ test/           Tests (vitest)
 ### Key Patterns
 
 - **Commands** in `src/commands/` export a function that receives the Commander program and registers a subcommand.
-- **Shell scripts** in `scripts/` are de-parameterized — they read configuration from `SFDT_` prefixed environment variables, not from positional arguments. The `script-runner.js` lib handles setting these vars and invoking scripts.
+- **Shell scripts** in `scripts/` are de-parameterized — they read configuration from `SFDT_` prefixed environment variables, not from positional arguments. The `script-runner.js` lib handles setting these vars and invoking scripts. `scripts/postinstall.js` is an exception — it is a Node.js ESM script invoked by npm's `postinstall` lifecycle hook, not by `script-runner.js`.
 - **Config system** uses a `.sfdt/` directory created per-project. Config is loaded by `src/lib/config.js`. At load time, config is enriched with values from `sfdx-project.json` (e.g. `sourceApiVersion`, `defaultSourcePath` derived from `packageDirectories`).
 - **AI features** are optional and gated behind `features.ai` in config. They require the Claude CLI to be installed externally.
 - **File matching** uses the `glob` package (v11) for pattern-based file discovery.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,9 @@ test/           Tests (vitest)
 | `SFDT_COVERAGE_THRESHOLD` | `config.deployment.coverageThreshold` (default: `75`) |
 | `SFDT_LOG_DIR` | `config.logDir` (optional; scripts fall back to `${SFDT_PROJECT_ROOT}/logs`) |
 | `SFDT_BACKUP_BEFORE_ROLLBACK` | `config.deployment.backupBeforeRollback` (default: `true`) |
+| `SFDT_PREFLIGHT_ENFORCE_TESTS` | `"true"` when `config.deployment.preflight.enforceTests` is set; gates Apex test check in preflight |
+| `SFDT_PREFLIGHT_ENFORCE_BRANCH` | `"true"` when `config.deployment.preflight.enforceBranchNaming` is set; promotes branch WARN to FAIL |
+| `SFDT_PREFLIGHT_ENFORCE_CHANGELOG` | `"true"` when `config.deployment.preflight.enforceChangelog` is set; promotes CHANGELOG WARN to FAIL |
 | `SFDT_FEATURE_*` | Flattened from `config.features` |
 | `SFDT_DEFAULT_ENV` | `config.environments.default` |
 | `SFDT_ENV_ORGS` | Comma-joined org aliases from `config.environments.orgs` |
@@ -59,6 +62,14 @@ test/           Tests (vitest)
 | `SFDT_PULL_*` | Flattened from `config.pullConfig` |
 
 When adding a new env var, update both `buildScriptEnv()` in `script-runner.js` and this table.
+
+### Config Template
+
+`src/templates/sfdt.config.json` is the canonical source of truth for the shape and defaults of `.sfdt/config.json`. `sfdt init` reads this template via `fs.readJson` and deep-merges user-provided answers on top. When adding new config keys, add them to the template first — `init.js` will pick them up automatically.
+
+### Known Gaps
+
+- **No `sfdt config` command**: `.sfdt/config.json` must be hand-edited to change settings after `init`. A future `sfdt config set <key> <value>` command would let users and scripts update config without opening a JSON file, and would be especially useful for CI pipelines setting `deployment.preflight.enforce*` flags.
 
 ### Error Handling
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,10 @@
 Production-grade CLI for Salesforce DX deployment, testing, quality analysis, and release management.
 
 [![npm version](https://img.shields.io/npm/v/@sfdt/cli.svg)](https://www.npmjs.com/package/@sfdt/cli)
-[![license](https://img.shields.io/npm/l/@sfdt/cli.svg)](https://github.com/sfdt-cli/sfdt/blob/main/LICENSE)
+[![npm downloads](https://img.shields.io/npm/dm/@sfdt/cli.svg)](https://www.npmjs.com/package/@sfdt/cli)
+[![CI](https://github.com/scoobydrew83/sfdt/actions/workflows/ci.yml/badge.svg)](https://github.com/scoobydrew83/sfdt/actions/workflows/ci.yml)
+[![CodeQL](https://github.com/scoobydrew83/sfdt/actions/workflows/codeql.yml/badge.svg)](https://github.com/scoobydrew83/sfdt/actions/workflows/codeql.yml)
+[![license](https://img.shields.io/npm/l/@sfdt/cli.svg)](https://github.com/scoobydrew83/sfdt/blob/main/LICENSE)
 [![node](https://img.shields.io/node/v/@sfdt/cli.svg)](https://nodejs.org)
 
 ## Features
@@ -133,7 +136,7 @@ Use groups with `sfdt pull --group core` to pull only the metadata types defined
 ## Development
 
 ```bash
-git clone https://github.com/sfdt-cli/sfdt.git
+git clone https://github.com/scoobydrew83/sfdt.git
 cd sfdt
 npm install
 npm link
@@ -154,6 +157,10 @@ Contributions are welcome! Please follow these steps:
 7. Push to your fork and open a Pull Request
 
 Please ensure all tests pass and linting is clean before submitting.
+
+## Security
+
+To report a vulnerability, please use [GitHub's private security advisory feature](https://github.com/scoobydrew83/sfdt/security/advisories/new) rather than opening a public issue. See [SECURITY.md](SECURITY.md) for the full policy and scope.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,39 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+| ------- | --------- |
+| 0.2.x   | Yes       |
+| < 0.2   | No        |
+
+## Reporting a Vulnerability
+
+**Please do not open a public GitHub issue for security vulnerabilities.**
+
+Report vulnerabilities privately using [GitHub's private security advisory feature](https://github.com/scoobydrew83/sfdt/security/advisories/new).
+
+Include as much detail as possible:
+
+- A description of the vulnerability and its potential impact
+- Steps to reproduce or a proof-of-concept
+- Affected versions
+- Any suggested mitigations (optional)
+
+### What to expect
+
+- **Acknowledgement** within a few days
+- **Status update** within 2–3 weeks (confirmed, in progress, or not applicable)
+- **Fix and disclosure** coordinated with you before any public announcement
+
+We follow [responsible disclosure](https://en.wikipedia.org/wiki/Coordinated_vulnerability_disclosure) — we will credit reporters in the release notes unless you prefer to remain anonymous.
+
+## Scope
+
+This CLI tool runs locally on developer machines with the user's own Salesforce credentials. The primary attack surface is:
+
+- **Shell script injection** via malformed config values or environment variables
+- **Dependency vulnerabilities** in bundled npm packages
+- **Credential exposure** through log output or error messages
+
+Out of scope: vulnerabilities in Salesforce orgs themselves, the `sf` CLI, or the Claude CLI — report those to their respective maintainers.

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "src/",
     "scripts/",
     "README.md",
-    "LICENSE"
+    "LICENSE",
+    "SECURITY.md"
   ],
   "scripts": {
     "test": "vitest run",
@@ -25,6 +26,7 @@
     "lint:fix": "eslint src/ bin/ --fix",
     "format": "prettier --write \"src/**/*.js\" \"bin/*.js\" \"test/**/*.js\" \"README.md\" \"package.json\"",
     "dev": "npm link",
+    "postinstall": "node scripts/postinstall.js",
     "prepublishOnly": "npm test && npm run lint"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sfdt/cli",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Salesforce DevTools — Production-grade CLI for Salesforce DX deployment, testing, quality analysis, and release management",
   "type": "module",
   "bin": {

--- a/scripts/new/preflight.sh
+++ b/scripts/new/preflight.sh
@@ -14,6 +14,9 @@ COVERAGE_THRESHOLD="${SFDT_COVERAGE_THRESHOLD:-75}"
 DEFAULT_ORG="${SFDT_DEFAULT_ORG:-}"
 STRICT_MODE="${SFDT_PREFLIGHT_STRICT:-}"
 PROJECT_NAME="${SFDT_PROJECT_NAME:-sfdt}"
+ENFORCE_TESTS="${SFDT_PREFLIGHT_ENFORCE_TESTS:-}"
+ENFORCE_BRANCH="${SFDT_PREFLIGHT_ENFORCE_BRANCH:-}"
+ENFORCE_CHANGELOG="${SFDT_PREFLIGHT_ENFORCE_CHANGELOG:-}"
 
 # Track results
 PASS_COUNT=0
@@ -49,6 +52,8 @@ print_step "Checking branch naming..."
 current_branch=$(git rev-parse --abbrev-ref HEAD)
 if [[ "$current_branch" =~ ^(main|master|release/.*|develop/.*)$ ]]; then
     record_result "PASS" "Branch '${current_branch}' matches expected pattern"
+elif [[ -n "$ENFORCE_BRANCH" ]]; then
+    record_result "FAIL" "Branch '${current_branch}' does not match main|release/*|develop/* pattern"
 else
     record_result "WARN" "Branch '${current_branch}' does not match main|release/*|develop/* pattern"
 fi
@@ -56,11 +61,15 @@ fi
 # ── Check 3: CHANGELOG.md exists and has unreleased content ──────────────────
 print_step "Checking CHANGELOG.md..."
 if [[ -f "CHANGELOG.md" ]]; then
-    if changelog_has_unreleased; then
+    if has_unreleased_content; then
         record_result "PASS" "CHANGELOG.md has unreleased content"
+    elif [[ -n "$ENFORCE_CHANGELOG" ]]; then
+        record_result "FAIL" "CHANGELOG.md exists but has no unreleased content"
     else
         record_result "WARN" "CHANGELOG.md exists but has no unreleased content"
     fi
+elif [[ -n "$ENFORCE_CHANGELOG" ]]; then
+    record_result "FAIL" "CHANGELOG.md not found"
 else
     record_result "WARN" "CHANGELOG.md not found"
 fi
@@ -73,38 +82,42 @@ else
     record_result "FAIL" "sfdx-project.json not found"
 fi
 
-# ── Check 5: Run Apex tests ─────────────────────────────────────────────────
-print_step "Running Apex tests (RunLocalTests)..."
-if [[ -z "$DEFAULT_ORG" ]]; then
-    record_result "WARN" "Apex tests skipped" "SFDT_DEFAULT_ORG not set"
+# ── Check 5 & 6: Apex tests + coverage (enforced only) ──────────────────────
+print_step "Checking Apex tests..."
+if [[ -z "$ENFORCE_TESTS" ]]; then
+    record_result "WARN" "Apex tests skipped" "Set deployment.preflight.enforceTests in config to require"
 else
-    TEST_OUTPUT_FILE=$(mktemp)
-    if sf apex run test --test-level RunLocalTests --target-org "$DEFAULT_ORG" --json --wait 30 > "$TEST_OUTPUT_FILE" 2>&1; then
-        test_status=$(jq -r '.result.summary.outcome // "Unknown"' "$TEST_OUTPUT_FILE" 2>/dev/null || echo "Unknown")
-        if [[ "$test_status" == "Passed" ]]; then
-            record_result "PASS" "All Apex tests passed"
+    if [[ -z "$DEFAULT_ORG" ]]; then
+        record_result "FAIL" "Apex tests required but SFDT_DEFAULT_ORG is not set"
+    else
+        TEST_OUTPUT_FILE=$(mktemp)
+        if sf apex run test --test-level RunLocalTests --target-org "$DEFAULT_ORG" --json --wait 30 > "$TEST_OUTPUT_FILE" 2>&1; then
+            test_status=$(jq -r '.result.summary.outcome // "Unknown"' "$TEST_OUTPUT_FILE" 2>/dev/null || echo "Unknown")
+            if [[ "$test_status" == "Passed" ]]; then
+                record_result "PASS" "All Apex tests passed"
+            else
+                failing=$(jq -r '.result.summary.failing // "unknown"' "$TEST_OUTPUT_FILE" 2>/dev/null || echo "unknown")
+                record_result "FAIL" "Apex tests failed" "${failing} test(s) failing"
+            fi
         else
-            failing=$(jq -r '.result.summary.failing // "unknown"' "$TEST_OUTPUT_FILE" 2>/dev/null || echo "unknown")
-            record_result "FAIL" "Apex tests failed" "${failing} test(s) failing"
+            error_msg=$(jq -r '.message // "Unknown error"' "$TEST_OUTPUT_FILE" 2>/dev/null || echo "Test command failed")
+            record_result "FAIL" "Apex test run failed" "$error_msg"
         fi
-    else
-        error_msg=$(jq -r '.message // "Unknown error"' "$TEST_OUTPUT_FILE" 2>/dev/null || echo "Test command failed")
-        record_result "FAIL" "Apex test run failed" "$error_msg"
-    fi
 
-    # ── Check 6: Coverage threshold ──────────────────────────────────────────
-    print_step "Checking code coverage..."
-    coverage_pct=$(jq -r '.result.summary.orgWideCoverage // "0%"' "$TEST_OUTPUT_FILE" 2>/dev/null || echo "0%")
-    coverage_num="${coverage_pct//%/}"
-    if [[ "$coverage_num" =~ ^[0-9]+$ ]] && (( coverage_num >= COVERAGE_THRESHOLD )); then
-        record_result "PASS" "Code coverage ${coverage_pct} meets threshold (${COVERAGE_THRESHOLD}%)"
-    elif [[ "$coverage_num" =~ ^[0-9]+$ ]]; then
-        record_result "FAIL" "Code coverage ${coverage_pct} below threshold (${COVERAGE_THRESHOLD}%)"
-    else
-        record_result "WARN" "Could not parse coverage percentage" "$coverage_pct"
-    fi
+        # ── Check 6: Coverage threshold ──────────────────────────────────────────
+        print_step "Checking code coverage..."
+        coverage_pct=$(jq -r '.result.summary.orgWideCoverage // "0%"' "$TEST_OUTPUT_FILE" 2>/dev/null || echo "0%")
+        coverage_num="${coverage_pct//%/}"
+        if [[ "$coverage_num" =~ ^[0-9]+$ ]] && (( coverage_num >= COVERAGE_THRESHOLD )); then
+            record_result "PASS" "Code coverage ${coverage_pct} meets threshold (${COVERAGE_THRESHOLD}%)"
+        elif [[ "$coverage_num" =~ ^[0-9]+$ ]]; then
+            record_result "FAIL" "Code coverage ${coverage_pct} below threshold (${COVERAGE_THRESHOLD}%)"
+        else
+            record_result "WARN" "Could not parse coverage percentage" "$coverage_pct"
+        fi
 
-    rm -f "$TEST_OUTPUT_FILE"
+        rm -f "$TEST_OUTPUT_FILE"
+    fi
 fi
 
 # ── Check 7: Untracked files in force-app/ ──────────────────────────────────

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+// Runs after `npm install -g @sfdt/cli`
+// Kept intentionally minimal — no network calls, no telemetry.
+
+import { createRequire } from 'module';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
+const { version } = require(join(__dirname, '../package.json'));
+
+const reset = '\x1b[0m';
+const bold = '\x1b[1m';
+const green = '\x1b[32m';
+const cyan = '\x1b[36m';
+const dim = '\x1b[2m';
+
+console.log(`
+${green}${bold}  sfdt v${version} installed successfully!${reset}
+
+  ${bold}Get started:${reset}
+    ${cyan}cd your-salesforce-project${reset}
+    ${cyan}sfdt init${reset}
+    ${cyan}sfdt deploy${reset}
+
+  ${bold}Docs & source:${reset}  ${cyan}https://github.com/scoobydrew83/sfdt${reset}
+  ${bold}Report an issue:${reset} ${cyan}https://github.com/scoobydrew83/sfdt/issues${reset}
+
+  ${dim}AI features require: npm install -g @anthropic-ai/claude-code${reset}
+`);

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -1,21 +1,29 @@
 import fs from 'fs-extra';
 import path from 'path';
+import { fileURLToPath } from 'url';
 import { glob } from 'glob';
 import inquirer from 'inquirer';
 import { detectProject, getProjectRoot } from '../lib/project-detect.js';
 import { print } from '../lib/output.js';
 
 const CONFIG_DIR = '.sfdt';
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const TEMPLATE_PATH = path.join(__dirname, '../templates/sfdt.config.json');
 
-function buildConfigTemplate({ projectName, defaultOrg, features, releaseNotesDir }) {
+async function buildConfigTemplate({ projectName, defaultOrg, features, releaseNotesDir, coverageThreshold }) {
+  const template = await fs.readJson(TEMPLATE_PATH);
   return {
+    ...template,
     projectName,
     defaultOrg,
     releaseNotesDir,
+    deployment: {
+      ...template.deployment,
+      coverageThreshold,
+    },
     features: {
+      ...template.features,
       ai: features.ai,
-      notifications: features.notifications,
-      releaseManagement: features.releaseManagement,
     },
   };
 }
@@ -164,10 +172,11 @@ export function registerInitCommand(program) {
         // Create .sfdt/ directory
         await fs.ensureDir(configDir);
 
-        const config = buildConfigTemplate({
+        const config = await buildConfigTemplate({
           projectName: answers.projectName,
           defaultOrg: answers.defaultOrg,
           releaseNotesDir: answers.releaseNotesDir,
+          coverageThreshold: answers.coverageThreshold,
           features: {
             ai: answers.aiEnabled,
             notifications: false,

--- a/src/lib/script-runner.js
+++ b/src/lib/script-runner.js
@@ -28,6 +28,9 @@ export function buildScriptEnv(config) {
   env.SFDT_API_VERSION = config.sourceApiVersion || '';
   env.SFDT_COVERAGE_THRESHOLD = String(config.deployment?.coverageThreshold || 75);
   env.SFDT_LOG_DIR = config.logDir || '';
+  env.SFDT_PREFLIGHT_ENFORCE_TESTS = config.deployment?.preflight?.enforceTests ? 'true' : '';
+  env.SFDT_PREFLIGHT_ENFORCE_BRANCH = config.deployment?.preflight?.enforceBranchNaming ? 'true' : '';
+  env.SFDT_PREFLIGHT_ENFORCE_CHANGELOG = config.deployment?.preflight?.enforceChangelog ? 'true' : '';
 
   // Flatten features
   if (config.features && typeof config.features === 'object') {

--- a/src/templates/sfdt.config.json
+++ b/src/templates/sfdt.config.json
@@ -1,29 +1,19 @@
 {
   "projectName": "",
-  "sourceApiVersion": "",
-  "packageDirectories": [],
-  "defaultSourcePath": "",
+  "defaultOrg": "",
+  "releaseNotesDir": "release-notes",
   "manifestDir": "manifest/release",
   "deployment": {
-    "keyClasses": [],
     "coverageThreshold": 75,
-    "excludedProfiles": []
+    "preflight": {
+      "enforceTests": false,
+      "enforceBranchNaming": false,
+      "enforceChangelog": false
+    }
   },
   "features": {
     "ai": true,
-    "notifications": false
-  },
-  "ai": {
-    "provider": "claude",
-    "allowedTools": ["Bash(git*)", "Bash(gh*)"]
-  },
-  "notifications": {
-    "slack": {
-      "webhookUrl": ""
-    }
-  },
-  "smokeTests": {
-    "testClasses": [],
-    "healthChecks": []
+    "notifications": false,
+    "releaseManagement": true
   }
 }

--- a/test/commands/init.test.js
+++ b/test/commands/init.test.js
@@ -59,11 +59,34 @@ beforeEach(() => {
   // .sfdt does not exist yet
   fs.pathExists.mockResolvedValue(false);
 
-  // sfdx-project.json content
-  fs.readJson.mockResolvedValue({
-    name: 'test-project',
-    sourceApiVersion: '61.0',
-    packageDirectories: [{ path: 'force-app', default: true }],
+  // fs.readJson: return template or sfdx-project.json based on path
+  fs.readJson.mockImplementation((filePath) => {
+    if (filePath.endsWith('sfdt.config.json')) {
+      return Promise.resolve({
+        projectName: '',
+        defaultOrg: '',
+        releaseNotesDir: 'release-notes',
+        manifestDir: 'manifest/release',
+        deployment: {
+          coverageThreshold: 75,
+          preflight: {
+            enforceTests: false,
+            enforceBranchNaming: false,
+            enforceChangelog: false,
+          },
+        },
+        features: {
+          ai: true,
+          notifications: false,
+          releaseManagement: true,
+        },
+      });
+    }
+    return Promise.resolve({
+      name: 'test-project',
+      sourceApiVersion: '61.0',
+      packageDirectories: [{ path: 'force-app', default: true }],
+    });
   });
 
   fs.ensureDir.mockResolvedValue();
@@ -78,6 +101,7 @@ beforeEach(() => {
     defaultOrg: 'dev',
     coverageThreshold: 75,
     aiEnabled: true,
+    releaseNotesDir: 'release-notes',
   });
 });
 
@@ -104,6 +128,10 @@ describe('init command', () => {
     expect(config.projectName).toBe('test-project');
     expect(config.defaultOrg).toBe('dev');
     expect(config.features.ai).toBe(true);
+    expect(config.deployment.preflight).toBeDefined();
+    expect(config.deployment.preflight.enforceTests).toBe(false);
+    expect(config.deployment.preflight.enforceBranchNaming).toBe(false);
+    expect(config.deployment.preflight.enforceChangelog).toBe(false);
   });
 
   it('prompts for overwrite when .sfdt already exists', async () => {

--- a/test/script-runner.test.js
+++ b/test/script-runner.test.js
@@ -132,6 +132,44 @@ describe('buildScriptEnv', () => {
     expect(env.SFDT_PULL_METADATA_TYPES).toBe('ApexClass,ApexTrigger');
     expect(env.SFDT_PULL_TARGET_DIR).toBe('force-app/main/default');
   });
+
+  it('sets preflight enforce vars to "true" when config flags are set', () => {
+    const config = {
+      features: {},
+      deployment: {
+        preflight: {
+          enforceTests: true,
+          enforceBranchNaming: true,
+          enforceChangelog: true,
+        },
+      },
+    };
+
+    const env = buildScriptEnv(config);
+
+    expect(env.SFDT_PREFLIGHT_ENFORCE_TESTS).toBe('true');
+    expect(env.SFDT_PREFLIGHT_ENFORCE_BRANCH).toBe('true');
+    expect(env.SFDT_PREFLIGHT_ENFORCE_CHANGELOG).toBe('true');
+  });
+
+  it('sets preflight enforce vars to empty string when config flags are false or absent', () => {
+    const config = {
+      features: {},
+      deployment: {
+        preflight: {
+          enforceTests: false,
+          enforceBranchNaming: false,
+          enforceChangelog: false,
+        },
+      },
+    };
+
+    const env = buildScriptEnv(config);
+
+    expect(env.SFDT_PREFLIGHT_ENFORCE_TESTS).toBe('');
+    expect(env.SFDT_PREFLIGHT_ENFORCE_BRANCH).toBe('');
+    expect(env.SFDT_PREFLIGHT_ENFORCE_CHANGELOG).toBe('');
+  });
 });
 
 describe('runScript', () => {


### PR DESCRIPTION
## Summary
- Fixes `changelog_has_unreleased: command not found` error on every preflight run (wrong function name — should be `has_unreleased_content`)
- Restores user choice for Apex tests: tests are now **skipped by default** in preflight and remain in the interactive deployment assistant flow where users can choose test level
- Adds `deployment.preflight.enforceTests/enforceBranchNaming/enforceChangelog` config flags for enterprise teams to promote advisory checks to hard gates
- `sfdt init` now writes `deployment.preflight` defaults (all `false`) so new projects get the full config shape
- `src/templates/sfdt.config.json` is now the authoritative source for config structure; `init.js` reads and merges from it

## Test Plan
- [ ] `sfdt preflight` runs cleanly with no "command not found" error
- [ ] `sfdt deploy` with default config reaches the deployment assistant with interactive test selection intact
- [ ] `sfdt deploy` with `deployment.preflight.enforceTests: true` in config runs tests in preflight and blocks on failure
- [ ] `sfdt init` on a new project produces `deployment.preflight` block with all flags `false`
- [ ] `npm test` — 300 tests passing