### PR TITLE
feat: v0.3.0 — Phase 4 complete (multi-provider AI, plugins, Web UI, Docker)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,25 @@
+# Dependencies — installed fresh inside the image
+node_modules/
+gui/node_modules/
+
+# Dev / test artefacts
+coverage/
+.nyc_output/
+*.log
+
+# Git worktrees and local overrides
+.worktrees/
+.env
+.env.*
+
+# Editor and OS noise
+.DS_Store
+Thumbs.db
+.idea/
+.vscode/
+
+# CI workflows (not needed in the image)
+.github/
+
+# Skills / eval directories
+skills/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
         run: npm audit --audit-level=high
       - run: npm run lint
       - run: npm test
+      - name: Build GUI (Node 22 only)
+        if: matrix.node-version == 22
+        run: npm run build:gui
       - name: Publish dry-run (Node 22 only)
         if: matrix.node-version == 22
         run: npm publish --dry-run
@@ -73,6 +76,9 @@ jobs:
           git push origin "v${RELEASE_VERSION}"
       - run: npm ci
         if: steps.version.outputs.changed == 'true'
+      - name: Build GUI
+        if: steps.version.outputs.changed == 'true'
+        run: npm run build:gui
       - name: Publish to npm
         if: steps.version.outputs.changed == 'true'
         run: npx npm@latest publish --provenance --access public

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ gui/node_modules/
 
 # Build output
 dist/
-# gui/dist/ is intentionally NOT ignored — pre-built assets ship with the package
+gui/dist/
 
 # Coverage
 coverage/

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
 # Dependencies
 node_modules/
+gui/node_modules/
 
 # Build output
 dist/
+# gui/dist/ is intentionally NOT ignored — pre-built assets ship with the package
 
 # Coverage
 coverage/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-04-13
+
+### Added
+- **Multi-provider AI support**: `ai.provider` in `.sfdt/config.json` selects `claude` (Claude Code CLI, default), `gemini` (Google Gemini REST), or `openai` (OpenAI REST). Both API providers use native `fetch` with SSE streaming — no new npm dependencies. API keys stored in `ai.apiKey` or the corresponding env var (`GEMINI_API_KEY` / `OPENAI_API_KEY`).
+- **AI credential auto-discovery**: `sfdt init` now prompts for AI provider and optional API key; stored credentials are resolved at runtime with environment variable fallback.
+- **Plugin architecture** (`src/lib/plugin-loader.js`): plugins are discovered and loaded before CLI argument parsing from three sources — (1) `config.plugins[]` package names, (2) `sfdt-plugin-*` / `@scope/sfdt-plugin-*` packages auto-discovered in the project's `node_modules/`, (3) `.sfdt/plugins/*.js` local scripts. Each plugin exports `register(program)`; load errors are warnings, not crashes.
+- **Web dashboard** (`sfdt ui`): `src/commands/ui.js` + `src/lib/gui-server.js` — launches a local Express server on port 7654 serving a React 18 + Salesforce Lightning Design System dashboard. Pages: Dashboard (stat cards, recent runs), Test Runs (coverage-coloured DataTable), Preflight (per-check pass/fail), Drift Detection (filterable component table). Built with `npm run build:gui`; `gui/dist/` ships in the published package.
+- **Docker support**: `Dockerfile` ships Node 20 slim + Salesforce CLI + git/jq/bash, mounting a Salesforce DX project at `/project`. `.dockerignore` excludes `node_modules`, coverage output, and CI artifacts.
+- `src/lib/ai.js` additions: `isAiAvailable(config)`, `aiUnavailableMessage(config)`, `getConfiguredProvider(config)` — replace legacy `isClaudeAvailable()` across all AI-calling commands.
+- `sfdt.config.json` template updated with `ai` and `plugins` sections; `sfdt init` picks them up automatically.
+- New tests: `test/lib/plugin-loader.test.js` (3 tests); expanded `ai.test.js` covering all three providers. Total: 218 tests across 27 test files.
+
+### Changed
+- All 8 AI-calling commands (`review`, `explain`, `manifest`, `pr-description`, `changelog`, `release`, `quality`, `test`) updated to use `isAiAvailable(config)` / `aiUnavailableMessage(config)` and pass `config` to `runAiPrompt` for transparent provider routing.
+
 ## [0.2.2] - 2026-04-12
 
 ### Security

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,14 +14,17 @@ This is `@sfdt/cli`, a Node.js ESM CLI package for Salesforce DX deployment, tes
 ### Directory Structure
 
 ```
-bin/            CLI entry point
+bin/            CLI entry point (loads plugins, then parses args)
 src/
   commands/     Command modules (one file per command)
-  lib/          Shared libraries (config, output, AI, script-runner, project-detect, metadata-mapper)
+  lib/          Shared libraries (config, output, AI, script-runner, project-detect, metadata-mapper, plugin-loader, gui-server)
 scripts/        Shell scripts executed by commands (de-parameterized, use SFDT_ env vars)
                 Exception: scripts/postinstall.js is a Node.js ESM file run by npm on install
 test/           Tests (vitest)
+gui/            React + Vite web dashboard (sfdt ui); built output lives in gui/dist/
+Dockerfile      Official Docker image definition
 .sfdt/          Per-project config directory (created by `sfdt init` in target projects)
+  plugins/      Optional local JS plugins loaded automatically at startup
 ```
 
 ### Key Patterns
@@ -29,7 +32,9 @@ test/           Tests (vitest)
 - **Commands** in `src/commands/` export a function that receives the Commander program and registers a subcommand.
 - **Shell scripts** in `scripts/` are de-parameterized — they read configuration from `SFDT_` prefixed environment variables, not from positional arguments. The `script-runner.js` lib handles setting these vars and invoking scripts. `scripts/postinstall.js` is an exception — it is a Node.js ESM script invoked by npm's `postinstall` lifecycle hook, not by `script-runner.js`.
 - **Config system** uses a `.sfdt/` directory created per-project. Config is loaded by `src/lib/config.js`. At load time, config is enriched with values from `sfdx-project.json` (e.g. `sourceApiVersion`, `defaultSourcePath` derived from `packageDirectories`).
-- **AI features** are optional and gated behind `features.ai` in config. They require the Claude CLI to be installed externally.
+- **AI features** are optional and gated behind `features.ai` in config. The provider is selected by `ai.provider` (`claude` | `gemini` | `openai`). Claude requires the Claude Code CLI; Gemini and OpenAI use native `fetch` with an API key from `ai.apiKey` or the corresponding env var. Use `isAiAvailable(config)` / `aiUnavailableMessage(config)` from `src/lib/ai.js` instead of the legacy `isClaudeAvailable()`.
+- **Plugin system** (`src/lib/plugin-loader.js`) runs before argument parsing. Plugins are loaded from: (1) `config.plugins[]` package names, (2) `sfdt-plugin-*` packages auto-discovered in the project's `node_modules/`, (3) `.sfdt/plugins/*.js` local files. Each plugin exports `register(program)`.
+- **Web UI** (`src/commands/ui.js` + `src/lib/gui-server.js`) starts a local Express server on port 7654 serving a pre-built React/SLDS dashboard from `gui/dist/`. Build with `npm run build:gui`.
 - **File matching** uses the `glob` package (v11) for pattern-based file discovery.
 - **Metadata mapping** (`src/lib/metadata-mapper.js`) provides a pure-JS mirror of `scripts/lib/metadata-parser.sh` for use in Node commands. Used by `manifest` and `pr-description`.
 
@@ -72,6 +77,7 @@ When adding a new env var, update both `buildScriptEnv()` in `script-runner.js` 
 ### Known Gaps
 
 - **No `sfdt config` command**: `.sfdt/config.json` must be hand-edited to change settings after `init`. A future `sfdt config set <key> <value>` command would let users and scripts update config without opening a JSON file, and would be especially useful for CI pipelines setting `deployment.preflight.enforce*` flags.
+- **GUI not pre-built in dev**: `gui/dist/` must be compiled with `npm run build:gui` before `sfdt ui` shows the full dashboard. The server falls back to a build-instructions page when `dist/` is absent.
 
 ### Error Handling
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,57 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# SFDT — Salesforce DevTools  Docker image
+#
+# Usage (run against a mounted Salesforce DX project):
+#   docker build -t sfdt .
+#   docker run --rm -v "$(pwd):/project" sfdt --help
+#   docker run --rm -v "$(pwd):/project" sfdt deploy
+#
+# CI/CD example (GitHub Actions):
+#   - uses: docker/build-push-action@v5
+#     with:
+#       context: .
+#       tags: sfdt:latest
+#
+# Environment variables you can pass at run time:
+#   GEMINI_API_KEY, OPENAI_API_KEY  — for non-Claude AI providers
+#   SF_*                             — Salesforce CLI auth env vars
+# ─────────────────────────────────────────────────────────────────────────────
+
+FROM node:20-slim AS base
+
+# ── System packages ───────────────────────────────────────────────────────────
+# git: required by manifest, changelog, review, pr-description commands
+# bash: required by shell scripts in scripts/
+# jq:  required by several shell scripts for JSON parsing
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      git \
+      bash \
+      jq \
+      curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# ── Salesforce CLI ────────────────────────────────────────────────────────────
+RUN npm install -g @salesforce/cli@latest --omit=dev
+
+# ── sfdt ──────────────────────────────────────────────────────────────────────
+WORKDIR /sfdt
+
+# Copy only what's needed to install production dependencies
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev
+
+# Copy package source
+COPY bin/     bin/
+COPY src/     src/
+COPY scripts/ scripts/
+COPY gui/dist/ gui/dist/
+
+# Make sfdt available globally inside the container
+RUN npm link --legacy-peer-deps
+
+# ── Runtime ───────────────────────────────────────────────────────────────────
+# Mount your Salesforce DX project at /project
+WORKDIR /project
+
+ENTRYPOINT ["sfdt"]
+CMD ["--help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,18 @@
 #   SF_*                             — Salesforce CLI auth env vars
 # ─────────────────────────────────────────────────────────────────────────────
 
+# ── Stage 1: Build the GUI ────────────────────────────────────────────────────
+FROM node:20-slim AS gui-builder
+
+WORKDIR /sfdt-gui
+
+COPY gui/package.json gui/package-lock.json* ./
+RUN npm ci
+
+COPY gui/ ./
+RUN npm run build
+
+# ── Stage 2: Runtime image ────────────────────────────────────────────────────
 FROM node:20-slim AS base
 
 # ── System packages ───────────────────────────────────────────────────────────
@@ -44,7 +56,9 @@ RUN npm ci --omit=dev
 COPY bin/     bin/
 COPY src/     src/
 COPY scripts/ scripts/
-COPY gui/dist/ gui/dist/
+
+# Copy pre-built GUI from the builder stage
+COPY --from=gui-builder /sfdt-gui/dist/ gui/dist/
 
 # Make sfdt available globally inside the container
 RUN npm link --legacy-peer-deps

--- a/README.md
+++ b/README.md
@@ -11,21 +11,22 @@ Production-grade CLI for Salesforce DX deployment, testing, quality analysis, an
 
 ## Features
 
-- Interactive deployment workflows with validation, tagging, and PR creation
+- Interactive deployment workflows with preflight validation, tagging, and PR creation
 - Automated release manifest generation from git diffs
-- Parallel test execution with coverage enforcement
-- Code and test quality analysis
-- Pre-release validation checklist
-- Deployment rollback support
+- Parallel Apex test execution with configurable coverage enforcement
+- Code and test quality analysis with AI-powered fix plans
+- Pre-release validation checklist (`sfdt preflight`)
+- Deployment rollback with pre-rollback org state backup
 - Post-deploy smoke testing
 - Org metadata drift detection
-- AI-powered changelog generation and management
-- AI-powered code review, test failure analysis, and release notes (optional, uses Claude)
-- Smart package.xml generator from git diffs with AI dependency cleanup
-- AI deployment error log interpreter with heuristic fallback
-- AI-generated PR descriptions and Slack deployment messages
+- **Smart package.xml generator** from git diffs with AI dependency cleanup (`sfdt manifest`)
+- **AI deployment error log interpreter** with heuristic fallback for offline use (`sfdt explain`)
+- **AI-generated PR descriptions and Slack messages** from deployment changes (`sfdt pr-description`)
+- **AI-powered code review, test failure analysis, changelog generation, and release notes** — optional, works with Claude, Gemini, or OpenAI
+- **Local web dashboard** for test results, preflight, and drift monitoring (`sfdt ui`)
+- **Plugin architecture** — extend sfdt with `sfdt-plugin-*` npm packages or local `.sfdt/plugins/` scripts
 - Slack notifications for deployment events
-- Works with **any** Salesforce DX project
+- Works with **any** Salesforce DX project — no project-specific values hardcoded
 
 ## Quick Start
 
@@ -38,105 +39,272 @@ sfdt deploy
 
 ## Commands Reference
 
-| Command          | Description                                        | Key Options                                            |
-| ---------------- | -------------------------------------------------- | ------------------------------------------------------ |
-| `sfdt init`      | Initialize `.sfdt/` config in current project      | `--force` to overwrite existing config                 |
-| `sfdt deploy`    | Interactive deployment with validation and tagging | `--target-org`, `--dry-run`, `--skip-tests`            |
-| `sfdt release`   | Generate release manifest from git diffs           | `--from <ref>`, `--to <ref>`, `--output <dir>`         |
-| `sfdt test`      | Run Apex tests with coverage enforcement           | `--parallel`, `--min-coverage <pct>`, `--suite <name>` |
-| `sfdt quality`   | Analyze code and test quality                      | `--type <code\|tests\|all>`, `--fail-on <level>`       |
-| `sfdt preflight` | Pre-release validation checklist                   | `--strict`, `--skip <checks>`                          |
-| `sfdt rollback`  | Roll back a deployment                             | `--target-org`, `--manifest <path>`                    |
-| `sfdt smoke`     | Post-deploy smoke testing                          | `--target-org`, `--suite <name>`                       |
-| `sfdt drift`     | Detect org metadata drift from source              | `--target-org`, `--types <list>`                       |
-| `sfdt changelog` | Manage project CHANGELOG.md                        | `generate`, `release`, `check`                         |
-| `sfdt review`    | AI-powered code review                             | `--from <ref>`, `--to <ref>`                           |
-| `sfdt manifest`  | Smart package.xml from git diffs with AI cleanup   | `--base <ref>`, `--print`, `--ai-cleanup`              |
-| `sfdt explain`   | AI analysis of deployment error logs               | `<file>`, `--from-stdin`, `--latest`                   |
-| `sfdt pr-description` | Generate PR description or Slack message      | `--format github\|slack`, `--output <file>`            |
-| `sfdt pull`      | Pull metadata from org using configured groups     | `--group <name>`, `--target-org`                       |
-| `sfdt notify`    | Send Slack deployment notifications                | `--channel`, `--status <success\|failure>`             |
+### Core
+
+| Command | Description | Key Options |
+|---|---|---|
+| `sfdt init` | Initialize `.sfdt/` config (interactive) | — |
+| `sfdt deploy` | Deploy to a Salesforce org | `--managed`, `--skip-preflight` |
+| `sfdt release` | Generate release manifest + optional AI release notes | — |
+| `sfdt test` | Run Apex tests with the enhanced test runner | `--legacy`, `--analyze` |
+| `sfdt pull` | Pull metadata from the configured org | — |
+| `sfdt preflight` | Run pre-deployment validation checks | `--strict` |
+| `sfdt rollback` | Roll back a deployment to a target org | `--org <alias>` |
+| `sfdt smoke` | Post-deploy smoke tests | `--org <alias>` |
+| `sfdt drift` | Detect metadata drift between local source and an org | `--org <alias>` |
+| `sfdt notify` | Send Slack deployment notifications | `--org <alias>`, `--version <ver>`, `--message <msg>` |
+
+### AI & Intelligence (Phase 3)
+
+| Command | Description | Key Options |
+|---|---|---|
+| `sfdt manifest` | Build `package.xml` from git diffs | `--base <ref>`, `--head <ref>`, `--output <path>`, `--destructive <path>`, `--ai-cleanup`, `--print` |
+| `sfdt explain [file]` | Analyze a deployment error log with AI + heuristics | `--from-stdin`, `--latest` |
+| `sfdt pr-description` | Generate a PR description or Slack message | `--base <ref>`, `--head <ref>`, `--format github\|slack\|markdown`, `--output <path>`, `--commit-limit <n>` |
+| `sfdt review` | AI code review of current branch changes | `--base <branch>` |
+| `sfdt changelog` | Manage `CHANGELOG.md` | subcommands: `generate`, `release <version>`, `check` |
+| `sfdt quality` | Code & test quality analysis | `--tests`, `--all`, `--fix-plan`, `--generate-stubs`, `--dry-run` |
+
+### Platform (Phase 4)
+
+| Command | Description | Key Options |
+|---|---|---|
+| `sfdt ui` | Launch local Salesforce Lightning Design System dashboard | `--port <n>` (default 7654), `--no-open` |
 
 ## Configuration
 
-Running `sfdt init` creates a `.sfdt/` directory in your project root with the following configuration files:
+Running `sfdt init` creates a `.sfdt/` directory in your project root:
 
 ```
 .sfdt/
-  config.json          # Core settings: target orgs, default branch, feature flags
-  release-config.json  # Release manifest rules: included types, naming conventions
-  test-config.json     # Test execution: suites, coverage thresholds, parallelism
-  pull-config.json     # Metadata pull groups: named sets of metadata types to retrieve
+  config.json          # Core settings: org aliases, feature flags, AI provider, coverage threshold
+  environments.json    # Named environments and org aliases
+  test-config.json     # Test classes, coverage threshold, test level
+  pull-config.json     # Metadata types to pull from org
 ```
 
 ### config.json
 
-Controls global behavior including target org aliases, the base branch for diff comparisons, and feature toggles (AI, Slack, etc.).
-
-### release-config.json
-
-Defines which metadata types to include in release manifests, archive directory structure, and version tagging format.
-
-### test-config.json
-
-Configures test suites, minimum coverage thresholds, parallel execution settings, and test result output formats.
-
-### pull-config.json
-
-Defines named groups of metadata types for targeted org pulls. See [Pull Groups](#pull-groups) below.
+```json
+{
+  "projectName": "My Salesforce Project",
+  "defaultOrg": "my-dev-org",
+  "deployment": {
+    "coverageThreshold": 75,
+    "preflight": {
+      "enforceTests": false,
+      "enforceBranchNaming": false,
+      "enforceChangelog": false
+    }
+  },
+  "features": {
+    "ai": true,
+    "notifications": false,
+    "releaseManagement": true
+  },
+  "ai": {
+    "provider": "claude",
+    "model": "",
+    "apiKey": ""
+  },
+  "plugins": []
+}
+```
 
 ## AI Features
 
-AI features (code review, test failure analysis, release notes generation) are **optional** and require the Claude CLI:
+AI-powered commands (`review`, `explain`, `manifest --ai-cleanup`, `quality --fix-plan`, `pr-description`, `changelog generate`, `release`) work with **Claude, Gemini, or OpenAI**. The provider is configured during `sfdt init` or by editing `.sfdt/config.json`.
+
+### Claude (default)
+
+Requires the [Claude Code CLI](https://www.npmjs.com/package/@anthropic-ai/claude-code):
 
 ```bash
 npm install -g @anthropic-ai/claude-code
 ```
 
-AI features can be disabled entirely by setting `features.ai` to `false` in `.sfdt/config.json`:
+```json
+{ "ai": { "provider": "claude" } }
+```
+
+Claude's interactive mode lets AI commands read your repository files directly with tool use.
+
+### Gemini
+
+Set your API key in the environment or in config:
+
+```bash
+export GEMINI_API_KEY=your-key
+```
 
 ```json
-{
-  "features": {
-    "ai": false
-  }
+{ "ai": { "provider": "gemini", "model": "gemini-2.0-flash", "apiKey": "" } }
+```
+
+Default model: `gemini-2.0-flash`. Override with `ai.model`.
+
+### OpenAI
+
+```bash
+export OPENAI_API_KEY=sk-...
+```
+
+```json
+{ "ai": { "provider": "openai", "model": "gpt-4o-mini", "apiKey": "" } }
+```
+
+Default model: `gpt-4o-mini`. Override with `ai.model`.
+
+### Disabling AI
+
+Set `features.ai` to `false` to disable all AI prompts. Heuristic fallbacks still run in `sfdt explain`.
+
+```json
+{ "features": { "ai": false } }
+```
+
+## Web Dashboard (`sfdt ui`)
+
+`sfdt ui` starts a local Express server and opens a **Salesforce Lightning Design System** dashboard in your browser:
+
+```bash
+sfdt ui                   # opens http://localhost:7654
+sfdt ui --port 8080       # custom port
+sfdt ui --no-open         # start server without opening browser
+```
+
+Dashboard pages:
+- **Dashboard** — summary stat cards, recent test runs, preflight and drift status
+- **Test Runs** — Apex test history with coverage colouring
+- **Preflight** — per-check pass/fail list
+- **Drift Detection** — filterable component table (All / Clean / Drift)
+
+The dashboard reads log files from the project's configured `logDir` (defaults to `<project>/logs`). Data appears automatically after running `sfdt test`, `sfdt preflight`, or `sfdt drift` when those commands write JSON result files.
+
+**Build the GUI** (required after cloning from source):
+
+```bash
+npm run build:gui
+```
+
+The pre-built `gui/dist/` is included in the published npm package so end users don't need to build it.
+
+## Plugin Architecture
+
+Extend sfdt with custom subcommands by creating a plugin.
+
+### npm package plugin
+
+Create a package named `sfdt-plugin-<name>` and publish it to npm:
+
+```javascript
+// sfdt-plugin-my-thing/index.js
+export function register(program) {
+  program
+    .command('my-thing')
+    .description('My custom command')
+    .action(async () => {
+      console.log('Hello from my-thing!');
+    });
 }
 ```
 
-When enabled, the `sfdt review` command uses Claude to analyze code changes and provide actionable feedback. Test failure analysis automatically runs when tests fail during `sfdt test` or `sfdt deploy`.
+Install it in your Salesforce project:
+
+```bash
+npm install --save-dev sfdt-plugin-my-thing
+```
+
+sfdt auto-discovers all `sfdt-plugin-*` packages in your project's `node_modules/` on startup — no config required.
+
+### Local plugin
+
+Drop a `.js` file in `.sfdt/plugins/`:
+
+```javascript
+// .sfdt/plugins/custom-deploy.js
+export function register(program) {
+  program.command('custom-deploy').action(async () => { ... });
+}
+```
+
+### Explicit plugin list
+
+List plugin package names in `config.plugins` to load them in a specific order:
+
+```json
+{ "plugins": ["sfdt-plugin-my-thing", "@myorg/sfdt-plugin-audit"] }
+```
+
+## Docker
+
+An official Docker image is available for CI/CD pipelines. It ships Node 20, Salesforce CLI, git, bash, and jq.
+
+**Build from source:**
+
+```bash
+docker build -t sfdt .
+```
+
+**Run against a mounted project:**
+
+```bash
+docker run --rm \
+  -v "$(pwd):/project" \
+  -e SFDX_AUTH_URL="$SFDX_AUTH_URL" \
+  sfdt deploy
+```
+
+**GitHub Actions example:**
+
+```yaml
+- name: Deploy
+  run: |
+    docker run --rm \
+      -v "${{ github.workspace }}:/project" \
+      -e SF_ORG_INSTANCE_URL="${{ secrets.SF_ORG_INSTANCE_URL }}" \
+      sfdt deploy --skip-preflight
+```
+
+Pass AI API keys as environment variables:
+
+```bash
+docker run --rm -v "$(pwd):/project" \
+  -e GEMINI_API_KEY="$GEMINI_API_KEY" \
+  sfdt explain --latest
+```
 
 ## Pull Groups
 
-Pull groups let you define named sets of metadata types in `.sfdt/pull-config.json` for project-specific metadata retrieval:
+Pull groups let you define named sets of metadata types in `.sfdt/pull-config.json`:
 
 ```json
 {
-  "groups": {
-    "core": {
-      "description": "Core application metadata",
-      "types": ["ApexClass", "ApexTrigger", "LightningComponentBundle"]
-    },
-    "config": {
-      "description": "Configuration and settings",
-      "types": ["CustomMetadata", "CustomPermission", "PermissionSet"]
-    },
-    "ui": {
-      "description": "UI components and layouts",
-      "types": ["LightningComponentBundle", "FlexiPage", "Layout"]
-    }
-  }
+  "metadataTypes": [
+    "ApexClass",
+    "ApexTrigger",
+    "LightningComponentBundle",
+    "CustomObject",
+    "CustomField",
+    "Layout",
+    "FlexiPage",
+    "PermissionSet",
+    "Flow"
+  ],
+  "targetDir": "force-app/main/default"
 }
 ```
 
-Use groups with `sfdt pull --group core` to pull only the metadata types defined in that group.
+Use `sfdt pull` to retrieve all configured metadata types from the default org.
 
 ## Requirements
 
 - **Node.js** >= 20.0.0
 - **Salesforce CLI** (`sf`) installed and authenticated to target orgs
 - **bash** 4.0+ (macOS users: `brew install bash`)
-- **jq** 1.6+ (essential for test results and metadata processing)
-- **Optional:** [Claude CLI](https://www.npmjs.com/package/@anthropic-ai/claude-code) for AI features
+- **jq** 1.6+ (required by several shell scripts)
+- **Optional:** [Claude Code CLI](https://www.npmjs.com/package/@anthropic-ai/claude-code) for AI features with the `claude` provider
+- **Optional:** Gemini or OpenAI API key for `gemini`/`openai` provider
 - **Optional:** [GitHub CLI](https://cli.github.com/) (`gh`) for PR creation during deployments
 
 ## Development
@@ -145,10 +313,19 @@ Use groups with `sfdt pull --group core` to pull only the metadata types defined
 git clone https://github.com/scoobydrew83/sfdt.git
 cd sfdt
 npm install
-npm link
+npm link              # makes `sfdt` available globally from your checkout
+
+# Build the web dashboard
+npm run build:gui
+
+# Run tests
+npm test
+
+# Lint
+npm run lint
 ```
 
-After `npm link`, the `sfdt` command is available globally and points to your local checkout. Run `npm test` and `npm run lint` before submitting changes.
+After `npm link`, the `sfdt` command points to your local checkout.
 
 ## Contributing
 
@@ -157,16 +334,15 @@ Contributions are welcome! Please follow these steps:
 1. Fork the repository
 2. Create a feature branch (`git checkout -b feature/your-feature`)
 3. Make your changes with tests
-4. Run the test suite (`npm test`)
-5. Run the linter (`npm run lint`)
-6. Commit your changes with a descriptive message
-7. Push to your fork and open a Pull Request
+4. Run the test suite (`npm test`) and linter (`npm run lint`)
+5. Commit with a descriptive message
+6. Push to your fork and open a Pull Request
 
 Please ensure all tests pass and linting is clean before submitting.
 
 ## Security
 
-To report a vulnerability, please use [GitHub's private security advisory feature](https://github.com/scoobydrew83/sfdt/security/advisories/new) rather than opening a public issue. See [SECURITY.md](SECURITY.md) for the full policy and scope.
+To report a vulnerability, use [GitHub's private security advisory feature](https://github.com/scoobydrew83/sfdt/security/advisories/new) rather than opening a public issue. See [SECURITY.md](SECURITY.md) for the full policy.
 
 ## License
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -27,7 +27,7 @@ This roadmap outlines the planned features and improvements for the @sfdt/cli to
 
 - [ ] **Other AI Platforms**: Add Gemini, others
 - [ ] **Plugin Architecture**: Allow external developers to add custom subcommands and scripts.
-- [ ] **Web UI**: A lightweight local web dashboard for monitoring test results and drift detection.
+- [x] **Web UI**: `sfdt ui` — launches a local Salesforce Lightning Design System dashboard (built with `@salesforce/design-system-react` + React + Vite) showing test run history, preflight check results, and drift detection status. Build the GUI with `npm run build:gui` from the package root.
 - [ ] **Docker Support**: Official Docker image for use in CI/CD pipelines.
 
 ---

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,12 +23,12 @@ This roadmap outlines the planned features and improvements for the @sfdt/cli to
 - [x] **Error Log Interpreter**: `sfdt explain` — AI-powered analysis of deployment error logs with heuristic fallback for offline use. Reads from file, stdin, or auto-discovers the latest log.
 - [x] **PR Description Automator**: `sfdt pr-description` — generates GitHub PR descriptions or Slack messages from deployment changes using AI. Supports `--format github|slack|markdown` and `--output`.
 
-## Phase 4: Platform & Ecosystem 🌐
+## Phase 4: Platform & Ecosystem 🌐 ✅
 
-- [ ] **Other AI Platforms**: Add Gemini, others
-- [ ] **Plugin Architecture**: Allow external developers to add custom subcommands and scripts.
+- [x] **Other AI Platforms**: Multi-provider AI support — `ai.provider` in `.sfdt/config.json` selects `claude` (Claude Code CLI, default), `gemini` (Google Gemini REST, uses `GEMINI_API_KEY`), or `openai` (OpenAI REST, uses `OPENAI_API_KEY`). `sfdt init` now prompts for provider and optional API key. All AI commands route through the selected provider transparently.
+- [x] **Plugin Architecture**: `src/lib/plugin-loader.js` discovers and loads plugins before CLI parsing. Sources (in order): (1) packages listed in `config.plugins[]`, (2) any `sfdt-plugin-*` or `@scope/sfdt-plugin-*` package in the project's `node_modules/`, (3) `.sfdt/plugins/*.js` local scripts. Each plugin exports `register(program)`.
 - [x] **Web UI**: `sfdt ui` — launches a local Salesforce Lightning Design System dashboard (built with `@salesforce/design-system-react` + React + Vite) showing test run history, preflight check results, and drift detection status. Build the GUI with `npm run build:gui` from the package root.
-- [ ] **Docker Support**: Official Docker image for use in CI/CD pipelines.
+- [x] **Docker Support**: `Dockerfile` + `.dockerignore` — mounts a Salesforce DX project at `/project`; ships Node 20, Salesforce CLI, git, jq, and sfdt. Use with `docker run --rm -v "$(pwd):/project" sfdt deploy`.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -32,6 +32,16 @@ This roadmap outlines the planned features and improvements for the @sfdt/cli to
 
 ---
 
+## Phase 5: Developer Experience & Ecosystem 🔭 (Planned)
+
+- [ ] **`sfdt config` command**: `sfdt config set <key> <value>` to update `.sfdt/config.json` without hand-editing — especially useful for CI pipelines toggling `deployment.preflight.enforce*` flags.
+- [ ] **Pre-built GUI in the published package**: automate `npm run build:gui` in CI so end users never need to build the dashboard from source.
+- [ ] **Plugin registry & scaffolding**: `sfdt plugin create` scaffold to bootstrap a new `sfdt-plugin-*` package with example `register(program)` wiring.
+- [ ] **AI context window improvements**: pass structured project metadata (org shape, test history, recent diffs) to AI commands for higher-quality output with fewer prompts.
+- [ ] **Structured log format**: standardized JSON schema for test-run, preflight, and drift log files consumed by `sfdt ui` and external observability tools.
+
+---
+
 ## Feedback & Suggestions
 
 We value community feedback! If you have ideas for features, please open an issue in the repository.

--- a/bin/sfdt.js
+++ b/bin/sfdt.js
@@ -6,6 +6,11 @@
  */
 
 import { createCli } from '../src/cli.js';
+import { loadPlugins } from '../src/lib/plugin-loader.js';
 
 const program = createCli();
+
+// Load plugins before parsing so they appear in --help and tab-completion
+await loadPlugins(program);
+
 program.parseAsync(process.argv);

--- a/gui/.npmrc
+++ b/gui/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/gui/index.html
+++ b/gui/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SFDT — Salesforce DevTools</title>
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/gui/package-lock.json
+++ b/gui/package-lock.json
@@ -1,0 +1,2398 @@
+{
+  "name": "@sfdt/gui",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@sfdt/gui",
+      "version": "0.1.0",
+      "dependencies": {
+        "@salesforce-ux/design-system": "2.25.0-alpha.2",
+        "@salesforce/design-system-react": "^0.10.50",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1"
+      },
+      "devDependencies": {
+        "@vitejs/plugin-react": "^4.3.4",
+        "vite": "^5.4.14",
+        "vite-plugin-static-copy": "^2.2.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
+      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
+      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
+      "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
+      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
+      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
+      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
+      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
+      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
+      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
+      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
+      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
+      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
+      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
+      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
+      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
+      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
+      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
+      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
+      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
+      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
+      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
+      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
+      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@salesforce-ux/design-system": {
+      "version": "2.25.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@salesforce-ux/design-system/-/design-system-2.25.0-alpha.2.tgz",
+      "integrity": "sha512-mSc+2e+YL5Imfut6c5QQOfaPEMi43pUznEfWv8uFpyZWOuNMKDyzbeWOP0HmRjaP/SdcjS+ueOb8DAO68QZZkQ==",
+      "license": "BSD-3-Clause",
+      "peerDependencies": {
+        "postcss": "^8.3.5"
+      }
+    },
+    "node_modules/@salesforce/babel-preset-design-system-react": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@salesforce/babel-preset-design-system-react/-/babel-preset-design-system-react-3.0.0.tgz",
+      "integrity": "sha512-NM3aObtfYl9RpfVu5eDU96fmTW7Mj2V1Y1O5b8dpLGESgXxqHiGIV7d4bKHzmD8O00g1qjPAPusd0f2IB7Yi0Q==",
+      "license": "SEE LICENSE IN README.md"
+    },
+    "node_modules/@salesforce/design-system-react": {
+      "version": "0.10.65",
+      "resolved": "https://registry.npmjs.org/@salesforce/design-system-react/-/design-system-react-0.10.65.tgz",
+      "integrity": "sha512-b+NEGQDxeIsPkOigDdjdkOlztBwUxvXtsGbfca2rbBCuluWZu82puXDehKTaGkzWsQfoOmX4/e9UUPtLlBiIrg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@salesforce/babel-preset-design-system-react": "^3.0.0",
+        "classnames": "^2.2.6",
+        "column-resizer": "^1.3.6",
+        "create-react-class": "^15.7.0",
+        "lodash.assign": "^4.2.0",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.find": "^4.6.0",
+        "lodash.findindex": "^4.6.0",
+        "lodash.isdate": "^4.0.1",
+        "lodash.isequal": "^4.5.0",
+        "lodash.isfunction": "^3.0.9",
+        "lodash.reject": "^4.6.0",
+        "memoize-one": "^6.0.0",
+        "nanoid": "^5.0.9",
+        "popper.js": "^1.10.8",
+        "prop-types": ">=15.7.2",
+        "react-contenteditable": "^3.3.5",
+        "react-highlighter-ts": "^2.2.0",
+        "react-modal": "3.14.3",
+        "react-onclickoutside": "^6.10.0",
+        "react-required-if": "^1.0.3",
+        "react-text-truncate": "^0.19.0",
+        "warning": "^4.0.3"
+      },
+      "peerDependencies": {
+        "@salesforce-ux/design-system": "2.25.0-alpha.2",
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.18",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.18.tgz",
+      "integrity": "sha512-VSnGQAOLtP5mib/DPyg2/t+Tlv65NTBz83BJBJvmLVHHuKJVaDOBvJJykiT5TR++em5nfAySPccDZDa4oSrn8A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001787",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001787.tgz",
+      "integrity": "sha512-mNcrMN9KeI68u7muanUpEejSLghOKlVhRqS/Za2IeyGllJ9I9otGpR9g3nsw7n4W378TE/LyIteA0+/FOZm4Kg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "license": "MIT"
+    },
+    "node_modules/column-resizer": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/column-resizer/-/column-resizer-1.4.0.tgz",
+      "integrity": "sha512-KM5Jh/UBKwVUr01oEGN/OvxF6gZIEn4c1Qde4iHSqNru9hxq93ao3u93qb9N1E1TZ2Sxjh4x7OHGe8v/P8FgkA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "string-hash": "~1.1.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/create-react-class": {
+      "version": "15.7.0",
+      "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.7.0.tgz",
+      "integrity": "sha512-QZv4sFWG9S5RUvkTYWbflxeZX+JG7Cz0Tn33rQBJ+WFQTqTfUTjMjiv9tnfXazjsO5r0KhPs+AqCjyrQX6h2ng==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.3.1",
+        "object-assign": "^4.1.1"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.335",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.335.tgz",
+      "integrity": "sha512-q9n5T4BR4Xwa2cwbrwcsDJtHD/enpQ5S1xF1IAtdqf5AAgqDFmR/aakqH3ChFdqd/QXJhS3rnnXFtexU7rax6Q==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/exenv": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
+      "integrity": "sha512-Z+ktTxTwv9ILfgKCk32OX3n/doe+OcLTRtqK9pcL+JsP3J1/VW8Uvl4ZjLlKqeW4rzK4oesDOGMEMRIZqtP4Iw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "11.3.4",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
+      "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/lodash.assign": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+      "integrity": "sha512-hFuH8TY+Yji7Eja3mGiuAxBqLagejScbG8GbG0j6o9vzn0YL14My+ktnqtZgFTosKymC9/44wP6s7xyuLfnClw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.find": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.find/-/lodash.find-4.6.0.tgz",
+      "integrity": "sha512-yaRZoAV3Xq28F1iafWN1+a0rflOej93l1DQUejs3SZ41h2O9UJBoS9aueGjPDgAl4B6tPC0NuuchLKaDQQ3Isg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.findindex": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.findindex/-/lodash.findindex-4.6.0.tgz",
+      "integrity": "sha512-9er6Ccz6sEST3bHFtUrCFWk14nE8cdL/RoW1RRDV1BxqN3qsmsT56L14jhfctAqhVPVcdJw4MRxEaVoAK+JVvw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isdate": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isdate/-/lodash.isdate-4.0.1.tgz",
+      "integrity": "sha512-hg5B1GD+R9egsBgMwmAhk+V53Us03TVvXT4dnyKugEfsD4QKuG9Wlyvxq8OGy2nu7qVGsh4DRSnMk33hoWBq/Q==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isfunction": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
+      "integrity": "sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.reject": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.reject/-/lodash.reject-4.6.0.tgz",
+      "integrity": "sha512-qkTuvgEzYdyhiJBx42YPzPo71R1aEr0z79kAv7Ixg8wPFEjgRgJdUsGMG3Hf3OYSF/kHI79XhNlt+5Ar6OzwxQ==",
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/memoize-one": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
+      "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==",
+      "license": "MIT"
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.7.tgz",
+      "integrity": "sha512-ua3NDgISf6jdwezAheMOk4mbE1LXjm1DfMUDMuJf4AqxLFK3ccGpgWizwa5YV7Yz9EpXwEaWoRXSb/BnV0t5dQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.37",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
+      "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/p-map": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
+      "integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/popper.js": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
+      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
+      "deprecated": "You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.9",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
+      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss/node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-contenteditable": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/react-contenteditable/-/react-contenteditable-3.3.7.tgz",
+      "integrity": "sha512-GA9NbC0DkDdpN3iGvib/OMHWTJzDX2cfkgy5Tt98JJAbA3kLnyrNbBIpsSpPpq7T8d3scD39DHP+j8mAM7BIfQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "prop-types": "^15.7.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.3"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-highlighter-ts": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/react-highlighter-ts/-/react-highlighter-ts-2.2.0.tgz",
+      "integrity": "sha512-wZgYrOq6bO1O1szjyduvqeiuV1DuZbKb22FvbclXEhyG5rw9vFaJhdO420RwBvDkD4DvFnDLX4hFuAOg0aQkXA==",
+      "license": "MIT",
+      "dependencies": {
+        "react": "^17.0.1"
+      }
+    },
+    "node_modules/react-highlighter-ts/node_modules/react": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
+      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
+    "node_modules/react-lifecycles-compat": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
+      "license": "MIT"
+    },
+    "node_modules/react-modal": {
+      "version": "3.14.3",
+      "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.14.3.tgz",
+      "integrity": "sha512-+C2KODVKyu20zHXPJxfOOcf571L1u/EpFlH+oS/3YDn8rgVE51QZuxuuIwabJ8ZFnOEHaD+r6XNjqwtxZnXO0g==",
+      "license": "MIT",
+      "dependencies": {
+        "exenv": "^1.2.0",
+        "prop-types": "^15.7.2",
+        "react-lifecycles-compat": "^3.0.0",
+        "warning": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "react": "^0.14.0 || ^15.0.0 || ^16 || ^17",
+        "react-dom": "^0.14.0 || ^15.0.0 || ^16 || ^17"
+      }
+    },
+    "node_modules/react-onclickoutside": {
+      "version": "6.13.2",
+      "resolved": "https://registry.npmjs.org/react-onclickoutside/-/react-onclickoutside-6.13.2.tgz",
+      "integrity": "sha512-h6Hbf1c8b7tIYY4u90mDdBLY4+AGQVMFtIE89HgC0DtVCh/JfKl477gYqUtGLmjZBKK3MJxomP/lFiLbz4sq9A==",
+      "license": "MIT",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/Pomax/react-onclickoutside/blob/master/FUNDING.md"
+      },
+      "peerDependencies": {
+        "react": "^15.5.x || ^16.x || ^17.x || ^18.x",
+        "react-dom": "^15.5.x || ^16.x || ^17.x || ^18.x"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-required-if": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/react-required-if/-/react-required-if-1.0.3.tgz",
+      "integrity": "sha512-MdbG9mGJVA12lV+jvsU/U6D50NrGfkL6Yvy132dLCUioOvDqemtbYAMTn2gIxS6cTVqqC50mL/37t0UosJkgiQ==",
+      "license": "MIT"
+    },
+    "node_modules/react-text-truncate": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/react-text-truncate/-/react-text-truncate-0.19.0.tgz",
+      "integrity": "sha512-QxHpZABfGG0Z3WEYbRTZ+rXdZn50Zvp+sWZXgVAd7FCKAMzv/kcwctTpNmWgXDTpAoHhMjOVwmgRtX3x5yeF4w==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.5.7"
+      },
+      "peerDependencies": {
+        "react": "^15.4.1 || ^16.0.0 || ^17.0.0 ||  || ^18.0.0",
+        "react-dom": "^15.4.1 || ^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
+      "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.1",
+        "@rollup/rollup-android-arm64": "4.60.1",
+        "@rollup/rollup-darwin-arm64": "4.60.1",
+        "@rollup/rollup-darwin-x64": "4.60.1",
+        "@rollup/rollup-freebsd-arm64": "4.60.1",
+        "@rollup/rollup-freebsd-x64": "4.60.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
+        "@rollup/rollup-linux-arm64-musl": "4.60.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
+        "@rollup/rollup-linux-loong64-musl": "4.60.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-musl": "4.60.1",
+        "@rollup/rollup-openbsd-x64": "4.60.1",
+        "@rollup/rollup-openharmony-arm64": "4.60.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
+        "@rollup/rollup-win32-x64-gnu": "4.60.1",
+        "@rollup/rollup-win32-x64-msvc": "4.60.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/string-hash": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
+      "integrity": "sha512-kJUvRUFK49aub+a7T1nNE66EJbZBMnBgoC1UbCZ5n6bsZKBRga4KgBRTMn/pFkeCZSYtNeSyMxPDM0AXWELk2A==",
+      "license": "CC0-1.0"
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-plugin-static-copy": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-2.3.2.tgz",
+      "integrity": "sha512-iwrrf+JupY4b9stBttRWzGHzZbeMjAHBhkrn67MNACXJVjEMRpCI10Q3AkxdBkl45IHaTfw/CNVevzQhP7yTwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^3.5.3",
+        "fast-glob": "^3.2.11",
+        "fs-extra": "^11.1.0",
+        "p-map": "^7.0.3",
+        "picocolors": "^1.0.0"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.0.0 || ^6.0.0"
+      }
+    },
+    "node_modules/warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/gui/package.json
+++ b/gui/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@sfdt/gui",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@salesforce/design-system-react": "^0.10.50",
+    "@salesforce-ux/design-system": "2.25.0-alpha.2",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.3.4",
+    "vite": "^5.4.14",
+    "vite-plugin-static-copy": "^2.2.0"
+  }
+}

--- a/gui/src/App.jsx
+++ b/gui/src/App.jsx
@@ -1,0 +1,145 @@
+import React, { useState, useEffect } from 'react';
+import IconSettings from '@salesforce/design-system-react/components/icon-settings';
+import { api } from './api.js';
+import Dashboard from './pages/Dashboard.jsx';
+import TestRuns from './pages/TestRuns.jsx';
+import PreflightPage from './pages/Preflight.jsx';
+import DriftPage from './pages/Drift.jsx';
+
+const NAV_ITEMS = [
+  { id: 'dashboard', label: 'Dashboard', icon: '⚡' },
+  { id: 'tests', label: 'Test Runs', icon: '✓' },
+  { id: 'preflight', label: 'Preflight', icon: '🔍' },
+  { id: 'drift', label: 'Drift Detection', icon: '⚖' },
+];
+
+export default function App() {
+  const [page, setPage] = useState('dashboard');
+  const [project, setProject] = useState(null);
+
+  useEffect(() => {
+    api.project().then(setProject).catch(() => null);
+  }, []);
+
+  const renderPage = () => {
+    switch (page) {
+      case 'dashboard':
+        return <Dashboard project={project} />;
+      case 'tests':
+        return <TestRuns />;
+      case 'preflight':
+        return <PreflightPage />;
+      case 'drift':
+        return <DriftPage />;
+      default:
+        return <Dashboard project={project} />;
+    }
+  };
+
+  return (
+    <IconSettings iconPath="/assets/icons">
+      <div className="slds-grid slds-nowrap" style={{ height: '100vh' }}>
+        {/* Sidebar */}
+        <aside
+          className="slds-col slds-no-flex"
+          style={{
+            width: '220px',
+            background: '#032d60',
+            color: '#fff',
+            display: 'flex',
+            flexDirection: 'column',
+          }}
+        >
+          {/* Logo / App Name */}
+          <div
+            style={{
+              padding: '20px 16px 16px',
+              borderBottom: '1px solid rgba(255,255,255,0.15)',
+            }}
+          >
+            <div
+              style={{
+                fontSize: '11px',
+                fontWeight: 700,
+                letterSpacing: '1px',
+                textTransform: 'uppercase',
+                color: 'rgba(255,255,255,0.6)',
+                marginBottom: '4px',
+              }}
+            >
+              Salesforce DevTools
+            </div>
+            <div style={{ fontSize: '16px', fontWeight: 700, color: '#fff' }}>
+              {project?.name ?? 'SFDT'}
+            </div>
+            {project?.org && (
+              <div
+                style={{
+                  fontSize: '12px',
+                  color: 'rgba(255,255,255,0.55)',
+                  marginTop: '2px',
+                }}
+              >
+                {project.org}
+              </div>
+            )}
+          </div>
+
+          {/* Nav */}
+          <nav style={{ flex: 1, padding: '8px 0' }}>
+            {NAV_ITEMS.map((item) => (
+              <button
+                key={item.id}
+                onClick={() => setPage(item.id)}
+                style={{
+                  width: '100%',
+                  textAlign: 'left',
+                  background: page === item.id ? 'rgba(255,255,255,0.12)' : 'transparent',
+                  border: 'none',
+                  borderLeft: page === item.id ? '3px solid #1b96ff' : '3px solid transparent',
+                  color: page === item.id ? '#fff' : 'rgba(255,255,255,0.72)',
+                  padding: '10px 16px 10px 13px',
+                  cursor: 'pointer',
+                  fontSize: '14px',
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '10px',
+                  transition: 'background 0.1s',
+                }}
+                onMouseEnter={(e) => {
+                  if (page !== item.id)
+                    e.currentTarget.style.background = 'rgba(255,255,255,0.07)';
+                }}
+                onMouseLeave={(e) => {
+                  if (page !== item.id) e.currentTarget.style.background = 'transparent';
+                }}
+              >
+                <span style={{ fontSize: '16px', width: '20px', textAlign: 'center' }}>
+                  {item.icon}
+                </span>
+                {item.label}
+              </button>
+            ))}
+          </nav>
+
+          {/* Footer */}
+          <div
+            style={{
+              padding: '12px 16px',
+              borderTop: '1px solid rgba(255,255,255,0.12)',
+              fontSize: '11px',
+              color: 'rgba(255,255,255,0.4)',
+            }}
+          >
+            sfdt v{project?.version ?? '…'}
+          </div>
+        </aside>
+
+        {/* Main */}
+        <main className="slds-col" style={{ flex: 1, overflow: 'auto', background: '#f3f3f3' }}>
+          {renderPage()}
+        </main>
+      </div>
+    </IconSettings>
+  );
+}

--- a/gui/src/api.js
+++ b/gui/src/api.js
@@ -1,0 +1,15 @@
+const BASE = '/api';
+
+async function fetchJson(path) {
+  const res = await fetch(`${BASE}${path}`);
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  return res.json();
+}
+
+export const api = {
+  project: () => fetchJson('/project'),
+  testRuns: () => fetchJson('/test-runs'),
+  preflight: () => fetchJson('/preflight'),
+  drift: () => fetchJson('/drift'),
+  health: () => fetchJson('/health'),
+};

--- a/gui/src/components/EmptyState.jsx
+++ b/gui/src/components/EmptyState.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+export default function EmptyState({ title, message }) {
+  return (
+    <div
+      style={{
+        textAlign: 'center',
+        padding: '60px 32px',
+        color: '#706e6b',
+      }}
+    >
+      <div style={{ fontSize: '48px', marginBottom: '16px' }}>📭</div>
+      <div style={{ fontSize: '16px', fontWeight: 600, color: '#3e3e3c', marginBottom: '8px' }}>
+        {title ?? 'No data yet'}
+      </div>
+      <div style={{ fontSize: '14px' }}>{message ?? 'Run a command to see results here.'}</div>
+    </div>
+  );
+}

--- a/gui/src/components/StatCard.jsx
+++ b/gui/src/components/StatCard.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+
+export default function StatCard({ label, value, sub, accent }) {
+  return (
+    <div
+      className="slds-box slds-box_small"
+      style={{
+        background: '#fff',
+        borderRadius: '8px',
+        padding: '20px 24px',
+        flex: 1,
+        minWidth: '150px',
+        borderTop: `4px solid ${accent ?? '#0176d3'}`,
+        boxShadow: '0 1px 3px rgba(0,0,0,0.08)',
+      }}
+    >
+      <div
+        style={{
+          fontSize: '12px',
+          fontWeight: 600,
+          textTransform: 'uppercase',
+          letterSpacing: '0.5px',
+          color: '#706e6b',
+          marginBottom: '8px',
+        }}
+      >
+        {label}
+      </div>
+      <div
+        style={{
+          fontSize: '36px',
+          fontWeight: 700,
+          color: '#181818',
+          lineHeight: 1,
+          marginBottom: '4px',
+        }}
+      >
+        {value ?? '—'}
+      </div>
+      {sub && (
+        <div style={{ fontSize: '12px', color: '#706e6b', marginTop: '4px' }}>{sub}</div>
+      )}
+    </div>
+  );
+}

--- a/gui/src/components/StatusBadge.jsx
+++ b/gui/src/components/StatusBadge.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+const VARIANTS = {
+  pass: { bg: '#2e844a', color: '#fff', label: 'Pass' },
+  passed: { bg: '#2e844a', color: '#fff', label: 'Passed' },
+  success: { bg: '#2e844a', color: '#fff', label: 'Success' },
+  fail: { bg: '#ba0517', color: '#fff', label: 'Fail' },
+  failed: { bg: '#ba0517', color: '#fff', label: 'Failed' },
+  error: { bg: '#ba0517', color: '#fff', label: 'Error' },
+  warn: { bg: '#dd7a01', color: '#fff', label: 'Warning' },
+  warning: { bg: '#dd7a01', color: '#fff', label: 'Warning' },
+  running: { bg: '#0176d3', color: '#fff', label: 'Running' },
+  unknown: { bg: '#919191', color: '#fff', label: 'Unknown' },
+  clean: { bg: '#2e844a', color: '#fff', label: 'Clean' },
+  drift: { bg: '#dd7a01', color: '#fff', label: 'Drift' },
+};
+
+export default function StatusBadge({ status }) {
+  const key = (status ?? 'unknown').toLowerCase();
+  const variant = VARIANTS[key] ?? VARIANTS.unknown;
+  return (
+    <span
+      style={{
+        display: 'inline-block',
+        padding: '2px 10px',
+        borderRadius: '12px',
+        fontSize: '12px',
+        fontWeight: 600,
+        background: variant.bg,
+        color: variant.color,
+        textTransform: 'uppercase',
+        letterSpacing: '0.5px',
+      }}
+    >
+      {variant.label}
+    </span>
+  );
+}

--- a/gui/src/main.jsx
+++ b/gui/src/main.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import '@salesforce-ux/design-system/assets/styles/salesforce-lightning-design-system.min.css';
+import App from './App.jsx';
+
+const root = createRoot(document.getElementById('root'));
+root.render(<App />);

--- a/gui/src/pages/Dashboard.jsx
+++ b/gui/src/pages/Dashboard.jsx
@@ -1,0 +1,194 @@
+import React, { useState, useEffect } from 'react';
+import Card from '@salesforce/design-system-react/components/card';
+import Spinner from '@salesforce/design-system-react/components/spinner';
+import { api } from '../api.js';
+import StatCard from '../components/StatCard.jsx';
+import StatusBadge from '../components/StatusBadge.jsx';
+
+function Section({ title, children }) {
+  return (
+    <div style={{ marginBottom: '24px' }}>
+      <h2
+        style={{
+          fontSize: '13px',
+          fontWeight: 700,
+          textTransform: 'uppercase',
+          letterSpacing: '0.8px',
+          color: '#706e6b',
+          marginBottom: '12px',
+        }}
+      >
+        {title}
+      </h2>
+      {children}
+    </div>
+  );
+}
+
+export default function Dashboard({ project }) {
+  const [tests, setTests] = useState(null);
+  const [preflight, setPreflight] = useState(null);
+  const [drift, setDrift] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    Promise.all([api.testRuns(), api.preflight(), api.drift()])
+      .then(([t, p, d]) => {
+        setTests(t);
+        setPreflight(p);
+        setDrift(d);
+      })
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, []);
+
+  const lastTest = tests?.runs?.[0];
+  const totalPassed = tests?.runs?.reduce((s, r) => s + (r.passed ?? 0), 0) ?? 0;
+  const totalFailed = tests?.runs?.reduce((s, r) => s + (r.failed ?? 0), 0) ?? 0;
+
+  if (loading) {
+    return (
+      <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '60vh' }}>
+        <Spinner size="large" variant="brand" />
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ padding: '28px 32px' }}>
+      {/* Page header */}
+      <div style={{ marginBottom: '28px' }}>
+        <h1 style={{ fontSize: '24px', fontWeight: 700, color: '#032d60', margin: 0 }}>
+          Dashboard
+        </h1>
+        {project?.org && (
+          <div style={{ fontSize: '14px', color: '#706e6b', marginTop: '4px' }}>
+            Connected org: <strong>{project.org}</strong>
+          </div>
+        )}
+      </div>
+
+      {/* Summary stats */}
+      <Section title="Summary">
+        <div style={{ display: 'flex', gap: '16px', flexWrap: 'wrap' }}>
+          <StatCard label="Tests Passed" value={totalPassed} accent="#2e844a" />
+          <StatCard label="Tests Failed" value={totalFailed} accent={totalFailed > 0 ? '#ba0517' : '#2e844a'} />
+          <StatCard
+            label="Coverage Threshold"
+            value={project?.coverageThreshold ? `${project.coverageThreshold}%` : '75%'}
+            accent="#0176d3"
+          />
+          <StatCard
+            label="Last Test Run"
+            value={lastTest ? new Date(lastTest.date).toLocaleDateString() : '—'}
+            sub={lastTest ? new Date(lastTest.date).toLocaleTimeString() : undefined}
+            accent="#9050e9"
+          />
+        </div>
+      </Section>
+
+      {/* Recent activity */}
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '20px' }}>
+        {/* Test runs */}
+        <Card
+          heading="Recent Test Runs"
+          style={{ background: '#fff', borderRadius: '8px' }}
+        >
+          <div style={{ padding: '0 16px 16px' }}>
+            {!tests?.runs?.length ? (
+              <p style={{ color: '#706e6b', fontSize: '14px', padding: '12px 0' }}>
+                No test runs found. Run <code>sfdt test</code> to generate results.
+              </p>
+            ) : (
+              <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '13px' }}>
+                <thead>
+                  <tr style={{ borderBottom: '1px solid #e5e5e5' }}>
+                    <th style={{ textAlign: 'left', padding: '8px 4px', color: '#706e6b', fontWeight: 600 }}>Date</th>
+                    <th style={{ textAlign: 'right', padding: '8px 4px', color: '#706e6b', fontWeight: 600 }}>Passed</th>
+                    <th style={{ textAlign: 'right', padding: '8px 4px', color: '#706e6b', fontWeight: 600 }}>Failed</th>
+                    <th style={{ textAlign: 'right', padding: '8px 4px', color: '#706e6b', fontWeight: 600 }}>Status</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {tests.runs.slice(0, 5).map((run, i) => (
+                    <tr key={i} style={{ borderBottom: '1px solid #f3f3f3' }}>
+                      <td style={{ padding: '8px 4px', color: '#3e3e3c' }}>
+                        {new Date(run.date).toLocaleDateString()}
+                      </td>
+                      <td style={{ padding: '8px 4px', textAlign: 'right', color: '#2e844a', fontWeight: 600 }}>
+                        {run.passed ?? 0}
+                      </td>
+                      <td style={{ padding: '8px 4px', textAlign: 'right', color: run.failed ? '#ba0517' : '#3e3e3c', fontWeight: run.failed ? 700 : 400 }}>
+                        {run.failed ?? 0}
+                      </td>
+                      <td style={{ padding: '8px 4px', textAlign: 'right' }}>
+                        <StatusBadge status={run.failed ? 'fail' : 'pass'} />
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </div>
+        </Card>
+
+        {/* Preflight + Drift */}
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
+          <Card heading="Last Preflight Check">
+            <div style={{ padding: '0 16px 16px' }}>
+              {!preflight?.checks?.length ? (
+                <p style={{ color: '#706e6b', fontSize: '14px', padding: '12px 0' }}>
+                  No preflight data. Run <code>sfdt preflight</code>.
+                </p>
+              ) : (
+                <>
+                  <div style={{ marginBottom: '8px', fontSize: '12px', color: '#706e6b' }}>
+                    {preflight.date ? new Date(preflight.date).toLocaleString() : ''}
+                  </div>
+                  {preflight.checks.slice(0, 4).map((c, i) => (
+                    <div
+                      key={i}
+                      style={{
+                        display: 'flex',
+                        justifyContent: 'space-between',
+                        alignItems: 'center',
+                        padding: '5px 0',
+                        borderBottom: '1px solid #f3f3f3',
+                        fontSize: '13px',
+                      }}
+                    >
+                      <span style={{ color: '#3e3e3c' }}>{c.name}</span>
+                      <StatusBadge status={c.status} />
+                    </div>
+                  ))}
+                </>
+              )}
+            </div>
+          </Card>
+
+          <Card heading="Drift Status">
+            <div style={{ padding: '0 16px 16px' }}>
+              {!drift?.result ? (
+                <p style={{ color: '#706e6b', fontSize: '14px', padding: '12px 0' }}>
+                  No drift data. Run <code>sfdt drift</code>.
+                </p>
+              ) : (
+                <div style={{ display: 'flex', alignItems: 'center', gap: '12px', padding: '12px 0' }}>
+                  <StatusBadge status={drift.result} />
+                  <span style={{ fontSize: '13px', color: '#706e6b' }}>
+                    {drift.date ? new Date(drift.date).toLocaleString() : ''}
+                  </span>
+                  {drift.count !== undefined && (
+                    <span style={{ fontSize: '13px', color: '#706e6b' }}>
+                      {drift.count} component{drift.count !== 1 ? 's' : ''} differ
+                    </span>
+                  )}
+                </div>
+              )}
+            </div>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/gui/src/pages/Drift.jsx
+++ b/gui/src/pages/Drift.jsx
@@ -1,0 +1,159 @@
+import React, { useState, useEffect } from 'react';
+import DataTable from '@salesforce/design-system-react/components/data-table';
+import DataTableColumn from '@salesforce/design-system-react/components/data-table/column';
+import DataTableCell from '@salesforce/design-system-react/components/data-table/cell';
+import Spinner from '@salesforce/design-system-react/components/spinner';
+import { api } from '../api.js';
+import StatusBadge from '../components/StatusBadge.jsx';
+import EmptyState from '../components/EmptyState.jsx';
+
+const DriftStatusCell = ({ item }) => <StatusBadge status={item.drift} />;
+DriftStatusCell.displayName = DataTableCell.displayName;
+
+export default function DriftPage() {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [filter, setFilter] = useState('all');
+
+  useEffect(() => {
+    api
+      .drift()
+      .then(setData)
+      .catch(() => null)
+      .finally(() => setLoading(false));
+  }, []);
+
+  const components = data?.components ?? [];
+  const filtered =
+    filter === 'all'
+      ? components
+      : components.filter((c) => c.drift?.toLowerCase() === filter);
+
+  const rows = filtered.map((c, i) => ({
+    id: String(i),
+    name: c.name ?? '—',
+    type: c.type ?? '—',
+    drift: c.drift ?? 'unknown',
+  }));
+
+  const driftCount = components.filter(
+    (c) => c.drift?.toLowerCase() === 'drift',
+  ).length;
+  const cleanCount = components.filter(
+    (c) => c.drift?.toLowerCase() === 'clean',
+  ).length;
+
+  return (
+    <div style={{ padding: '28px 32px' }}>
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'flex-start',
+          marginBottom: '28px',
+        }}
+      >
+        <div>
+          <h1 style={{ fontSize: '24px', fontWeight: 700, color: '#032d60', margin: 0 }}>
+            Drift Detection
+          </h1>
+          <p style={{ fontSize: '14px', color: '#706e6b', marginTop: '4px' }}>
+            Metadata drift between local source and target org
+          </p>
+        </div>
+        {data?.date && (
+          <div style={{ fontSize: '13px', color: '#706e6b' }}>
+            Last checked: {new Date(data.date).toLocaleString()}
+          </div>
+        )}
+      </div>
+
+      {/* Stats row */}
+      {components.length > 0 && (
+        <div
+          style={{ display: 'flex', gap: '12px', marginBottom: '24px', flexWrap: 'wrap' }}
+        >
+          {[
+            {
+              id: 'all',
+              label: 'All',
+              count: components.length,
+              accent: '#0176d3',
+            },
+            { id: 'clean', label: 'Clean', count: cleanCount, accent: '#2e844a' },
+            { id: 'drift', label: 'Drift', count: driftCount, accent: '#dd7a01' },
+          ].map((tab) => (
+            <button
+              key={tab.id}
+              onClick={() => setFilter(tab.id)}
+              style={{
+                padding: '8px 20px',
+                borderRadius: '20px',
+                border: `2px solid ${filter === tab.id ? tab.accent : '#e5e5e5'}`,
+                background: filter === tab.id ? tab.accent : '#fff',
+                color: filter === tab.id ? '#fff' : '#3e3e3c',
+                fontWeight: 600,
+                fontSize: '13px',
+                cursor: 'pointer',
+                display: 'flex',
+                alignItems: 'center',
+                gap: '8px',
+                transition: 'all 0.15s',
+              }}
+            >
+              {tab.label}
+              <span
+                style={{
+                  fontSize: '12px',
+                  background: filter === tab.id ? 'rgba(255,255,255,0.25)' : '#f3f3f3',
+                  padding: '1px 7px',
+                  borderRadius: '10px',
+                }}
+              >
+                {tab.count}
+              </span>
+            </button>
+          ))}
+        </div>
+      )}
+
+      {loading && (
+        <div style={{ display: 'flex', justifyContent: 'center', padding: '60px' }}>
+          <Spinner size="large" variant="brand" />
+        </div>
+      )}
+
+      {!loading && components.length === 0 && (
+        <EmptyState
+          title="No drift data"
+          message="Run sfdt drift to compare your local source against the target org."
+        />
+      )}
+
+      {!loading && components.length > 0 && (
+        <div
+          style={{
+            background: '#fff',
+            borderRadius: '8px',
+            boxShadow: '0 1px 3px rgba(0,0,0,0.08)',
+            overflow: 'hidden',
+          }}
+        >
+          {rows.length === 0 ? (
+            <div style={{ padding: '32px', textAlign: 'center', color: '#706e6b', fontSize: '14px' }}>
+              No components match the selected filter.
+            </div>
+          ) : (
+            <DataTable items={rows} id="drift-table" striped>
+              <DataTableColumn label="Component" property="name" />
+              <DataTableColumn label="Type" property="type" />
+              <DataTableColumn label="Drift" property="drift">
+                <DriftStatusCell />
+              </DataTableColumn>
+            </DataTable>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/gui/src/pages/Preflight.jsx
+++ b/gui/src/pages/Preflight.jsx
@@ -1,0 +1,163 @@
+import React, { useState, useEffect } from 'react';
+import Spinner from '@salesforce/design-system-react/components/spinner';
+import { api } from '../api.js';
+import StatusBadge from '../components/StatusBadge.jsx';
+import EmptyState from '../components/EmptyState.jsx';
+
+function CheckRow({ check }) {
+  const icon =
+    check.status === 'pass' || check.status === 'success'
+      ? '✓'
+      : check.status === 'fail' || check.status === 'error'
+        ? '✗'
+        : '⚠';
+  const iconColor =
+    check.status === 'pass' || check.status === 'success'
+      ? '#2e844a'
+      : check.status === 'fail' || check.status === 'error'
+        ? '#ba0517'
+        : '#dd7a01';
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'flex-start',
+        gap: '12px',
+        padding: '12px 20px',
+        borderBottom: '1px solid #f3f3f3',
+      }}
+    >
+      <span style={{ fontSize: '18px', color: iconColor, flexShrink: 0, marginTop: '1px' }}>
+        {icon}
+      </span>
+      <div style={{ flex: 1 }}>
+        <div
+          style={{ fontSize: '14px', fontWeight: 600, color: '#3e3e3c', marginBottom: '2px' }}
+        >
+          {check.name}
+        </div>
+        {check.message && (
+          <div style={{ fontSize: '13px', color: '#706e6b' }}>{check.message}</div>
+        )}
+      </div>
+      <StatusBadge status={check.status} />
+    </div>
+  );
+}
+
+export default function PreflightPage() {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    api
+      .preflight()
+      .then(setData)
+      .catch(() => null)
+      .finally(() => setLoading(false));
+  }, []);
+
+  const overallStatus = data?.status;
+  const checks = data?.checks ?? [];
+
+  return (
+    <div style={{ padding: '28px 32px' }}>
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'flex-start',
+          marginBottom: '28px',
+        }}
+      >
+        <div>
+          <h1 style={{ fontSize: '24px', fontWeight: 700, color: '#032d60', margin: 0 }}>
+            Preflight Check
+          </h1>
+          <p style={{ fontSize: '14px', color: '#706e6b', marginTop: '4px' }}>
+            Results of the last <code>sfdt preflight</code> run
+          </p>
+        </div>
+        {overallStatus && (
+          <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
+            <StatusBadge status={overallStatus} />
+            {data?.date && (
+              <span style={{ fontSize: '13px', color: '#706e6b' }}>
+                {new Date(data.date).toLocaleString()}
+              </span>
+            )}
+          </div>
+        )}
+      </div>
+
+      {loading && (
+        <div style={{ display: 'flex', justifyContent: 'center', padding: '60px' }}>
+          <Spinner size="large" variant="brand" />
+        </div>
+      )}
+
+      {!loading && checks.length === 0 && (
+        <EmptyState
+          title="No preflight data"
+          message="Run sfdt preflight to generate a report that will appear here."
+        />
+      )}
+
+      {!loading && checks.length > 0 && (
+        <div
+          style={{
+            background: '#fff',
+            borderRadius: '8px',
+            boxShadow: '0 1px 3px rgba(0,0,0,0.08)',
+            overflow: 'hidden',
+          }}
+        >
+          {/* Header */}
+          <div
+            style={{
+              padding: '16px 20px',
+              borderBottom: '1px solid #e5e5e5',
+              display: 'flex',
+              alignItems: 'center',
+              gap: '8px',
+            }}
+          >
+            <span style={{ fontSize: '14px', fontWeight: 700, color: '#3e3e3c' }}>
+              {checks.length} check{checks.length !== 1 ? 's' : ''}
+            </span>
+            {checks.filter((c) => c.status === 'pass').length > 0 && (
+              <span
+                style={{
+                  fontSize: '12px',
+                  color: '#2e844a',
+                  background: '#f3fbf5',
+                  padding: '2px 8px',
+                  borderRadius: '10px',
+                }}
+              >
+                {checks.filter((c) => c.status === 'pass' || c.status === 'success').length} passed
+              </span>
+            )}
+            {checks.filter((c) => c.status === 'fail' || c.status === 'error').length > 0 && (
+              <span
+                style={{
+                  fontSize: '12px',
+                  color: '#ba0517',
+                  background: '#fef1ee',
+                  padding: '2px 8px',
+                  borderRadius: '10px',
+                }}
+              >
+                {checks.filter((c) => c.status === 'fail' || c.status === 'error').length} failed
+              </span>
+            )}
+          </div>
+          {checks.map((c, i) => (
+            <CheckRow key={i} check={c} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/gui/src/pages/TestRuns.jsx
+++ b/gui/src/pages/TestRuns.jsx
@@ -1,0 +1,122 @@
+import React, { useState, useEffect } from 'react';
+import DataTable from '@salesforce/design-system-react/components/data-table';
+import DataTableColumn from '@salesforce/design-system-react/components/data-table/column';
+import DataTableCell from '@salesforce/design-system-react/components/data-table/cell';
+import Spinner from '@salesforce/design-system-react/components/spinner';
+import { api } from '../api.js';
+import StatusBadge from '../components/StatusBadge.jsx';
+import EmptyState from '../components/EmptyState.jsx';
+
+const StatusCell = ({ item }) => <StatusBadge status={item.status} />;
+StatusCell.displayName = DataTableCell.displayName;
+
+const CoverageCell = ({ item }) => {
+  const pct = item.coverage;
+  if (pct === undefined || pct === null) return <span style={{ color: '#919191' }}>—</span>;
+  const color = pct >= 75 ? '#2e844a' : pct >= 60 ? '#dd7a01' : '#ba0517';
+  return <span style={{ fontWeight: 700, color }}>{pct}%</span>;
+};
+CoverageCell.displayName = DataTableCell.displayName;
+
+export default function TestRuns() {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    api
+      .testRuns()
+      .then(setData)
+      .catch((e) => setError(e.message))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const rows = (data?.runs ?? []).map((r, i) => ({
+    id: String(i),
+    date: r.date ? new Date(r.date).toLocaleString() : '—',
+    passed: r.passed ?? 0,
+    failed: r.failed ?? 0,
+    errors: r.errors ?? 0,
+    coverage: r.coverage,
+    duration: r.duration ? `${(r.duration / 1000).toFixed(1)}s` : '—',
+    status: r.failed || r.errors ? 'fail' : 'pass',
+  }));
+
+  return (
+    <div style={{ padding: '28px 32px' }}>
+      <div style={{ marginBottom: '28px' }}>
+        <h1 style={{ fontSize: '24px', fontWeight: 700, color: '#032d60', margin: 0 }}>
+          Test Runs
+        </h1>
+        <p style={{ fontSize: '14px', color: '#706e6b', marginTop: '4px' }}>
+          History of Apex test executions from <code>sfdt test</code>
+        </p>
+      </div>
+
+      {loading && (
+        <div style={{ display: 'flex', justifyContent: 'center', padding: '60px' }}>
+          <Spinner size="large" variant="brand" />
+        </div>
+      )}
+
+      {error && (
+        <div
+          className="slds-notify slds-notify_alert slds-alert_error"
+          role="alert"
+          style={{ marginBottom: '20px' }}
+        >
+          <span className="slds-assistive-text">Error</span>
+          <h2>Failed to load test results: {error}</h2>
+        </div>
+      )}
+
+      {!loading && !error && rows.length === 0 && (
+        <EmptyState
+          title="No test runs found"
+          message="Run sfdt test to generate results that will appear here."
+        />
+      )}
+
+      {!loading && !error && rows.length > 0 && (
+        <div
+          style={{
+            background: '#fff',
+            borderRadius: '8px',
+            boxShadow: '0 1px 3px rgba(0,0,0,0.08)',
+            overflow: 'hidden',
+          }}
+        >
+          <DataTable items={rows} id="test-runs-table" striped>
+            <DataTableColumn label="Date" property="date" />
+            <DataTableColumn label="Passed" property="passed" />
+            <DataTableColumn label="Failed" property="failed" />
+            <DataTableColumn label="Errors" property="errors" />
+            <DataTableColumn label="Coverage" property="coverage">
+              <CoverageCell />
+            </DataTableColumn>
+            <DataTableColumn label="Duration" property="duration" />
+            <DataTableColumn label="Status" property="status">
+              <StatusCell />
+            </DataTableColumn>
+          </DataTable>
+        </div>
+      )}
+
+      {data?.summary && (
+        <div
+          style={{
+            marginTop: '20px',
+            padding: '16px 20px',
+            background: '#fff',
+            borderRadius: '8px',
+            boxShadow: '0 1px 3px rgba(0,0,0,0.08)',
+            fontSize: '13px',
+            color: '#706e6b',
+          }}
+        >
+          <strong style={{ color: '#3e3e3c' }}>Summary:</strong> {data.summary}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/gui/vite.config.js
+++ b/gui/vite.config.js
@@ -1,0 +1,59 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import { viteStaticCopy } from 'vite-plugin-static-copy';
+import { resolve } from 'path';
+
+export default defineConfig({
+  plugins: [
+    react(),
+    viteStaticCopy({
+      targets: [
+        {
+          src: resolve(
+            __dirname,
+            'node_modules/@salesforce-ux/design-system/assets/icons',
+          ),
+          dest: 'assets',
+        },
+      ],
+    }),
+  ],
+  optimizeDeps: {
+    include: [
+      '@salesforce/design-system-react/components/icon-settings',
+      '@salesforce/design-system-react/components/utilities/utility-icon/svg',
+      '@salesforce/design-system-react/components/icon',
+      '@salesforce/design-system-react/components/button',
+      '@salesforce/design-system-react/components/badge',
+      '@salesforce/design-system-react/components/card',
+      '@salesforce/design-system-react/components/data-table',
+      '@salesforce/design-system-react/components/data-table/column',
+      '@salesforce/design-system-react/components/data-table/cell',
+      '@salesforce/design-system-react/components/spinner',
+      '@salesforce/design-system-react/components/page-header',
+      '@salesforce/design-system-react/components/page-header/record-home',
+      '@salesforce/design-system-react/components/alert',
+      '@salesforce/design-system-react/components/alert/container',
+      '@salesforce/design-system-react/components/utilities/utility-icon',
+    ],
+    esbuildOptions: {
+      target: 'es2020',
+    },
+  },
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true,
+    target: 'es2020',
+    rollupOptions: {
+      input: resolve(__dirname, 'index.html'),
+    },
+  },
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:7654',
+        changeOrigin: true,
+      },
+    },
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,23 @@
 {
   "name": "@sfdt/cli",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sfdt/cli",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.4.1",
         "commander": "^13.1.0",
         "execa": "^9.5.2",
+        "express": "^4.21.2",
         "fs-extra": "^11.3.0",
         "glob": "^13.0.6",
         "inquirer": "^13.3.2",
+        "open": "^10.1.0",
         "ora": "^9.3.0"
       },
       "bin": {
@@ -1680,6 +1682,19 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -1755,6 +1770,12 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1784,6 +1805,57 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/body-parser": {
+      "version": "1.20.4",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
+      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.14.0",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/body-parser/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/body-parser/node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/body-parser/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
@@ -1795,6 +1867,30 @@
         "concat-map": "0.0.1"
       }
     },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -1803,6 +1899,35 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/callsites": {
@@ -1932,6 +2057,42 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -1981,6 +2142,79 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/default-browser": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -1988,12 +2222,57 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.27.4",
@@ -2036,6 +2315,12 @@
         "@esbuild/win32-ia32": "0.27.4",
         "@esbuild/win32-x64": "0.27.4"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -2231,6 +2516,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/execa": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
@@ -2266,6 +2560,67 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/express": {
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
+      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.3",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.14.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/express/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -2358,6 +2713,39 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/finalhandler/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/finalhandler/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -2413,6 +2801,24 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/fs-extra": {
       "version": "11.3.4",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
@@ -2442,6 +2848,15 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/get-east-asian-width": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
@@ -2452,6 +2867,43 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-stream": {
@@ -2549,6 +3001,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -2565,12 +3029,56 @@
         "node": ">=8"
       }
     },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/human-signals": {
       "version": "8.0.1",
@@ -2634,6 +3142,12 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
     "node_modules/inquirer": {
       "version": "13.3.2",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-13.3.2.tgz",
@@ -2658,6 +3172,30 @@
         "@types/node": {
           "optional": true
         }
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-extglob": {
@@ -2691,6 +3229,24 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-interactive": {
@@ -2736,6 +3292,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -2971,6 +3542,75 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/mimic-function": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
@@ -3009,7 +3649,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mute-stream": {
@@ -3047,6 +3686,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/npm-run-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
@@ -3075,6 +3723,30 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/onetime": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
@@ -3082,6 +3754,24 @@
       "license": "MIT",
       "dependencies": {
         "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "wsl-utils": "^0.1.0"
       },
       "engines": {
         "node": ">=18"
@@ -3194,6 +3884,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -3228,6 +3927,12 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -3336,6 +4041,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3344,6 +4062,57 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve-from": {
@@ -3417,6 +4186,18 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/run-async": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-4.0.6.tgz",
@@ -3434,6 +4215,26 @@
       "dependencies": {
         "tslib": "^2.1.0"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -3454,6 +4255,66 @@
         "node": ">=10"
       }
     },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/send/node_modules/debug/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -3473,6 +4334,78 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/siginfo": {
@@ -3510,6 +4443,15 @@
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/std-env": {
       "version": "3.10.0",
@@ -3973,6 +4915,15 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -3990,6 +4941,19 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/unicorn-magic": {
@@ -4013,6 +4977,15 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -4021,6 +4994,24 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/vite": {
@@ -4298,6 +5289,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,11 @@
     "bin/",
     "src/",
     "scripts/",
+    "gui/dist/",
+    "gui/package.json",
+    "gui/vite.config.js",
+    "gui/index.html",
+    "gui/src/",
     "README.md",
     "LICENSE",
     "SECURITY.md"
@@ -26,6 +31,7 @@
     "lint:fix": "eslint src/ bin/ --fix",
     "format": "prettier --write \"src/**/*.js\" \"bin/*.js\" \"test/**/*.js\" \"README.md\" \"package.json\"",
     "dev": "npm link",
+    "build:gui": "cd gui && npm install && npm run build",
     "postinstall": "node scripts/postinstall.js",
     "prepublishOnly": "npm test && npm run lint"
   },
@@ -52,9 +58,11 @@
     "chalk": "^5.4.1",
     "commander": "^13.1.0",
     "execa": "^9.5.2",
+    "express": "^4.21.2",
     "fs-extra": "^11.3.0",
     "glob": "^13.0.6",
     "inquirer": "^13.3.2",
+    "open": "^10.1.0",
     "ora": "^9.3.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sfdt/cli",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Salesforce DevTools — Production-grade CLI for Salesforce DX deployment, testing, quality analysis, and release management",
   "type": "module",
   "bin": {

--- a/src/cli.js
+++ b/src/cli.js
@@ -19,6 +19,7 @@ import { registerChangelogCommand } from './commands/changelog.js';
 import { registerManifestCommand } from './commands/manifest.js';
 import { registerExplainCommand } from './commands/explain.js';
 import { registerPrDescriptionCommand } from './commands/prDescription.js';
+import { registerUiCommand } from './commands/ui.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const pkg = JSON.parse(readFileSync(path.resolve(__dirname, '..', 'package.json'), 'utf-8'));
@@ -50,6 +51,7 @@ export function createCli() {
   registerManifestCommand(program);
   registerExplainCommand(program);
   registerPrDescriptionCommand(program);
+  registerUiCommand(program);
 
   return program;
 }

--- a/src/commands/changelog.js
+++ b/src/commands/changelog.js
@@ -107,6 +107,11 @@ export function registerChangelogCommand(program) {
     .command('release <version>')
     .description('Move [Unreleased] changes to a new version section')
     .action(async (version) => {
+      if (!/^\d+\.\d+\.\d+(-[\w.]+)?(\+[\w.]+)?$/.test(version)) {
+        print.error(`Invalid version: ${version} (expected semver e.g. 1.2.3)`);
+        process.exitCode = 1;
+        return;
+      }
       try {
         const config = await loadConfig();
         print.info(`Releasing version ${version} in CHANGELOG.md...`);

--- a/src/commands/changelog.js
+++ b/src/commands/changelog.js
@@ -2,7 +2,7 @@ import inquirer from 'inquirer';
 import fs from 'fs-extra';
 import path from 'path';
 import { loadConfig } from '../lib/config.js';
-import { isClaudeAvailable, runAiPrompt } from '../lib/ai.js';
+import { isAiAvailable, runAiPrompt } from '../lib/ai.js';
 import { print } from '../lib/output.js';
 import { execa } from 'execa';
 
@@ -39,10 +39,10 @@ export function registerChangelogCommand(program) {
           }
         }
 
-        if (!config.features?.ai || !(await isClaudeAvailable())) {
-          print.error('AI features are disabled or Claude CLI is not installed.');
+        if (!config.features?.ai || !(await isAiAvailable(config))) {
+          print.error('AI features are disabled or no AI provider is configured.');
           print.info(
-            'To enable AI, set features.ai: true in .sfdt/config.json and install @anthropic-ai/claude-code',
+            'Set features.ai: true and configure ai.provider in .sfdt/config.json.',
           );
           return;
         }
@@ -63,6 +63,7 @@ export function registerChangelogCommand(program) {
 
         print.header('AI Changelog Generation');
         const response = await runAiPrompt(prompt, {
+          config,
           allowedTools: ['Bash(git log:*)', 'Read'],
           cwd: projectRoot,
           aiEnabled: true,

--- a/src/commands/explain.js
+++ b/src/commands/explain.js
@@ -2,7 +2,7 @@ import fs from 'fs-extra';
 import path from 'path';
 import { glob } from 'glob';
 import { loadConfig } from '../lib/config.js';
-import { isClaudeAvailable, runAiPrompt } from '../lib/ai.js';
+import { isAiAvailable, aiUnavailableMessage, runAiPrompt } from '../lib/ai.js';
 import { print } from '../lib/output.js';
 
 const MAX_LOG_SIZE_BYTES = 512 * 1024; // 512 KB cap sent to the model
@@ -104,15 +104,14 @@ export function registerExplainCommand(program) {
           return;
         }
 
-        if (!(await isClaudeAvailable())) {
-          print.info(
-            'Claude CLI is not installed — heuristic analysis only. Install from https://docs.anthropic.com/en/docs/claude-cli for AI insights.',
-          );
+        if (!(await isAiAvailable(config))) {
+          print.info(`${aiUnavailableMessage(config)} — heuristic analysis only.`);
           return;
         }
 
         print.header('AI Error Analysis');
         await runAiPrompt(EXPLAIN_PROMPT + trimmed.content, {
+          config,
           allowedTools: ['Read', 'Grep', 'Glob'],
           cwd: projectRoot,
           aiEnabled: true,

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -10,7 +10,7 @@ const CONFIG_DIR = '.sfdt';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const TEMPLATE_PATH = path.join(__dirname, '../templates/sfdt.config.json');
 
-async function buildConfigTemplate({ projectName, defaultOrg, features, releaseNotesDir, coverageThreshold }) {
+async function buildConfigTemplate({ projectName, defaultOrg, features, releaseNotesDir, coverageThreshold, ai }) {
   const template = await fs.readJson(TEMPLATE_PATH);
   return {
     ...template,
@@ -24,6 +24,11 @@ async function buildConfigTemplate({ projectName, defaultOrg, features, releaseN
     features: {
       ...template.features,
       ai: features.ai,
+    },
+    ai: {
+      provider: ai.provider,
+      model: ai.model || '',
+      apiKey: ai.apiKey || '',
     },
   };
 }
@@ -129,8 +134,30 @@ export function registerInitCommand(program) {
           {
             type: 'confirm',
             name: 'aiEnabled',
-            message: 'Enable AI-powered features (requires Claude CLI)?',
+            message: 'Enable AI-powered features?',
             default: true,
+          },
+          {
+            type: 'list',
+            name: 'aiProvider',
+            message: 'AI provider:',
+            choices: [
+              { name: 'Claude (requires Claude Code CLI)', value: 'claude' },
+              { name: 'Gemini (requires GEMINI_API_KEY)', value: 'gemini' },
+              { name: 'OpenAI (requires OPENAI_API_KEY)', value: 'openai' },
+            ],
+            default: 'claude',
+            when: (ans) => ans.aiEnabled,
+          },
+          {
+            type: 'input',
+            name: 'aiApiKey',
+            message: (ans) =>
+              ans.aiProvider === 'gemini'
+                ? 'Gemini API key (or leave blank to use GEMINI_API_KEY env var):'
+                : 'OpenAI API key (or leave blank to use OPENAI_API_KEY env var):',
+            default: '',
+            when: (ans) => ans.aiEnabled && ans.aiProvider !== 'claude',
           },
           {
             type: 'input',
@@ -182,6 +209,11 @@ export function registerInitCommand(program) {
             notifications: false,
             releaseManagement: true,
           },
+          ai: {
+            provider: answers.aiProvider || 'claude',
+            model: '',
+            apiKey: answers.aiApiKey || '',
+          },
         });
 
         const environments = buildEnvironmentsTemplate(answers.defaultOrg);
@@ -216,7 +248,7 @@ export function registerInitCommand(program) {
         print.step(`  Project: ${answers.projectName}`);
         print.step(`  Default org: ${answers.defaultOrg}`);
         print.step(`  Coverage threshold: ${answers.coverageThreshold}%`);
-        print.step(`  AI features: ${answers.aiEnabled ? 'enabled' : 'disabled'}`);
+        print.step(`  AI features: ${answers.aiEnabled ? `enabled (${answers.aiProvider || 'claude'})` : 'disabled'}`);
         print.step(`  Test classes: ${testClasses.length}`);
         print.step(`  Apex classes: ${apexClasses.length}`);
 

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -5,6 +5,7 @@ import { glob } from 'glob';
 import inquirer from 'inquirer';
 import { detectProject, getProjectRoot } from '../lib/project-detect.js';
 import { print } from '../lib/output.js';
+import { storeCredential } from '../lib/ai.js';
 
 const CONFIG_DIR = '.sfdt';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -28,7 +29,7 @@ async function buildConfigTemplate({ projectName, defaultOrg, features, releaseN
     ai: {
       provider: ai.provider,
       model: ai.model || '',
-      apiKey: ai.apiKey || '',
+      // API keys are stored in ~/.sfdt/credentials.json, not here
     },
   };
 }
@@ -150,14 +151,15 @@ export function registerInitCommand(program) {
             when: (ans) => ans.aiEnabled,
           },
           {
-            type: 'input',
+            type: 'password',
             name: 'aiApiKey',
             message: (ans) =>
               ans.aiProvider === 'gemini'
-                ? 'Gemini API key (or leave blank to use GEMINI_API_KEY env var):'
-                : 'OpenAI API key (or leave blank to use OPENAI_API_KEY env var):',
+                ? 'Gemini API key (stored in ~/.sfdt/credentials.json, or leave blank to use GEMINI_API_KEY env var):'
+                : 'OpenAI API key (stored in ~/.sfdt/credentials.json, or leave blank to use OPENAI_API_KEY env var):',
             default: '',
             when: (ans) => ans.aiEnabled && ans.aiProvider !== 'claude',
+            mask: '*',
           },
           {
             type: 'input',
@@ -199,6 +201,12 @@ export function registerInitCommand(program) {
         // Create .sfdt/ directory
         await fs.ensureDir(configDir);
 
+        // Persist the API key to ~/.sfdt/credentials.json (never into the project config)
+        if (answers.aiEnabled && answers.aiProvider !== 'claude' && answers.aiApiKey) {
+          await storeCredential(answers.aiProvider, answers.aiApiKey);
+          print.success(`API key stored in ~/.sfdt/credentials.json (mode 0600)`);
+        }
+
         const config = await buildConfigTemplate({
           projectName: answers.projectName,
           defaultOrg: answers.defaultOrg,
@@ -212,7 +220,6 @@ export function registerInitCommand(program) {
           ai: {
             provider: answers.aiProvider || 'claude',
             model: '',
-            apiKey: answers.aiApiKey || '',
           },
         });
 

--- a/src/commands/manifest.js
+++ b/src/commands/manifest.js
@@ -2,7 +2,7 @@ import fs from 'fs-extra';
 import path from 'path';
 import { execa } from 'execa';
 import { loadConfig } from '../lib/config.js';
-import { isClaudeAvailable, runAiPrompt } from '../lib/ai.js';
+import { isAiAvailable, runAiPrompt } from '../lib/ai.js';
 import { print } from '../lib/output.js';
 import {
   parseDiffToMetadata,
@@ -121,11 +121,12 @@ export function registerManifestCommand(program) {
         const aiEnabled = config.features?.ai;
         const shouldRunAi = options.aiCleanup ?? aiEnabled;
 
-        if (shouldRunAi && aiEnabled && (await isClaudeAvailable())) {
+        if (shouldRunAi && aiEnabled && (await isAiAvailable(config))) {
           print.header('AI Dependency Cleanup');
-          print.info('Asking Claude to check for missing dependencies...');
+          print.info('Asking AI to check for missing dependencies...');
 
           await runAiPrompt(AI_DEPENDENCY_PROMPT + packageXml, {
+            config,
             allowedTools: ['Read', 'Grep', 'Glob'],
             cwd: projectRoot,
             aiEnabled: true,
@@ -134,7 +135,7 @@ export function registerManifestCommand(program) {
         } else if (shouldRunAi && !aiEnabled) {
           print.info('AI features are disabled (features.ai=false) — skipping dependency cleanup.');
         } else if (shouldRunAi) {
-          print.info('Claude CLI not available — skipping AI dependency cleanup.');
+          print.info('AI provider not available — skipping dependency cleanup.');
         }
       } catch (err) {
         print.error(`Manifest generation failed: ${err.message}`);

--- a/src/commands/prDescription.js
+++ b/src/commands/prDescription.js
@@ -2,7 +2,7 @@ import fs from 'fs-extra';
 import path from 'path';
 import { execa } from 'execa';
 import { loadConfig } from '../lib/config.js';
-import { isClaudeAvailable, runAiPrompt } from '../lib/ai.js';
+import { isAiAvailable, aiUnavailableMessage, runAiPrompt } from '../lib/ai.js';
 import { print } from '../lib/output.js';
 import { parseDiffToMetadata, countMembers } from '../lib/metadata-mapper.js';
 
@@ -82,11 +82,8 @@ export function registerPrDescriptionCommand(program) {
           return;
         }
 
-        if (!(await isClaudeAvailable())) {
-          print.error(
-            'Claude CLI is not installed or not in PATH.\n' +
-              '  Install from: https://docs.anthropic.com/en/docs/claude-cli',
-          );
+        if (!(await isAiAvailable(config))) {
+          print.error(aiUnavailableMessage(config));
           process.exitCode = 1;
           return;
         }
@@ -103,6 +100,7 @@ export function registerPrDescriptionCommand(program) {
         const prompt = buildPrompt(options.format, context);
 
         const response = await runAiPrompt(prompt, {
+          config,
           allowedTools: ['Read', 'Grep'],
           cwd: projectRoot,
           aiEnabled: true,

--- a/src/commands/quality.js
+++ b/src/commands/quality.js
@@ -1,6 +1,6 @@
 import { loadConfig } from '../lib/config.js';
 import { runScript } from '../lib/script-runner.js';
-import { isClaudeAvailable, runAiPrompt } from '../lib/ai.js';
+import { isAiAvailable, runAiPrompt } from '../lib/ai.js';
 import { print } from '../lib/output.js';
 
 export function registerQualityCommand(program) {
@@ -52,7 +52,7 @@ export function registerQualityCommand(program) {
         // AI fix plan
         if (options.fixPlan) {
           const aiEnabled = config.features?.ai;
-          if (aiEnabled && (await isClaudeAvailable())) {
+          if (aiEnabled && (await isAiAvailable(config))) {
             print.info('Generating AI fix plan...');
 
             const prompt = [
@@ -66,6 +66,7 @@ export function registerQualityCommand(program) {
             ].join('\n');
 
             await runAiPrompt(prompt, {
+              config,
               allowedTools: ['Read', 'Grep'],
               cwd: projectRoot,
               aiEnabled: true,

--- a/src/commands/release.js
+++ b/src/commands/release.js
@@ -4,7 +4,7 @@ import { execa } from 'execa';
 import inquirer from 'inquirer';
 import { loadConfig } from '../lib/config.js';
 import { runScript } from '../lib/script-runner.js';
-import { isClaudeAvailable, runAiPrompt } from '../lib/ai.js';
+import { isAiAvailable, runAiPrompt } from '../lib/ai.js';
 import { print } from '../lib/output.js';
 
 export function registerReleaseCommand(program) {
@@ -33,7 +33,7 @@ export function registerReleaseCommand(program) {
 
         // Offer AI release notes if enabled
         const aiEnabled = config.features?.ai;
-        if (aiEnabled && (await isClaudeAvailable())) {
+        if (aiEnabled && (await isAiAvailable(config))) {
           const { generateNotes } = await inquirer.prompt([
             {
               type: 'confirm',
@@ -62,6 +62,7 @@ export function registerReleaseCommand(program) {
             ].join('\n');
 
             await runAiPrompt(prompt, {
+              config,
               allowedTools: ['Bash(git log:*)', 'Read', 'Write'],
               cwd: projectRoot,
               aiEnabled: true,

--- a/src/commands/review.js
+++ b/src/commands/review.js
@@ -1,6 +1,6 @@
 import { execa } from 'execa';
 import { loadConfig } from '../lib/config.js';
-import { isClaudeAvailable, runAiPrompt } from '../lib/ai.js';
+import { isAiAvailable, aiUnavailableMessage, runAiPrompt } from '../lib/ai.js';
 import { print } from '../lib/output.js';
 
 const REVIEW_PROMPT = `You are a senior Salesforce developer reviewing a code diff. Analyze the following changes and report issues in these categories:
@@ -57,11 +57,8 @@ export function registerReviewCommand(program) {
           return;
         }
 
-        if (!(await isClaudeAvailable())) {
-          print.error(
-            'Claude CLI is not installed or not in PATH.\n' +
-              '  Install from: https://docs.anthropic.com/en/docs/claude-cli',
-          );
+        if (!(await isAiAvailable(config))) {
+          print.error(aiUnavailableMessage(config));
           process.exitCode = 1;
           return;
         }
@@ -87,6 +84,7 @@ export function registerReviewCommand(program) {
         const prompt = REVIEW_PROMPT + diff;
 
         await runAiPrompt(prompt, {
+          config,
           allowedTools: ['Read', 'Grep'],
           cwd: projectRoot,
           aiEnabled: true,

--- a/src/commands/test.js
+++ b/src/commands/test.js
@@ -1,7 +1,7 @@
 import inquirer from 'inquirer';
 import { loadConfig } from '../lib/config.js';
 import { runScript } from '../lib/script-runner.js';
-import { isClaudeAvailable, runAiPrompt } from '../lib/ai.js';
+import { isAiAvailable, runAiPrompt } from '../lib/ai.js';
 import { print } from '../lib/output.js';
 
 export function registerTestCommand(program) {
@@ -45,7 +45,7 @@ export function registerTestCommand(program) {
         // Offer AI analysis on failure
         if (testFailed) {
           const aiEnabled = config.features?.ai;
-          if (aiEnabled && (await isClaudeAvailable())) {
+          if (aiEnabled && (await isAiAvailable(config))) {
             const { analyzeFailure } = await inquirer.prompt([
               {
                 type: 'confirm',
@@ -66,6 +66,7 @@ export function registerTestCommand(program) {
               ].join('\n');
 
               await runAiPrompt(prompt, {
+                config,
                 allowedTools: ['Read', 'Grep', 'Bash(sf apex test:*)'],
                 cwd: projectRoot,
                 aiEnabled: true,

--- a/src/commands/ui.js
+++ b/src/commands/ui.js
@@ -1,0 +1,71 @@
+import { readFileSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { loadConfig } from '../lib/config.js';
+import { print } from '../lib/output.js';
+import { startGuiServer } from '../lib/gui-server.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const pkg = JSON.parse(
+  readFileSync(path.resolve(__dirname, '..', '..', 'package.json'), 'utf-8'),
+);
+
+const DEFAULT_PORT = 7654;
+
+export function registerUiCommand(program) {
+  program
+    .command('ui')
+    .description('Launch the local SFDT web dashboard (test results, drift, preflight)')
+    .option('-p, --port <number>', 'Port to listen on', String(DEFAULT_PORT))
+    .option('--no-open', 'Do not automatically open the browser')
+    .action(async (options) => {
+      const port = parseInt(options.port, 10) || DEFAULT_PORT;
+
+      let config;
+      try {
+        config = await loadConfig();
+      } catch {
+        // Allow running ui without an sfdt project (shows empty data)
+        config = { _projectRoot: process.cwd() };
+      }
+
+      print.header('SFDT Dashboard');
+
+      let server;
+      try {
+        server = await startGuiServer(port, config, pkg.version);
+      } catch (err) {
+        if (err.code === 'EADDRINUSE') {
+          print.error(`Port ${port} is already in use. Try: sfdt ui --port <other>`);
+        } else {
+          print.error(`Failed to start server: ${err.message}`);
+        }
+        process.exitCode = 1;
+        return;
+      }
+
+      const url = `http://localhost:${port}`;
+      print.success(`Dashboard running at ${url}`);
+      print.info('Press Ctrl+C to stop.');
+
+      // Open browser unless suppressed
+      if (options.open !== false) {
+        try {
+          const { default: open } = await import('open');
+          await open(url);
+        } catch {
+          // `open` is optional — non-fatal if unavailable
+          print.info(`Open ${url} in your browser.`);
+        }
+      }
+
+      // Keep the process alive until Ctrl+C
+      process.on('SIGINT', () => {
+        print.info('\nStopping dashboard…');
+        server.close(() => process.exit(0));
+      });
+      process.on('SIGTERM', () => {
+        server.close(() => process.exit(0));
+      });
+    });
+}

--- a/src/lib/ai.js
+++ b/src/lib/ai.js
@@ -1,4 +1,34 @@
 import { execa } from 'execa';
+import fs from 'fs-extra';
+import path from 'path';
+import os from 'os';
+
+// ─── Credential storage ───────────────────────────────────────────────────────
+
+const SFDT_HOME = path.join(os.homedir(), '.sfdt');
+const CREDENTIALS_FILE = path.join(SFDT_HOME, 'credentials.json');
+
+async function readStoredCredentials() {
+  try {
+    if (await fs.pathExists(CREDENTIALS_FILE)) {
+      return await fs.readJson(CREDENTIALS_FILE);
+    }
+  } catch {
+    // ignore corrupt/missing file
+  }
+  return {};
+}
+
+/**
+ * Persist an API key for a provider to ~/.sfdt/credentials.json (mode 0600).
+ */
+export async function storeCredential(provider, apiKey) {
+  await fs.ensureDir(SFDT_HOME);
+  const existing = await readStoredCredentials();
+  existing[provider] = { apiKey };
+  await fs.writeJson(CREDENTIALS_FILE, existing, { spaces: 2 });
+  await fs.chmod(CREDENTIALS_FILE, 0o600);
+}
 
 // ─── Provider helpers ─────────────────────────────────────────────────────────
 
@@ -26,19 +56,24 @@ export async function isClaudeAvailable() {
 
 /**
  * Resolve the API key for a given provider.
- * Priority: config.ai.apiKey → provider-specific env var.
+ * Priority: ~/.sfdt/credentials.json → provider env vars → legacy config.ai.apiKey.
  */
-function resolveApiKey(config, provider) {
-  if (config?.ai?.apiKey) return config.ai.apiKey;
+async function resolveApiKey(config, provider) {
+  // 1. User-level credentials file
+  const creds = await readStoredCredentials();
+  if (creds[provider]?.apiKey) return creds[provider].apiKey;
 
+  // 2. Environment variables
   const envVars = {
     gemini: ['GEMINI_API_KEY', 'GOOGLE_AI_API_KEY', 'GOOGLE_GENERATIVE_AI_API_KEY'],
     openai: ['OPENAI_API_KEY'],
   };
-
   for (const envVar of envVars[provider] ?? []) {
     if (process.env[envVar]) return process.env[envVar];
   }
+
+  // 3. Legacy: config.ai.apiKey (backwards compat — do not write here going forward)
+  if (config?.ai?.apiKey) return config.ai.apiKey;
 
   return null;
 }
@@ -53,8 +88,6 @@ export function getConfiguredProvider(config) {
 
 /**
  * Check whether the configured AI provider is usable.
- * For Claude: requires the `claude` CLI in PATH.
- * For Gemini/OpenAI: requires an API key in config or env.
  */
 export async function isAiAvailable(config) {
   if (!config?.features?.ai) return false;
@@ -65,9 +98,9 @@ export async function isAiAvailable(config) {
     case 'claude':
       return isClaudeAvailable();
     case 'gemini':
-      return !!resolveApiKey(config, 'gemini');
+      return !!(await resolveApiKey(config, 'gemini'));
     case 'openai':
-      return !!resolveApiKey(config, 'openai');
+      return !!(await resolveApiKey(config, 'openai'));
     default:
       return false;
   }
@@ -88,16 +121,233 @@ export function aiUnavailableMessage(config) {
     case 'gemini':
       return (
         'Gemini API key not found. ' +
-        'Set GEMINI_API_KEY in your environment or add ai.apiKey to .sfdt/config.json.'
+        'Set GEMINI_API_KEY in your environment or run `sfdt init` to store it in ~/.sfdt/credentials.json.'
       );
     case 'openai':
       return (
         'OpenAI API key not found. ' +
-        'Set OPENAI_API_KEY in your environment or add ai.apiKey to .sfdt/config.json.'
+        'Set OPENAI_API_KEY in your environment or run `sfdt init` to store it in ~/.sfdt/credentials.json.'
       );
     default:
       return `Unknown AI provider "${provider}". Supported: claude, gemini, openai.`;
   }
+}
+
+// ─── Local tool execution ─────────────────────────────────────────────────────
+
+/**
+ * Translate Claude-style allowedTools names to local tool names.
+ *   'Read'           → read_file
+ *   'Write'          → write_file
+ *   'Grep'           → grep_files
+ *   'LS' / 'Glob'    → list_directory
+ *   'Bash(git ...)'  → run_git
+ */
+function mapAllowedTools(allowedTools) {
+  if (!allowedTools || allowedTools.length === 0) return [];
+  const tools = new Set();
+  for (const tool of allowedTools) {
+    if (tool === 'Read') tools.add('read_file');
+    if (tool === 'Write') tools.add('write_file');
+    if (tool === 'Grep') tools.add('grep_files');
+    if (tool === 'LS' || tool === 'Glob') tools.add('list_directory');
+    if (tool.startsWith('Bash')) tools.add('run_git');
+  }
+  return [...tools];
+}
+
+const ALLOWED_GIT_SUBCOMMANDS = new Set([
+  'log', 'diff', 'status', 'show', 'branch', 'tag',
+  'remote', 'ls-files', 'rev-parse', 'describe',
+]);
+
+/**
+ * Resolve a user-supplied path and assert it stays within the project root.
+ * Returns the resolved absolute path, or throws if the path escapes cwd.
+ */
+async function safeResolvePath(base, relative) {
+  if (relative === undefined || relative === null) return base;
+  // Reject absolute paths and obvious traversal attempts outright
+  if (path.isAbsolute(relative)) {
+    throw new Error(`absolute paths are not allowed: ${relative}`);
+  }
+  const resolved = path.resolve(base, relative);
+  // Normalise the base so symlinks don't bypass the check
+  let realBase;
+  try {
+    realBase = await fs.realpath(base);
+  } catch {
+    realBase = path.resolve(base);
+  }
+  if (resolved !== realBase && !resolved.startsWith(realBase + path.sep)) {
+    throw new Error(`path traversal detected: ${relative}`);
+  }
+  return resolved;
+}
+
+/**
+ * Execute a single local tool call. Returns a string result.
+ */
+async function executeLocalTool(toolName, args, cwd) {
+  try {
+    switch (toolName) {
+      case 'read_file': {
+        const filePath = await safeResolvePath(cwd, args.path);
+        if (!(await fs.pathExists(filePath))) return `Error: file not found: ${args.path}`;
+        const content = await fs.readFile(filePath, 'utf8');
+        return content.length > 50000 ? content.slice(0, 50000) + '\n...(truncated)' : content;
+      }
+
+      case 'write_file': {
+        const filePath = await safeResolvePath(cwd, args.path);
+        await fs.ensureDir(path.dirname(filePath));
+        await fs.writeFile(filePath, args.content);
+        return `Successfully wrote ${args.content.length} bytes to ${args.path}`;
+      }
+
+      case 'list_directory': {
+        const dirPath = args.path ? await safeResolvePath(cwd, args.path) : cwd;
+        if (!(await fs.pathExists(dirPath))) return `Error: directory not found: ${args.path || '.'}`;
+        const entries = await fs.readdir(dirPath, { withFileTypes: true });
+        return entries.map((e) => `${e.isDirectory() ? 'd' : 'f'} ${e.name}`).join('\n');
+      }
+
+      case 'run_git': {
+        const gitArgs = Array.isArray(args.args)
+          ? args.args
+          : String(args.command || '').split(/\s+/).filter(Boolean);
+        const subcommand = gitArgs[0];
+        if (!ALLOWED_GIT_SUBCOMMANDS.has(subcommand)) {
+          return `Error: git subcommand "${subcommand}" is not allowed. Allowed: ${[...ALLOWED_GIT_SUBCOMMANDS].join(', ')}`;
+        }
+        const result = await execa('git', gitArgs, { cwd, reject: false });
+        const out = result.stdout || '';
+        const err = result.stderr ? `\nstderr: ${result.stderr}` : '';
+        return (out + err) || '(empty output)';
+      }
+
+      case 'grep_files': {
+        if (!args.pattern) return 'Error: pattern is required';
+        const searchPath = args.path ? await safeResolvePath(cwd, args.path) : cwd;
+        const result = await execa(
+          'grep',
+          ['-r', '-n', '--include=*.cls', '--include=*.js', '--include=*.html',
+           '--include=*.json', '--include=*.xml', args.pattern, searchPath],
+          { cwd, reject: false },
+        );
+        const output = result.stdout || '';
+        return output.length > 10000
+          ? output.slice(0, 10000) + '\n...(truncated)'
+          : output || '(no matches)';
+      }
+
+      default:
+        return `Error: unknown tool "${toolName}"`;
+    }
+  } catch (err) {
+    return `Error executing ${toolName}: ${err.message}`;
+  }
+}
+
+// ─── Tool schema definitions ──────────────────────────────────────────────────
+
+// Gemini uses uppercase types (OBJECT, STRING, ARRAY); we convert to lowercase for OpenAI.
+const TOOL_SCHEMAS = {
+  read_file: {
+    name: 'read_file',
+    description: 'Read the contents of a file from the project',
+    parameters: {
+      type: 'OBJECT',
+      properties: {
+        path: { type: 'STRING', description: 'File path relative to project root' },
+      },
+      required: ['path'],
+    },
+  },
+  write_file: {
+    name: 'write_file',
+    description: 'Write content to a file in the project',
+    parameters: {
+      type: 'OBJECT',
+      properties: {
+        path: { type: 'STRING', description: 'File path relative to project root' },
+        content: { type: 'STRING', description: 'Content to write to the file' },
+      },
+      required: ['path', 'content'],
+    },
+  },
+  list_directory: {
+    name: 'list_directory',
+    description: 'List files and directories at a path',
+    parameters: {
+      type: 'OBJECT',
+      properties: {
+        path: { type: 'STRING', description: 'Directory path relative to project root (omit for root)' },
+      },
+    },
+  },
+  run_git: {
+    name: 'run_git',
+    description: 'Run a read-only git command (log, diff, status, show, branch, etc.)',
+    parameters: {
+      type: 'OBJECT',
+      properties: {
+        args: {
+          type: 'ARRAY',
+          items: { type: 'STRING' },
+          description: 'Git arguments after "git", e.g. ["log", "--oneline", "-20"]',
+        },
+      },
+      required: ['args'],
+    },
+  },
+  grep_files: {
+    name: 'grep_files',
+    description: 'Search for a pattern in project source files',
+    parameters: {
+      type: 'OBJECT',
+      properties: {
+        pattern: { type: 'STRING', description: 'Search pattern (grep-compatible)' },
+        path: {
+          type: 'STRING',
+          description: 'Directory or file to search (optional, defaults to project root)',
+        },
+      },
+      required: ['pattern'],
+    },
+  },
+};
+
+function buildGeminiToolDefs(toolNames) {
+  return toolNames.map((n) => TOOL_SCHEMAS[n]).filter(Boolean);
+}
+
+function convertSchemaToOpenAi(schema) {
+  if (!schema || typeof schema !== 'object') return schema;
+  const result = { ...schema };
+  if (typeof result.type === 'string') result.type = result.type.toLowerCase();
+  if (result.properties) {
+    result.properties = Object.fromEntries(
+      Object.entries(result.properties).map(([k, v]) => [k, convertSchemaToOpenAi(v)]),
+    );
+  }
+  if (result.items) result.items = convertSchemaToOpenAi(result.items);
+  return result;
+}
+
+function buildOpenAiToolDefs(toolNames) {
+  return toolNames.map((n) => {
+    const def = TOOL_SCHEMAS[n];
+    if (!def) return null;
+    return {
+      type: 'function',
+      function: {
+        name: def.name,
+        description: def.description,
+        parameters: convertSchemaToOpenAi(def.parameters),
+      },
+    };
+  }).filter(Boolean);
 }
 
 // ─── Claude provider ──────────────────────────────────────────────────────────
@@ -138,66 +388,36 @@ async function runClaudePrompt(prompt, options) {
 
 const GEMINI_DEFAULT_MODEL = 'gemini-2.0-flash';
 const GEMINI_BASE_URL = 'https://generativelanguage.googleapis.com/v1beta/models';
+const MAX_TOOL_ITERATIONS = 10;
 
 async function runGeminiPrompt(prompt, options, config) {
-  const apiKey = resolveApiKey(config, 'gemini');
+  const apiKey = await resolveApiKey(config, 'gemini');
   if (!apiKey) {
     console.log(aiUnavailableMessage(config));
     return null;
   }
 
   const model = config?.ai?.model || GEMINI_DEFAULT_MODEL;
-  const { interactive = false } = options;
+  const { interactive = false, allowedTools, cwd = process.cwd() } = options;
 
-  const body = JSON.stringify({
-    contents: [{ role: 'user', parts: [{ text: prompt }] }],
-  });
+  const enabledTools = mapAllowedTools(allowedTools);
+  const toolDefs = buildGeminiToolDefs(enabledTools);
 
-  const headers = { 'Content-Type': 'application/json' };
+  const messages = [{ role: 'user', parts: [{ text: prompt }] }];
+  let finalText = '';
 
-  if (interactive) {
-    // Streaming mode — write tokens to stdout as they arrive
-    const url = `${GEMINI_BASE_URL}/${model}:streamGenerateContent?key=${apiKey}&alt=sse`;
-    const res = await fetch(url, { method: 'POST', headers, body });
-
-    if (!res.ok) {
-      const errText = await res.text();
-      throw new Error(`Gemini API error ${res.status}: ${errText}`);
+  for (let i = 0; i < MAX_TOOL_ITERATIONS; i++) {
+    const body = { contents: messages };
+    if (toolDefs.length > 0) {
+      body.tools = [{ functionDeclarations: toolDefs }];
     }
 
-    let fullText = '';
-    const reader = res.body.getReader();
-    const decoder = new TextDecoder();
-
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
-
-      const chunk = decoder.decode(value, { stream: true });
-      for (const line of chunk.split('\n')) {
-        if (!line.startsWith('data: ')) continue;
-        const data = line.slice(6).trim();
-        if (!data || data === '[DONE]') continue;
-
-        try {
-          const parsed = JSON.parse(data);
-          const text = parsed.candidates?.[0]?.content?.parts?.[0]?.text ?? '';
-          if (text) {
-            process.stdout.write(text);
-            fullText += text;
-          }
-        } catch {
-          // ignore malformed SSE frames
-        }
-      }
-    }
-
-    if (fullText) process.stdout.write('\n');
-    return { stdout: fullText, stderr: '', exitCode: 0 };
-  } else {
-    // Non-streaming — capture full response
     const url = `${GEMINI_BASE_URL}/${model}:generateContent?key=${apiKey}`;
-    const res = await fetch(url, { method: 'POST', headers, body });
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
 
     if (!res.ok) {
       const errText = await res.text();
@@ -205,9 +425,38 @@ async function runGeminiPrompt(prompt, options, config) {
     }
 
     const json = await res.json();
-    const text = json.candidates?.[0]?.content?.parts?.[0]?.text ?? '';
-    return { stdout: text, stderr: '', exitCode: 0 };
+    const parts = json.candidates?.[0]?.content?.parts ?? [];
+
+    const funcCalls = parts.filter((p) => p.functionCall);
+
+    if (funcCalls.length > 0) {
+      // Add the model turn to history
+      messages.push({ role: 'model', parts });
+
+      // Execute each tool and feed results back
+      const funcResponses = [];
+      for (const part of funcCalls) {
+        const { name, args: toolArgs } = part.functionCall;
+        const result = await executeLocalTool(name, toolArgs || {}, cwd);
+        funcResponses.push({
+          functionResponse: { name, response: { output: result } },
+        });
+      }
+      messages.push({ role: 'user', parts: funcResponses });
+      continue;
+    }
+
+    // No tool calls — final response
+    finalText = parts.filter((p) => p.text).map((p) => p.text).join('');
+    break;
   }
+
+  if (interactive && finalText) {
+    process.stdout.write(finalText);
+    process.stdout.write('\n');
+  }
+
+  return { stdout: finalText, stderr: '', exitCode: 0 };
 }
 
 // ─── OpenAI provider ─────────────────────────────────────────────────────────
@@ -216,71 +465,37 @@ const OPENAI_DEFAULT_MODEL = 'gpt-4o-mini';
 const OPENAI_CHAT_URL = 'https://api.openai.com/v1/chat/completions';
 
 async function runOpenAiPrompt(prompt, options, config) {
-  const apiKey = resolveApiKey(config, 'openai');
+  const apiKey = await resolveApiKey(config, 'openai');
   if (!apiKey) {
     console.log(aiUnavailableMessage(config));
     return null;
   }
 
   const model = config?.ai?.model || OPENAI_DEFAULT_MODEL;
-  const { interactive = false } = options;
+  const { interactive = false, allowedTools, cwd = process.cwd() } = options;
+
+  const enabledTools = mapAllowedTools(allowedTools);
+  const toolDefs = buildOpenAiToolDefs(enabledTools);
 
   const headers = {
     'Content-Type': 'application/json',
     Authorization: `Bearer ${apiKey}`,
   };
 
-  if (interactive) {
-    const body = JSON.stringify({
-      model,
-      messages: [{ role: 'user', content: prompt }],
-      stream: true,
-    });
+  const messages = [{ role: 'user', content: prompt }];
+  let finalText = '';
 
-    const res = await fetch(OPENAI_CHAT_URL, { method: 'POST', headers, body });
-
-    if (!res.ok) {
-      const errText = await res.text();
-      throw new Error(`OpenAI API error ${res.status}: ${errText}`);
+  for (let i = 0; i < MAX_TOOL_ITERATIONS; i++) {
+    const body = { model, messages };
+    if (toolDefs.length > 0) {
+      body.tools = toolDefs;
     }
 
-    let fullText = '';
-    const reader = res.body.getReader();
-    const decoder = new TextDecoder();
-
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
-
-      const chunk = decoder.decode(value, { stream: true });
-      for (const line of chunk.split('\n')) {
-        if (!line.startsWith('data: ')) continue;
-        const data = line.slice(6).trim();
-        if (!data || data === '[DONE]') continue;
-
-        try {
-          const parsed = JSON.parse(data);
-          const delta = parsed.choices?.[0]?.delta?.content ?? '';
-          if (delta) {
-            process.stdout.write(delta);
-            fullText += delta;
-          }
-        } catch {
-          // ignore malformed SSE frames
-        }
-      }
-    }
-
-    if (fullText) process.stdout.write('\n');
-    return { stdout: fullText, stderr: '', exitCode: 0 };
-  } else {
-    const body = JSON.stringify({
-      model,
-      messages: [{ role: 'user', content: prompt }],
-      stream: false,
+    const res = await fetch(OPENAI_CHAT_URL, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
     });
-
-    const res = await fetch(OPENAI_CHAT_URL, { method: 'POST', headers, body });
 
     if (!res.ok) {
       const errText = await res.text();
@@ -288,9 +503,41 @@ async function runOpenAiPrompt(prompt, options, config) {
     }
 
     const json = await res.json();
-    const text = json.choices?.[0]?.message?.content ?? '';
-    return { stdout: text, stderr: '', exitCode: 0 };
+    const choice = json.choices?.[0];
+    const message = choice?.message;
+
+    if (choice?.finish_reason === 'tool_calls' && message?.tool_calls?.length > 0) {
+      // Add assistant turn to history
+      messages.push(message);
+
+      // Execute each tool
+      for (const toolCall of message.tool_calls) {
+        const {
+          id,
+          function: { name, arguments: argsJson },
+        } = toolCall;
+        let toolArgs;
+        try {
+          toolArgs = JSON.parse(argsJson);
+        } catch {
+          toolArgs = {};
+        }
+        const result = await executeLocalTool(name, toolArgs, cwd);
+        messages.push({ role: 'tool', tool_call_id: id, content: result });
+      }
+      continue;
+    }
+
+    finalText = message?.content ?? '';
+    break;
   }
+
+  if (interactive && finalText) {
+    process.stdout.write(finalText);
+    process.stdout.write('\n');
+  }
+
+  return { stdout: finalText, stderr: '', exitCode: 0 };
 }
 
 // ─── Unified entry point ──────────────────────────────────────────────────────
@@ -300,11 +547,11 @@ async function runOpenAiPrompt(prompt, options, config) {
  *
  * @param {string} prompt - The prompt text to send
  * @param {object} [options]
- * @param {object} [options.config]        - Loaded sfdt config (determines provider)
- * @param {string[]} [options.allowedTools] - Claude-only: tool names to allow
+ * @param {object} [options.config]         - Loaded sfdt config (determines provider)
+ * @param {string[]} [options.allowedTools] - Tool names to allow (Claude names mapped to local impls)
  * @param {string} [options.input]          - Claude-only: pipe as stdin
- * @param {boolean} [options.interactive]   - Stream to stdout (default: false)
- * @param {string} [options.cwd]            - Claude-only: working directory
+ * @param {boolean} [options.interactive]   - Stream/print to stdout (default: false)
+ * @param {string} [options.cwd]            - Working directory for tool execution
  * @param {boolean} [options.aiEnabled]     - Feature-gate check (default: true)
  * @returns {Promise<{stdout,stderr,exitCode}|null>}
  */

--- a/src/lib/ai.js
+++ b/src/lib/ai.js
@@ -200,9 +200,13 @@ async function executeLocalTool(toolName, args, cwd) {
 
       case 'write_file': {
         const filePath = await safeResolvePath(cwd, args.path);
+        const content = String(args.content ?? '');
+        if (content.length > 1_000_000) {
+          return `Error: content too large (${content.length} bytes); limit is 1 MB`;
+        }
         await fs.ensureDir(path.dirname(filePath));
-        await fs.writeFile(filePath, args.content);
-        return `Successfully wrote ${args.content.length} bytes to ${args.path}`;
+        await fs.writeFile(filePath, content);
+        return `Successfully wrote ${content.length} bytes to ${args.path}`;
       }
 
       case 'list_directory': {

--- a/src/lib/ai.js
+++ b/src/lib/ai.js
@@ -1,10 +1,12 @@
 import { execa } from 'execa';
 
+// ─── Provider helpers ─────────────────────────────────────────────────────────
+
 let claudeAvailableCache = null;
 
 /**
  * Check whether the `claude` CLI is installed and accessible.
- * Result is cached for the lifetime of the process.
+ * Cached for the lifetime of the process.
  */
 export async function isClaudeAvailable() {
   if (claudeAvailableCache !== null) return claudeAvailableCache;
@@ -23,37 +25,93 @@ export async function isClaudeAvailable() {
 }
 
 /**
- * Run a prompt through the Claude CLI.
- *
- * @param {string} prompt - The prompt text to send
- * @param {object} [options] - Execution options
- * @param {string[]} [options.allowedTools] - Tools to allow (e.g., ['Bash', 'Read'])
- * @param {string} [options.input] - Pipe this string as stdin
- * @param {boolean} [options.interactive] - Use stdio inherit for TTY (default: false)
- * @param {string} [options.cwd] - Working directory
- * @param {boolean} [options.aiEnabled] - Whether AI features are enabled in config (config.features.ai)
- * @returns {Promise<{stdout: string, stderr: string, exitCode: number}|null>}
- *   Returns null if claude is not available or AI is disabled.
+ * Resolve the API key for a given provider.
+ * Priority: config.ai.apiKey → provider-specific env var.
  */
-export async function runAiPrompt(prompt, options = {}) {
-  const { allowedTools, input, interactive = false, cwd, aiEnabled = true } = options;
+function resolveApiKey(config, provider) {
+  if (config?.ai?.apiKey) return config.ai.apiKey;
 
-  if (!aiEnabled) {
-    console.log('AI features are disabled in sfdt configuration. Skipping AI prompt.');
-    return null;
+  const envVars = {
+    gemini: ['GEMINI_API_KEY', 'GOOGLE_AI_API_KEY', 'GOOGLE_GENERATIVE_AI_API_KEY'],
+    openai: ['OPENAI_API_KEY'],
+  };
+
+  for (const envVar of envVars[provider] ?? []) {
+    if (process.env[envVar]) return process.env[envVar];
   }
+
+  return null;
+}
+
+/**
+ * Return the configured AI provider name.
+ * Falls back to 'claude' if not set.
+ */
+export function getConfiguredProvider(config) {
+  return config?.ai?.provider || 'claude';
+}
+
+/**
+ * Check whether the configured AI provider is usable.
+ * For Claude: requires the `claude` CLI in PATH.
+ * For Gemini/OpenAI: requires an API key in config or env.
+ */
+export async function isAiAvailable(config) {
+  if (!config?.features?.ai) return false;
+
+  const provider = getConfiguredProvider(config);
+
+  switch (provider) {
+    case 'claude':
+      return isClaudeAvailable();
+    case 'gemini':
+      return !!resolveApiKey(config, 'gemini');
+    case 'openai':
+      return !!resolveApiKey(config, 'openai');
+    default:
+      return false;
+  }
+}
+
+/**
+ * Human-readable description of why a provider is unavailable.
+ */
+export function aiUnavailableMessage(config) {
+  const provider = getConfiguredProvider(config);
+
+  switch (provider) {
+    case 'claude':
+      return (
+        'Claude CLI is not installed or not in PATH. ' +
+        'Install it from https://docs.anthropic.com/en/docs/claude-code to enable AI features.'
+      );
+    case 'gemini':
+      return (
+        'Gemini API key not found. ' +
+        'Set GEMINI_API_KEY in your environment or add ai.apiKey to .sfdt/config.json.'
+      );
+    case 'openai':
+      return (
+        'OpenAI API key not found. ' +
+        'Set OPENAI_API_KEY in your environment or add ai.apiKey to .sfdt/config.json.'
+      );
+    default:
+      return `Unknown AI provider "${provider}". Supported: claude, gemini, openai.`;
+  }
+}
+
+// ─── Claude provider ──────────────────────────────────────────────────────────
+
+async function runClaudePrompt(prompt, options) {
+  const { allowedTools, input, interactive = false, cwd } = options;
 
   const available = await isClaudeAvailable();
   if (!available) {
-    console.log(
-      'Claude CLI is not installed or not in PATH. Skipping AI prompt.\n' +
-        'Install it from https://docs.anthropic.com/en/docs/claude-cli to enable AI features.',
-    );
+    console.log(aiUnavailableMessage({ ai: { provider: 'claude' } }));
     return null;
   }
 
   const args = ['-p', prompt];
-
   if (allowedTools && allowedTools.length > 0) {
     args.push('--allowedTools', allowedTools.join(','));
   }
@@ -61,16 +119,11 @@ export async function runAiPrompt(prompt, options = {}) {
   const execOptions = {
     cwd: cwd || process.cwd(),
     reject: false,
-    timeout: 300000, // 5 minute timeout for AI operations
+    timeout: 300_000,
   };
 
-  if (interactive) {
-    execOptions.stdio = 'inherit';
-  }
-
-  if (input) {
-    execOptions.input = input;
-  }
+  if (interactive) execOptions.stdio = 'inherit';
+  if (input) execOptions.input = input;
 
   const result = await execa('claude', args, execOptions);
 
@@ -79,4 +132,199 @@ export async function runAiPrompt(prompt, options = {}) {
     stderr: result.stderr || '',
     exitCode: result.exitCode,
   };
+}
+
+// ─── Gemini provider ──────────────────────────────────────────────────────────
+
+const GEMINI_DEFAULT_MODEL = 'gemini-2.0-flash';
+const GEMINI_BASE_URL = 'https://generativelanguage.googleapis.com/v1beta/models';
+
+async function runGeminiPrompt(prompt, options, config) {
+  const apiKey = resolveApiKey(config, 'gemini');
+  if (!apiKey) {
+    console.log(aiUnavailableMessage(config));
+    return null;
+  }
+
+  const model = config?.ai?.model || GEMINI_DEFAULT_MODEL;
+  const { interactive = false } = options;
+
+  const body = JSON.stringify({
+    contents: [{ role: 'user', parts: [{ text: prompt }] }],
+  });
+
+  const headers = { 'Content-Type': 'application/json' };
+
+  if (interactive) {
+    // Streaming mode — write tokens to stdout as they arrive
+    const url = `${GEMINI_BASE_URL}/${model}:streamGenerateContent?key=${apiKey}&alt=sse`;
+    const res = await fetch(url, { method: 'POST', headers, body });
+
+    if (!res.ok) {
+      const errText = await res.text();
+      throw new Error(`Gemini API error ${res.status}: ${errText}`);
+    }
+
+    let fullText = '';
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      const chunk = decoder.decode(value, { stream: true });
+      for (const line of chunk.split('\n')) {
+        if (!line.startsWith('data: ')) continue;
+        const data = line.slice(6).trim();
+        if (!data || data === '[DONE]') continue;
+
+        try {
+          const parsed = JSON.parse(data);
+          const text = parsed.candidates?.[0]?.content?.parts?.[0]?.text ?? '';
+          if (text) {
+            process.stdout.write(text);
+            fullText += text;
+          }
+        } catch {
+          // ignore malformed SSE frames
+        }
+      }
+    }
+
+    if (fullText) process.stdout.write('\n');
+    return { stdout: fullText, stderr: '', exitCode: 0 };
+  } else {
+    // Non-streaming — capture full response
+    const url = `${GEMINI_BASE_URL}/${model}:generateContent?key=${apiKey}`;
+    const res = await fetch(url, { method: 'POST', headers, body });
+
+    if (!res.ok) {
+      const errText = await res.text();
+      throw new Error(`Gemini API error ${res.status}: ${errText}`);
+    }
+
+    const json = await res.json();
+    const text = json.candidates?.[0]?.content?.parts?.[0]?.text ?? '';
+    return { stdout: text, stderr: '', exitCode: 0 };
+  }
+}
+
+// ─── OpenAI provider ─────────────────────────────────────────────────────────
+
+const OPENAI_DEFAULT_MODEL = 'gpt-4o-mini';
+const OPENAI_CHAT_URL = 'https://api.openai.com/v1/chat/completions';
+
+async function runOpenAiPrompt(prompt, options, config) {
+  const apiKey = resolveApiKey(config, 'openai');
+  if (!apiKey) {
+    console.log(aiUnavailableMessage(config));
+    return null;
+  }
+
+  const model = config?.ai?.model || OPENAI_DEFAULT_MODEL;
+  const { interactive = false } = options;
+
+  const headers = {
+    'Content-Type': 'application/json',
+    Authorization: `Bearer ${apiKey}`,
+  };
+
+  if (interactive) {
+    const body = JSON.stringify({
+      model,
+      messages: [{ role: 'user', content: prompt }],
+      stream: true,
+    });
+
+    const res = await fetch(OPENAI_CHAT_URL, { method: 'POST', headers, body });
+
+    if (!res.ok) {
+      const errText = await res.text();
+      throw new Error(`OpenAI API error ${res.status}: ${errText}`);
+    }
+
+    let fullText = '';
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      const chunk = decoder.decode(value, { stream: true });
+      for (const line of chunk.split('\n')) {
+        if (!line.startsWith('data: ')) continue;
+        const data = line.slice(6).trim();
+        if (!data || data === '[DONE]') continue;
+
+        try {
+          const parsed = JSON.parse(data);
+          const delta = parsed.choices?.[0]?.delta?.content ?? '';
+          if (delta) {
+            process.stdout.write(delta);
+            fullText += delta;
+          }
+        } catch {
+          // ignore malformed SSE frames
+        }
+      }
+    }
+
+    if (fullText) process.stdout.write('\n');
+    return { stdout: fullText, stderr: '', exitCode: 0 };
+  } else {
+    const body = JSON.stringify({
+      model,
+      messages: [{ role: 'user', content: prompt }],
+      stream: false,
+    });
+
+    const res = await fetch(OPENAI_CHAT_URL, { method: 'POST', headers, body });
+
+    if (!res.ok) {
+      const errText = await res.text();
+      throw new Error(`OpenAI API error ${res.status}: ${errText}`);
+    }
+
+    const json = await res.json();
+    const text = json.choices?.[0]?.message?.content ?? '';
+    return { stdout: text, stderr: '', exitCode: 0 };
+  }
+}
+
+// ─── Unified entry point ──────────────────────────────────────────────────────
+
+/**
+ * Run a prompt through the configured AI provider.
+ *
+ * @param {string} prompt - The prompt text to send
+ * @param {object} [options]
+ * @param {object} [options.config]        - Loaded sfdt config (determines provider)
+ * @param {string[]} [options.allowedTools] - Claude-only: tool names to allow
+ * @param {string} [options.input]          - Claude-only: pipe as stdin
+ * @param {boolean} [options.interactive]   - Stream to stdout (default: false)
+ * @param {string} [options.cwd]            - Claude-only: working directory
+ * @param {boolean} [options.aiEnabled]     - Feature-gate check (default: true)
+ * @returns {Promise<{stdout,stderr,exitCode}|null>}
+ */
+export async function runAiPrompt(prompt, options = {}) {
+  const { config, aiEnabled = true, interactive = false } = options;
+
+  if (!aiEnabled) {
+    console.log('AI features are disabled in sfdt configuration. Skipping AI prompt.');
+    return null;
+  }
+
+  const provider = getConfiguredProvider(config);
+
+  switch (provider) {
+    case 'gemini':
+      return runGeminiPrompt(prompt, { ...options, interactive }, config);
+    case 'openai':
+      return runOpenAiPrompt(prompt, { ...options, interactive }, config);
+    default:
+      // claude (and unknown providers fall back to claude)
+      return runClaudePrompt(prompt, { ...options, interactive });
+  }
 }

--- a/src/lib/gui-server.js
+++ b/src/lib/gui-server.js
@@ -10,7 +10,6 @@ import express from 'express';
 import fs from 'fs-extra';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { loadConfig } from './config.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -145,6 +144,26 @@ async function safeReaddir(dir) {
   }
 }
 
+// ─── Rate limiter ─────────────────────────────────────────────────────────────
+
+/**
+ * Minimal in-process rate limiter — no external deps required.
+ * Limits requests to maxRequests per windowMs across all local clients.
+ */
+function createRateLimiter(maxRequests = 60, windowMs = 60_000) {
+  const timestamps = [];
+  return (_req, res, next) => {
+    const now = Date.now();
+    const cutoff = now - windowMs;
+    while (timestamps.length && timestamps[0] < cutoff) timestamps.shift();
+    if (timestamps.length >= maxRequests) {
+      return res.status(429).json({ error: 'Too many requests' });
+    }
+    timestamps.push(now);
+    next();
+  };
+}
+
 // ─── Server factory ───────────────────────────────────────────────────────────
 
 /**
@@ -161,6 +180,8 @@ export function createGuiApp(config, version) {
   const logDir =
     config.logDir ||
     path.join(config._projectRoot || process.cwd(), 'logs');
+
+  const apiLimiter = createRateLimiter(60, 60_000);
 
   // ── API routes ──────────────────────────────────────────────────────────────
 
@@ -179,7 +200,7 @@ export function createGuiApp(config, version) {
     });
   });
 
-  app.get('/api/test-runs', async (_req, res) => {
+  app.get('/api/test-runs', apiLimiter, async (_req, res) => {
     try {
       const runs = await readTestRuns(logDir);
       res.json({ runs });
@@ -188,7 +209,7 @@ export function createGuiApp(config, version) {
     }
   });
 
-  app.get('/api/preflight', async (_req, res) => {
+  app.get('/api/preflight', apiLimiter, async (_req, res) => {
     try {
       const data = await readPreflight(logDir);
       res.json(data ?? {});
@@ -197,7 +218,7 @@ export function createGuiApp(config, version) {
     }
   });
 
-  app.get('/api/drift', async (_req, res) => {
+  app.get('/api/drift', apiLimiter, async (_req, res) => {
     try {
       const data = await readDrift(logDir);
       res.json(data ?? {});
@@ -212,7 +233,7 @@ export function createGuiApp(config, version) {
     app.use(express.static(GUI_DIST));
 
     // SPA fallback — all non-API routes return index.html
-    app.get('*', (_req, res) => {
+    app.get('*', apiLimiter, (_req, res) => {
       res.sendFile(path.join(GUI_DIST, 'index.html'));
     });
   } else {

--- a/src/lib/gui-server.js
+++ b/src/lib/gui-server.js
@@ -1,0 +1,285 @@
+/**
+ * SFDT GUI Server
+ *
+ * Lightweight Express server that:
+ *  - Serves the pre-built React/SLDS dashboard from gui/dist/
+ *  - Exposes REST API endpoints that read sfdt config and log files
+ */
+
+import express from 'express';
+import fs from 'fs-extra';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { loadConfig } from './config.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// gui/dist lives at <package-root>/gui/dist
+const GUI_DIST = path.resolve(__dirname, '..', '..', 'gui', 'dist');
+
+// ─── Log parsers ─────────────────────────────────────────────────────────────
+
+/**
+ * Attempt to parse a JSON file; return null on any error.
+ */
+async function tryReadJson(filePath) {
+  try {
+    return await fs.readJson(filePath);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Scan the test-results directory for sfdt result files.
+ * Returns an array of run objects: { date, passed, failed, errors, coverage, duration }.
+ */
+async function readTestRuns(logDir) {
+  const resultsDir = path.join(logDir, 'test-results');
+  if (!(await fs.pathExists(resultsDir))) return [];
+
+  let entries;
+  try {
+    entries = await fs.readdir(resultsDir);
+  } catch {
+    return [];
+  }
+
+  const jsonFiles = entries
+    .filter((f) => f.endsWith('.json'))
+    .sort()
+    .reverse(); // newest first
+
+  const runs = [];
+
+  for (const file of jsonFiles) {
+    const raw = await tryReadJson(path.join(resultsDir, file));
+    if (!raw) continue;
+
+    // Handle sf apex test run JSON output format
+    if (raw.result) {
+      const r = raw.result;
+      runs.push({
+        date: r.summary?.testStartTime ?? raw.timestamp ?? file,
+        passed: r.summary?.passing ?? 0,
+        failed: r.summary?.failing ?? 0,
+        errors: r.summary?.skipped ?? 0,
+        coverage: r.summary?.testRunCoverage
+          ? parseFloat(r.summary.testRunCoverage)
+          : undefined,
+        duration: r.summary?.testExecutionTimeInMs ?? undefined,
+      });
+    } else if (raw.summary) {
+      // Direct summary object
+      runs.push({
+        date: raw.summary.testStartTime ?? raw.timestamp ?? file,
+        passed: raw.summary.passing ?? 0,
+        failed: raw.summary.failing ?? 0,
+        errors: raw.summary.skipped ?? 0,
+        coverage: raw.summary.testRunCoverage
+          ? parseFloat(raw.summary.testRunCoverage)
+          : undefined,
+        duration: raw.summary.testExecutionTimeInMs ?? undefined,
+      });
+    } else if (Array.isArray(raw)) {
+      // Array of test results (simple format)
+      const passed = raw.filter((t) => t.outcome === 'Pass').length;
+      const failed = raw.filter((t) => t.outcome === 'Fail').length;
+      runs.push({
+        date: raw[0]?.testTimestamp ?? file,
+        passed,
+        failed,
+        errors: 0,
+      });
+    }
+  }
+
+  return runs;
+}
+
+/**
+ * Read the most recent preflight log.
+ * Returns { date, status, checks: [{name, status, message}] } or null.
+ */
+async function readPreflight(logDir) {
+  const preflightFile = path.join(logDir, 'preflight-latest.json');
+  const data = await tryReadJson(preflightFile);
+  if (data) return data;
+
+  // Fallback: look for preflight_*.json
+  const files = await safeReaddir(logDir);
+  const preflightFiles = files
+    .filter((f) => f.startsWith('preflight_') && f.endsWith('.json'))
+    .sort()
+    .reverse();
+
+  if (!preflightFiles.length) return null;
+  return tryReadJson(path.join(logDir, preflightFiles[0]));
+}
+
+/**
+ * Read the most recent drift log.
+ * Returns { date, result, count, components: [{name, type, drift}] } or null.
+ */
+async function readDrift(logDir) {
+  const driftFile = path.join(logDir, 'drift-latest.json');
+  const data = await tryReadJson(driftFile);
+  if (data) return data;
+
+  const files = await safeReaddir(logDir);
+  const driftFiles = files
+    .filter((f) => f.startsWith('drift_') && f.endsWith('.json'))
+    .sort()
+    .reverse();
+
+  if (!driftFiles.length) return null;
+  return tryReadJson(path.join(logDir, driftFiles[0]));
+}
+
+async function safeReaddir(dir) {
+  try {
+    return await fs.readdir(dir);
+  } catch {
+    return [];
+  }
+}
+
+// ─── Server factory ───────────────────────────────────────────────────────────
+
+/**
+ * Create and configure the Express app.
+ *
+ * @param {object} config  - Loaded sfdt config
+ * @param {string} version - CLI version string
+ * @returns {import('express').Application}
+ */
+export function createGuiApp(config, version) {
+  const app = express();
+  app.use(express.json());
+
+  const logDir =
+    config.logDir ||
+    path.join(config._projectRoot || process.cwd(), 'logs');
+
+  // ── API routes ──────────────────────────────────────────────────────────────
+
+  app.get('/api/health', (_req, res) => {
+    res.json({ ok: true, timestamp: new Date().toISOString() });
+  });
+
+  app.get('/api/project', (_req, res) => {
+    res.json({
+      name: config.projectName || 'Salesforce Project',
+      org: config.defaultOrg || null,
+      apiVersion: config.sourceApiVersion || null,
+      coverageThreshold: config.deployment?.coverageThreshold ?? 75,
+      features: config.features || {},
+      version,
+    });
+  });
+
+  app.get('/api/test-runs', async (_req, res) => {
+    try {
+      const runs = await readTestRuns(logDir);
+      res.json({ runs });
+    } catch (err) {
+      res.status(500).json({ error: err.message });
+    }
+  });
+
+  app.get('/api/preflight', async (_req, res) => {
+    try {
+      const data = await readPreflight(logDir);
+      res.json(data ?? {});
+    } catch (err) {
+      res.status(500).json({ error: err.message });
+    }
+  });
+
+  app.get('/api/drift', async (_req, res) => {
+    try {
+      const data = await readDrift(logDir);
+      res.json(data ?? {});
+    } catch (err) {
+      res.status(500).json({ error: err.message });
+    }
+  });
+
+  // ── Static: serve pre-built React app ──────────────────────────────────────
+
+  if (fs.existsSync(GUI_DIST)) {
+    app.use(express.static(GUI_DIST));
+
+    // SPA fallback — all non-API routes return index.html
+    app.get('*', (_req, res) => {
+      res.sendFile(path.join(GUI_DIST, 'index.html'));
+    });
+  } else {
+    // GUI not built yet — serve a helpful plain-HTML placeholder
+    app.get('/', (_req, res) => {
+      res.send(buildPlaceholderHtml(version));
+    });
+  }
+
+  return app;
+}
+
+/**
+ * Start the GUI server.
+ *
+ * @param {number} port
+ * @param {object} config
+ * @param {string} version
+ * @returns {Promise<import('http').Server>}
+ */
+export async function startGuiServer(port, config, version) {
+  const app = createGuiApp(config, version);
+
+  return new Promise((resolve, reject) => {
+    const server = app.listen(port, '127.0.0.1', () => resolve(server));
+    server.once('error', reject);
+  });
+}
+
+// ─── Placeholder HTML (when gui/dist hasn't been built yet) ──────────────────
+
+function buildPlaceholderHtml(version) {
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>SFDT Dashboard</title>
+  <style>
+    *{box-sizing:border-box;margin:0;padding:0}
+    body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;
+         background:#f3f3f3;display:flex;align-items:center;
+         justify-content:center;min-height:100vh}
+    .card{background:#fff;border-radius:8px;padding:40px 48px;
+          max-width:500px;width:100%;box-shadow:0 2px 8px rgba(0,0,0,.1);
+          border-top:4px solid #0176d3}
+    h1{font-size:22px;color:#032d60;margin-bottom:8px}
+    p{color:#706e6b;font-size:14px;line-height:1.6;margin-bottom:16px}
+    code{background:#f3f3f3;padding:2px 6px;border-radius:4px;
+         font-family:monospace;font-size:13px;color:#032d60}
+    pre{background:#032d60;color:#fff;padding:16px 20px;border-radius:6px;
+        font-size:13px;overflow-x:auto;margin-bottom:16px}
+    .version{color:#919191;font-size:12px;margin-top:24px}
+  </style>
+</head>
+<body>
+  <div class="card">
+    <h1>SFDT Dashboard — Build Required</h1>
+    <p>The GUI hasn't been compiled yet. Run these commands from the
+       <code>sfdt</code> package root to build it:</p>
+    <pre>cd gui
+npm install
+npm run build</pre>
+    <p>Or use the convenience script from the package root:</p>
+    <pre>npm run build:gui</pre>
+    <p>Then restart <code>sfdt ui</code> and refresh this page.</p>
+    <p class="version">sfdt v${version}</p>
+  </div>
+</body>
+</html>`;
+}

--- a/src/lib/plugin-loader.js
+++ b/src/lib/plugin-loader.js
@@ -50,62 +50,66 @@ export async function loadPlugins(program) {
     }
   }
 
-  // ── 2. Auto-discover sfdt-plugin-* in project node_modules ───────────────
-  const nodeModulesDir = path.join(projectRoot, 'node_modules');
-  if (await fs.pathExists(nodeModulesDir)) {
-    let entries;
-    try {
-      entries = await fs.readdir(nodeModulesDir);
-    } catch {
-      entries = [];
-    }
-
-    const explicitNames = new Set((config.plugins ?? []).map((n) => String(n)));
-
-    for (const entry of entries) {
-      if (entry.startsWith('sfdt-plugin-') && !explicitNames.has(entry)) {
-        sources.push({ name: entry, type: 'package', explicit: false });
+  // ── 2 & 3. Auto-discovery (opt-in only) ──────────────────────────────────
+  // Auto-discovery executes arbitrary project-local code before CLI parsing.
+  // It is disabled by default. Enable via pluginOptions.autoDiscover in config.
+  if (config.pluginOptions?.autoDiscover === true) {
+    const nodeModulesDir = path.join(projectRoot, 'node_modules');
+    if (await fs.pathExists(nodeModulesDir)) {
+      let entries;
+      try {
+        entries = await fs.readdir(nodeModulesDir);
+      } catch {
+        entries = [];
       }
-    }
 
-    // Also scan scoped packages (@org/sfdt-plugin-*)
-    for (const entry of entries) {
-      if (entry.startsWith('@')) {
-        const scopeDir = path.join(nodeModulesDir, entry);
-        let scopedEntries;
-        try {
-          scopedEntries = await fs.readdir(scopeDir);
-        } catch {
-          continue;
+      const explicitNames = new Set((config.plugins ?? []).map((n) => String(n)));
+
+      for (const entry of entries) {
+        if (entry.startsWith('sfdt-plugin-') && !explicitNames.has(entry)) {
+          sources.push({ name: entry, type: 'package', explicit: false });
         }
-        for (const scoped of scopedEntries) {
-          if (scoped.startsWith('sfdt-plugin-')) {
-            const fullName = `${entry}/${scoped}`;
-            if (!explicitNames.has(fullName)) {
-              sources.push({ name: fullName, type: 'package', explicit: false });
+      }
+
+      // Also scan scoped packages (@org/sfdt-plugin-*)
+      for (const entry of entries) {
+        if (entry.startsWith('@')) {
+          const scopeDir = path.join(nodeModulesDir, entry);
+          let scopedEntries;
+          try {
+            scopedEntries = await fs.readdir(scopeDir);
+          } catch {
+            continue;
+          }
+          for (const scoped of scopedEntries) {
+            if (scoped.startsWith('sfdt-plugin-')) {
+              const fullName = `${entry}/${scoped}`;
+              if (!explicitNames.has(fullName)) {
+                sources.push({ name: fullName, type: 'package', explicit: false });
+              }
             }
           }
         }
       }
     }
-  }
 
-  // ── 3. Local plugins in .sfdt/plugins/ ───────────────────────────────────
-  const localPluginsDir = path.join(configDir, 'plugins');
-  if (await fs.pathExists(localPluginsDir)) {
-    let files;
-    try {
-      files = await fs.readdir(localPluginsDir);
-    } catch {
-      files = [];
-    }
+    // Local plugins in .sfdt/plugins/
+    const localPluginsDir = path.join(configDir, 'plugins');
+    if (await fs.pathExists(localPluginsDir)) {
+      let files;
+      try {
+        files = await fs.readdir(localPluginsDir);
+      } catch {
+        files = [];
+      }
 
-    for (const file of files.filter((f) => f.endsWith('.js') || f.endsWith('.mjs'))) {
-      sources.push({
-        name: path.join(localPluginsDir, file),
-        type: 'local',
-        explicit: false,
-      });
+      for (const file of files.filter((f) => f.endsWith('.js') || f.endsWith('.mjs'))) {
+        sources.push({
+          name: path.join(localPluginsDir, file),
+          type: 'local',
+          explicit: false,
+        });
+      }
     }
   }
 

--- a/src/lib/plugin-loader.js
+++ b/src/lib/plugin-loader.js
@@ -1,0 +1,151 @@
+/**
+ * SFDT Plugin Loader
+ *
+ * Discovers and loads sfdt plugins from three sources (in order):
+ *  1. Packages listed explicitly in config.plugins[]
+ *  2. Any package named sfdt-plugin-* in the project's node_modules/
+ *  3. Local JS files in .sfdt/plugins/
+ *
+ * Each plugin must export a register(program) function.
+ *
+ * Plugin example (sfdt-plugin-my-thing/index.js):
+ *   export function register(program) {
+ *     program.command('my-thing').action(async () => { ... });
+ *   }
+ */
+
+import fs from 'fs-extra';
+import path from 'path';
+import { createRequire } from 'module';
+import { pathToFileURL } from 'url';
+import { loadConfig } from './config.js';
+import { print } from './output.js';
+
+/**
+ * Load all plugins into the Commander program.
+ * Silently skips if not inside an sfdt project (no config found).
+ *
+ * @param {import('commander').Command} program
+ */
+export async function loadPlugins(program) {
+  let config;
+  try {
+    config = await loadConfig();
+  } catch {
+    // Not in an sfdt project — no plugins to load, that's fine
+    return;
+  }
+
+  const projectRoot = config._projectRoot;
+  const configDir = config._configDir;
+
+  const sources = [];
+
+  // ── 1. Explicit packages from config.plugins ──────────────────────────────
+  if (Array.isArray(config.plugins) && config.plugins.length > 0) {
+    for (const name of config.plugins) {
+      if (typeof name === 'string' && name.trim()) {
+        sources.push({ name: name.trim(), type: 'package', explicit: true });
+      }
+    }
+  }
+
+  // ── 2. Auto-discover sfdt-plugin-* in project node_modules ───────────────
+  const nodeModulesDir = path.join(projectRoot, 'node_modules');
+  if (await fs.pathExists(nodeModulesDir)) {
+    let entries;
+    try {
+      entries = await fs.readdir(nodeModulesDir);
+    } catch {
+      entries = [];
+    }
+
+    const explicitNames = new Set((config.plugins ?? []).map((n) => String(n)));
+
+    for (const entry of entries) {
+      if (entry.startsWith('sfdt-plugin-') && !explicitNames.has(entry)) {
+        sources.push({ name: entry, type: 'package', explicit: false });
+      }
+    }
+
+    // Also scan scoped packages (@org/sfdt-plugin-*)
+    for (const entry of entries) {
+      if (entry.startsWith('@')) {
+        const scopeDir = path.join(nodeModulesDir, entry);
+        let scopedEntries;
+        try {
+          scopedEntries = await fs.readdir(scopeDir);
+        } catch {
+          continue;
+        }
+        for (const scoped of scopedEntries) {
+          if (scoped.startsWith('sfdt-plugin-')) {
+            const fullName = `${entry}/${scoped}`;
+            if (!explicitNames.has(fullName)) {
+              sources.push({ name: fullName, type: 'package', explicit: false });
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // ── 3. Local plugins in .sfdt/plugins/ ───────────────────────────────────
+  const localPluginsDir = path.join(configDir, 'plugins');
+  if (await fs.pathExists(localPluginsDir)) {
+    let files;
+    try {
+      files = await fs.readdir(localPluginsDir);
+    } catch {
+      files = [];
+    }
+
+    for (const file of files.filter((f) => f.endsWith('.js') || f.endsWith('.mjs'))) {
+      sources.push({
+        name: path.join(localPluginsDir, file),
+        type: 'local',
+        explicit: false,
+      });
+    }
+  }
+
+  if (sources.length === 0) return;
+
+  // ── Load each plugin ──────────────────────────────────────────────────────
+  // Create a require function rooted at the project (for package resolution)
+  const projectRequire = createRequire(path.join(projectRoot, 'package.json'));
+
+  for (const source of sources) {
+    const label = source.type === 'local' ? path.basename(source.name) : source.name;
+
+    try {
+      let mod;
+
+      if (source.type === 'local') {
+        // Local file: convert to file:// URL for dynamic import
+        mod = await import(pathToFileURL(source.name).href);
+      } else {
+        // Package: resolve from the project's node_modules
+        const resolved = projectRequire.resolve(source.name);
+        mod = await import(pathToFileURL(resolved).href);
+      }
+
+      const registerFn = mod.register ?? mod.default?.register;
+
+      if (typeof registerFn !== 'function') {
+        print.warning(`Plugin "${label}" does not export a register() function — skipping.`);
+        continue;
+      }
+
+      registerFn(program);
+
+      if (!source.explicit) {
+        // Only log auto-discovered plugins so users know they were picked up
+        print.info(`Loaded plugin: ${label}`);
+      }
+    } catch (err) {
+      // Plugin errors are warnings, never crashes
+      print.warning(`Failed to load plugin "${label}": ${err.message}`);
+    }
+  }
+}

--- a/src/templates/sfdt.config.json
+++ b/src/templates/sfdt.config.json
@@ -15,5 +15,11 @@
     "ai": true,
     "notifications": false,
     "releaseManagement": true
-  }
+  },
+  "ai": {
+    "provider": "claude",
+    "model": "",
+    "apiKey": ""
+  },
+  "plugins": []
 }

--- a/src/templates/sfdt.config.json
+++ b/src/templates/sfdt.config.json
@@ -18,8 +18,10 @@
   },
   "ai": {
     "provider": "claude",
-    "model": "",
-    "apiKey": ""
+    "model": ""
   },
-  "plugins": []
+  "plugins": [],
+  "pluginOptions": {
+    "autoDiscover": false
+  }
 }

--- a/test/ai.test.js
+++ b/test/ai.test.js
@@ -5,17 +5,105 @@ vi.mock('execa', () => ({
 }));
 
 import { execa } from 'execa';
-import { isClaudeAvailable, runAiPrompt } from '../src/lib/ai.js';
+import {
+  isClaudeAvailable,
+  isAiAvailable,
+  getConfiguredProvider,
+  aiUnavailableMessage,
+  runAiPrompt,
+} from '../src/lib/ai.js';
 
 beforeEach(() => {
   vi.resetAllMocks();
-  // Reset the cached value between tests by re-importing would be complex,
-  // so we test the cache behavior via sequential calls
 });
 
-// Because ai.js caches the result, we need to test it in isolation
-// by using dynamic imports with cache busting. For simplicity, we test
-// the runAiPrompt function which exercises the full flow.
+// ─── getConfiguredProvider ────────────────────────────────────────────────────
+
+describe('getConfiguredProvider', () => {
+  it('defaults to claude when config has no ai section', () => {
+    expect(getConfiguredProvider({})).toBe('claude');
+    expect(getConfiguredProvider(null)).toBe('claude');
+    expect(getConfiguredProvider(undefined)).toBe('claude');
+  });
+
+  it('returns the configured provider', () => {
+    expect(getConfiguredProvider({ ai: { provider: 'gemini' } })).toBe('gemini');
+    expect(getConfiguredProvider({ ai: { provider: 'openai' } })).toBe('openai');
+    expect(getConfiguredProvider({ ai: { provider: 'claude' } })).toBe('claude');
+  });
+});
+
+// ─── aiUnavailableMessage ─────────────────────────────────────────────────────
+
+describe('aiUnavailableMessage', () => {
+  it('returns Claude install instructions for claude provider', () => {
+    const msg = aiUnavailableMessage({ ai: { provider: 'claude' } });
+    expect(msg).toMatch(/Claude/i);
+  });
+
+  it('returns Gemini key instructions for gemini provider', () => {
+    const msg = aiUnavailableMessage({ ai: { provider: 'gemini' } });
+    expect(msg).toMatch(/GEMINI_API_KEY/);
+  });
+
+  it('returns OpenAI key instructions for openai provider', () => {
+    const msg = aiUnavailableMessage({ ai: { provider: 'openai' } });
+    expect(msg).toMatch(/OPENAI_API_KEY/);
+  });
+});
+
+// ─── isAiAvailable ────────────────────────────────────────────────────────────
+
+describe('isAiAvailable', () => {
+  it('returns false when features.ai is false', async () => {
+    const result = await isAiAvailable({ features: { ai: false } });
+    expect(result).toBe(false);
+  });
+
+  it('checks Claude CLI for claude provider', async () => {
+    execa.mockResolvedValue({ exitCode: 0 });
+    const result = await isAiAvailable({ features: { ai: true }, ai: { provider: 'claude' } });
+    expect(result).toBe(true);
+    expect(execa).toHaveBeenCalledWith('claude', ['--version'], expect.any(Object));
+  });
+
+  it('returns true for gemini when API key is in config', async () => {
+    const result = await isAiAvailable({
+      features: { ai: true },
+      ai: { provider: 'gemini', apiKey: 'test-key' },
+    });
+    expect(result).toBe(true);
+  });
+
+  it('returns false for gemini when no API key available', async () => {
+    const origKey = process.env.GEMINI_API_KEY;
+    const origKey2 = process.env.GOOGLE_AI_API_KEY;
+    const origKey3 = process.env.GOOGLE_GENERATIVE_AI_API_KEY;
+    delete process.env.GEMINI_API_KEY;
+    delete process.env.GOOGLE_AI_API_KEY;
+    delete process.env.GOOGLE_GENERATIVE_AI_API_KEY;
+
+    const result = await isAiAvailable({
+      features: { ai: true },
+      ai: { provider: 'gemini', apiKey: '' },
+    });
+    expect(result).toBe(false);
+
+    if (origKey) process.env.GEMINI_API_KEY = origKey;
+    if (origKey2) process.env.GOOGLE_AI_API_KEY = origKey2;
+    if (origKey3) process.env.GOOGLE_GENERATIVE_AI_API_KEY = origKey3;
+  });
+
+  it('returns true for openai when API key is in config', async () => {
+    const result = await isAiAvailable({
+      features: { ai: true },
+      ai: { provider: 'openai', apiKey: 'sk-test-key' },
+    });
+    expect(result).toBe(true);
+  });
+});
+
+// ─── runAiPrompt ─────────────────────────────────────────────────────────────
 
 describe('runAiPrompt', () => {
   it('returns null when aiEnabled is false', async () => {
@@ -28,12 +116,9 @@ describe('runAiPrompt', () => {
     consoleSpy.mockRestore();
   });
 
-  it('passes prompt and allowed tools to claude CLI', async () => {
-    // Mock claude --version check (isClaudeAvailable)
-    execa.mockImplementation(async (cmd, args) => {
-      if (args && args[0] === '--version') {
-        return { exitCode: 0 };
-      }
+  it('routes to claude by default and passes prompt + tools to CLI', async () => {
+    execa.mockImplementation(async (_cmd, args) => {
+      if (args[0] === '--version') return { exitCode: 0 };
       return { exitCode: 0, stdout: 'review output', stderr: '' };
     });
 
@@ -42,13 +127,26 @@ describe('runAiPrompt', () => {
       cwd: '/project',
     });
 
-    // Find the actual prompt call (not the --version call)
-    const promptCall = execa.mock.calls.find((call) => call[1] && call[1].includes('-p'));
-
+    const promptCall = execa.mock.calls.find((call) => call[1]?.includes('-p'));
     expect(promptCall).toBeDefined();
     expect(promptCall[1]).toContain('-p');
     expect(promptCall[1]).toContain('review this code');
     expect(promptCall[1]).toContain('--allowedTools');
     expect(result.stdout).toBe('review output');
+  });
+
+  it('routes to claude when config.ai.provider is claude', async () => {
+    execa.mockImplementation(async (_cmd, args) => {
+      if (args[0] === '--version') return { exitCode: 0 };
+      return { exitCode: 0, stdout: 'claude out', stderr: '' };
+    });
+
+    const result = await runAiPrompt('hello', {
+      config: { ai: { provider: 'claude' } },
+    });
+
+    const promptCall = execa.mock.calls.find((call) => call[1]?.includes('-p'));
+    expect(promptCall).toBeDefined();
+    expect(result.stdout).toBe('claude out');
   });
 });

--- a/test/commands/changelog.test.js
+++ b/test/commands/changelog.test.js
@@ -23,7 +23,7 @@ vi.mock('inquirer', () => ({
 }));
 
 vi.mock('../../src/lib/ai.js', () => ({
-  isClaudeAvailable: vi.fn(),
+  isAiAvailable: vi.fn(), aiUnavailableMessage: vi.fn().mockReturnValue("AI provider not available"),
   runAiPrompt: vi.fn(),
 }));
 
@@ -42,7 +42,7 @@ import { loadConfig } from '../../src/lib/config.js';
 import { execa } from 'execa';
 import fs from 'fs-extra';
 import inquirer from 'inquirer';
-import { isClaudeAvailable, runAiPrompt } from '../../src/lib/ai.js';
+import { isAiAvailable, aiUnavailableMessage, runAiPrompt } from '../../src/lib/ai.js';
 import { print } from '../../src/lib/output.js';
 import { registerChangelogCommand } from '../../src/commands/changelog.js';
 
@@ -164,7 +164,7 @@ describe('changelog generate command', () => {
       features: { ai: false },
     });
     fs.pathExists.mockResolvedValue(true);
-    isClaudeAvailable.mockResolvedValue(false);
+    isAiAvailable.mockResolvedValue(false);
 
     await createProgram().parseAsync(['node', 'sfdt', 'changelog', 'generate']);
 
@@ -187,7 +187,7 @@ describe('changelog generate command', () => {
 
   it('appends AI response to [Unreleased] section when user approves', async () => {
     fs.pathExists.mockResolvedValue(true);
-    isClaudeAvailable.mockResolvedValue(true);
+    isAiAvailable.mockResolvedValue(true);
     runAiPrompt.mockResolvedValue('### Added\n- New feature');
     inquirer.prompt.mockResolvedValueOnce({ apply: true });
     fs.readFile.mockResolvedValue('# Changelog\n\n## [Unreleased]\n\n## [1.0.0]\n');

--- a/test/commands/changelog.test.js
+++ b/test/commands/changelog.test.js
@@ -84,23 +84,15 @@ describe('changelog release command', () => {
     expect(print.success).toHaveBeenCalled();
   });
 
-  it('does not interpolate version into the script body', async () => {
+  it('rejects non-semver version strings before invoking the shell', async () => {
     const maliciousVersion = '1.0"; rm -rf /; echo "';
     execa.mockResolvedValue({ stdout: '', exitCode: 0 });
 
     await createProgram().parseAsync(['node', 'sfdt', 'changelog', 'release', maliciousVersion]);
 
-    const [, args] = execa.mock.calls[0];
-    const scriptBody = args[1];
-    // The script body must NOT contain the raw version string
-    expect(scriptBody).not.toContain(maliciousVersion);
-    // It must reference the env var instead
-    expect(scriptBody).toContain('$SFDT_VERSION');
-    // Path is safely in args, not the script body
-    expect(args[3]).toContain('changelog-utils.sh');
-    // The version is safely in env
-    const options = execa.mock.calls[0][2];
-    expect(options.env.SFDT_VERSION).toBe(maliciousVersion);
+    // Semver validation must reject the malicious input — execa should never be called
+    expect(execa).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
   });
 
   it('sets exitCode 1 on failure', async () => {

--- a/test/commands/explain.test.js
+++ b/test/commands/explain.test.js
@@ -18,7 +18,7 @@ vi.mock('glob', () => ({
 }));
 
 vi.mock('../../src/lib/ai.js', () => ({
-  isClaudeAvailable: vi.fn(),
+  isAiAvailable: vi.fn(), aiUnavailableMessage: vi.fn().mockReturnValue("AI provider not available"),
   runAiPrompt: vi.fn(),
 }));
 
@@ -36,7 +36,7 @@ vi.mock('../../src/lib/output.js', () => ({
 import fs from 'fs-extra';
 import { glob } from 'glob';
 import { loadConfig } from '../../src/lib/config.js';
-import { isClaudeAvailable, runAiPrompt } from '../../src/lib/ai.js';
+import { isAiAvailable, aiUnavailableMessage, runAiPrompt } from '../../src/lib/ai.js';
 import { print } from '../../src/lib/output.js';
 import { registerExplainCommand } from '../../src/commands/explain.js';
 
@@ -56,6 +56,7 @@ const defaultConfig = {
 beforeEach(() => {
   vi.resetAllMocks();
   process.exitCode = undefined;
+  aiUnavailableMessage.mockReturnValue('AI provider not available');
   loadConfig.mockResolvedValue(defaultConfig);
 });
 
@@ -65,7 +66,7 @@ describe('explain command', () => {
     fs.readFile.mockResolvedValue(
       "Error: No such column 'MissingField__c' on entity 'Account'\nDEPLOYMENT FAILED",
     );
-    isClaudeAvailable.mockResolvedValue(true);
+    isAiAvailable.mockResolvedValue(true);
     runAiPrompt.mockResolvedValue({ stdout: 'analysis', exitCode: 0 });
 
     await createProgram().parseAsync(['node', 'sfdt', 'explain', 'logs/deploy.log']);
@@ -90,14 +91,14 @@ describe('explain command', () => {
     expect(runAiPrompt).not.toHaveBeenCalled();
   });
 
-  it('reports info when Claude CLI is not available', async () => {
+  it('reports info when AI provider is not available', async () => {
     fs.pathExists.mockResolvedValue(true);
     fs.readFile.mockResolvedValue('Some error log content');
-    isClaudeAvailable.mockResolvedValue(false);
+    isAiAvailable.mockResolvedValue(false);
 
     await createProgram().parseAsync(['node', 'sfdt', 'explain', 'logs/deploy.log']);
 
-    expect(print.info).toHaveBeenCalledWith(expect.stringContaining('Claude CLI is not installed'));
+    expect(print.info).toHaveBeenCalledWith(expect.stringContaining('not available'));
     expect(runAiPrompt).not.toHaveBeenCalled();
   });
 
@@ -119,7 +120,7 @@ describe('explain command', () => {
       .mockResolvedValueOnce({ mtimeMs: 1000 }) // old.log
       .mockResolvedValueOnce({ mtimeMs: 2000 }); // new.log
     fs.readFile.mockResolvedValue('Latest log content');
-    isClaudeAvailable.mockResolvedValue(true);
+    isAiAvailable.mockResolvedValue(true);
     runAiPrompt.mockResolvedValue({ stdout: 'result', exitCode: 0 });
 
     await createProgram().parseAsync(['node', 'sfdt', 'explain', '--latest']);

--- a/test/commands/manifest.test.js
+++ b/test/commands/manifest.test.js
@@ -18,7 +18,7 @@ vi.mock('fs-extra', () => ({
 }));
 
 vi.mock('../../src/lib/ai.js', () => ({
-  isClaudeAvailable: vi.fn(),
+  isAiAvailable: vi.fn(), aiUnavailableMessage: vi.fn().mockReturnValue("AI provider not available"),
   runAiPrompt: vi.fn(),
 }));
 
@@ -36,7 +36,7 @@ vi.mock('../../src/lib/output.js', () => ({
 import { execa } from 'execa';
 import fs from 'fs-extra';
 import { loadConfig } from '../../src/lib/config.js';
-import { isClaudeAvailable, runAiPrompt } from '../../src/lib/ai.js';
+import { isAiAvailable, aiUnavailableMessage, runAiPrompt } from '../../src/lib/ai.js';
 import { print } from '../../src/lib/output.js';
 import { registerManifestCommand } from '../../src/commands/manifest.js';
 
@@ -153,7 +153,7 @@ describe('manifest command', () => {
   it('runs AI cleanup when AI is enabled and --ai-cleanup is set', async () => {
     const aiConfig = { ...defaultConfig, features: { ai: true } };
     loadConfig.mockResolvedValue(aiConfig);
-    isClaudeAvailable.mockResolvedValue(true);
+    isAiAvailable.mockResolvedValue(true);
 
     const diffOutput = 'A\tforce-app/main/default/classes/Foo.cls';
     execa

--- a/test/commands/prDescription.test.js
+++ b/test/commands/prDescription.test.js
@@ -17,7 +17,7 @@ vi.mock('fs-extra', () => ({
 }));
 
 vi.mock('../../src/lib/ai.js', () => ({
-  isClaudeAvailable: vi.fn(),
+  isAiAvailable: vi.fn(), aiUnavailableMessage: vi.fn().mockReturnValue("AI provider not available"),
   runAiPrompt: vi.fn(),
 }));
 
@@ -35,7 +35,7 @@ vi.mock('../../src/lib/output.js', () => ({
 import { execa } from 'execa';
 import fs from 'fs-extra';
 import { loadConfig } from '../../src/lib/config.js';
-import { isClaudeAvailable, runAiPrompt } from '../../src/lib/ai.js';
+import { isAiAvailable, aiUnavailableMessage, runAiPrompt } from '../../src/lib/ai.js';
 import { print } from '../../src/lib/output.js';
 import { registerPrDescriptionCommand } from '../../src/commands/prDescription.js';
 
@@ -56,6 +56,7 @@ const defaultConfig = {
 beforeEach(() => {
   vi.resetAllMocks();
   process.exitCode = undefined;
+  aiUnavailableMessage.mockReturnValue('AI provider not available');
   loadConfig.mockResolvedValue(defaultConfig);
   fs.ensureDir.mockResolvedValue();
   fs.writeFile.mockResolvedValue();
@@ -74,19 +75,17 @@ describe('pr-description command', () => {
     expect(process.exitCode).toBe(1);
   });
 
-  it('errors when Claude CLI not available', async () => {
-    isClaudeAvailable.mockResolvedValue(false);
+  it('errors when AI provider not available', async () => {
+    isAiAvailable.mockResolvedValue(false);
 
     await createProgram().parseAsync(['node', 'sfdt', 'pr-description']);
 
-    expect(print.error).toHaveBeenCalledWith(
-      expect.stringContaining('Claude CLI is not installed'),
-    );
+    expect(print.error).toHaveBeenCalledWith(expect.stringContaining('not available'));
     expect(process.exitCode).toBe(1);
   });
 
   it('generates github-format description and prints to stdout', async () => {
-    isClaudeAvailable.mockResolvedValue(true);
+    isAiAvailable.mockResolvedValue(true);
     execa
       .mockResolvedValueOnce({ stdout: 'abc1234 Add AccountHelper' }) // git log
       .mockResolvedValueOnce({
@@ -112,7 +111,7 @@ describe('pr-description command', () => {
   });
 
   it('writes output to file with --output', async () => {
-    isClaudeAvailable.mockResolvedValue(true);
+    isAiAvailable.mockResolvedValue(true);
     execa
       .mockResolvedValueOnce({ stdout: 'abc1234 Commit msg' })
       .mockResolvedValueOnce({ stdout: 'A\tforce-app/main/default/classes/Foo.cls' });
@@ -135,7 +134,7 @@ describe('pr-description command', () => {
   });
 
   it('supports slack format', async () => {
-    isClaudeAvailable.mockResolvedValue(true);
+    isAiAvailable.mockResolvedValue(true);
     execa
       .mockResolvedValueOnce({ stdout: 'abc1234 Commit' })
       .mockResolvedValueOnce({ stdout: 'A\tforce-app/main/default/classes/Foo.cls' });
@@ -178,7 +177,7 @@ describe('pr-description command', () => {
   });
 
   it('warns when no changes between refs', async () => {
-    isClaudeAvailable.mockResolvedValue(true);
+    isAiAvailable.mockResolvedValue(true);
     execa
       .mockResolvedValueOnce({ stdout: '' }) // no commits
       .mockResolvedValueOnce({ stdout: '' }); // no diff
@@ -189,7 +188,7 @@ describe('pr-description command', () => {
   });
 
   it('handles AI returning empty output', async () => {
-    isClaudeAvailable.mockResolvedValue(true);
+    isAiAvailable.mockResolvedValue(true);
     execa
       .mockResolvedValueOnce({ stdout: 'abc1234 Commit' })
       .mockResolvedValueOnce({ stdout: 'A\tforce-app/main/default/classes/Foo.cls' });

--- a/test/commands/quality.test.js
+++ b/test/commands/quality.test.js
@@ -10,7 +10,7 @@ vi.mock('../../src/lib/script-runner.js', () => ({
 }));
 
 vi.mock('../../src/lib/ai.js', () => ({
-  isClaudeAvailable: vi.fn(),
+  isAiAvailable: vi.fn(),
   runAiPrompt: vi.fn(),
 }));
 
@@ -27,7 +27,7 @@ vi.mock('../../src/lib/output.js', () => ({
 
 import { loadConfig } from '../../src/lib/config.js';
 import { runScript } from '../../src/lib/script-runner.js';
-import { isClaudeAvailable, runAiPrompt } from '../../src/lib/ai.js';
+import { isAiAvailable, runAiPrompt } from '../../src/lib/ai.js';
 import { print } from '../../src/lib/output.js';
 import { registerQualityCommand } from '../../src/commands/quality.js';
 
@@ -95,7 +95,7 @@ describe('quality command', () => {
 
   it('generates AI fix plan with --fix-plan', async () => {
     runScript.mockResolvedValue({ exitCode: 0, stdout: 'issues found' });
-    isClaudeAvailable.mockResolvedValue(true);
+    isAiAvailable.mockResolvedValue(true);
     runAiPrompt.mockResolvedValue({ stdout: 'fix plan', exitCode: 0 });
 
     await createProgram().parseAsync(['node', 'sfdt', 'quality', '--fix-plan']);
@@ -108,7 +108,7 @@ describe('quality command', () => {
 
   it('warns when AI unavailable for --fix-plan', async () => {
     runScript.mockResolvedValue({ exitCode: 0, stdout: '' });
-    isClaudeAvailable.mockResolvedValue(false);
+    isAiAvailable.mockResolvedValue(false);
 
     await createProgram().parseAsync(['node', 'sfdt', 'quality', '--fix-plan']);
 

--- a/test/commands/release.test.js
+++ b/test/commands/release.test.js
@@ -10,7 +10,7 @@ vi.mock('../../src/lib/script-runner.js', () => ({
 }));
 
 vi.mock('../../src/lib/ai.js', () => ({
-  isClaudeAvailable: vi.fn(),
+  isAiAvailable: vi.fn(), aiUnavailableMessage: vi.fn().mockReturnValue("AI provider not available"),
   runAiPrompt: vi.fn(),
 }));
 
@@ -42,7 +42,7 @@ vi.mock('../../src/lib/output.js', () => ({
 
 import { loadConfig } from '../../src/lib/config.js';
 import { runScript } from '../../src/lib/script-runner.js';
-import { isClaudeAvailable, runAiPrompt } from '../../src/lib/ai.js';
+import { isAiAvailable, aiUnavailableMessage, runAiPrompt } from '../../src/lib/ai.js';
 import inquirer from 'inquirer';
 import { execa } from 'execa';
 import { print } from '../../src/lib/output.js';
@@ -97,7 +97,7 @@ beforeEach(() => {
 
 describe('release command', () => {
   it('runs generate-release-manifest.sh with captureStdout', async () => {
-    isClaudeAvailable.mockResolvedValue(false);
+    isAiAvailable.mockResolvedValue(false);
     mockPromptFlow();
 
     await createProgram().parseAsync(['node', 'sfdt', 'release']);
@@ -110,7 +110,7 @@ describe('release command', () => {
   });
 
   it('passes version argument to script', async () => {
-    isClaudeAvailable.mockResolvedValue(false);
+    isAiAvailable.mockResolvedValue(false);
     mockPromptFlow();
 
     await createProgram().parseAsync(['node', 'sfdt', 'release', '2.0.0']);
@@ -123,7 +123,7 @@ describe('release command', () => {
   });
 
   it('offers AI release notes when AI available', async () => {
-    isClaudeAvailable.mockResolvedValue(true);
+    isAiAvailable.mockResolvedValue(true);
     runAiPrompt.mockResolvedValue({ stdout: 'notes', exitCode: 0 });
     mockPromptFlow({ generateNotes: true });
 
@@ -136,7 +136,7 @@ describe('release command', () => {
   });
 
   it('skips AI notes when user declines', async () => {
-    isClaudeAvailable.mockResolvedValue(true);
+    isAiAvailable.mockResolvedValue(true);
     mockPromptFlow({ generateNotes: false });
 
     await createProgram().parseAsync(['node', 'sfdt', 'release']);
@@ -156,7 +156,7 @@ describe('release command', () => {
   it('stages release notes and CHANGELOG in git workflow', async () => {
     const fse = (await import('fs-extra')).default;
     fse.pathExists.mockResolvedValue(true); // release notes file exists
-    isClaudeAvailable.mockResolvedValue(false);
+    isAiAvailable.mockResolvedValue(false);
     // CHANGELOG has changes (exitCode 1 = diff detected)
     execa
       .mockResolvedValueOnce({ exitCode: 0, stdout: '' }) // git add manifests
@@ -181,7 +181,7 @@ describe('release command', () => {
   });
 
   it('asks about deployment before push', async () => {
-    isClaudeAvailable.mockResolvedValue(false);
+    isAiAvailable.mockResolvedValue(false);
     // git status shows staged files
     execa.mockImplementation((cmd, args) => {
       if (cmd === 'git' && args[0] === 'status') {

--- a/test/commands/review.test.js
+++ b/test/commands/review.test.js
@@ -10,7 +10,8 @@ vi.mock('../../src/lib/config.js', () => ({
 }));
 
 vi.mock('../../src/lib/ai.js', () => ({
-  isClaudeAvailable: vi.fn(),
+  isAiAvailable: vi.fn(),
+  aiUnavailableMessage: vi.fn().mockReturnValue('AI provider not available'),
   runAiPrompt: vi.fn(),
 }));
 
@@ -27,7 +28,7 @@ vi.mock('../../src/lib/output.js', () => ({
 
 import { execa } from 'execa';
 import { loadConfig } from '../../src/lib/config.js';
-import { isClaudeAvailable, runAiPrompt } from '../../src/lib/ai.js';
+import { isAiAvailable, aiUnavailableMessage, runAiPrompt } from '../../src/lib/ai.js';
 import { print } from '../../src/lib/output.js';
 import { registerReviewCommand } from '../../src/commands/review.js';
 
@@ -41,6 +42,7 @@ function createProgram() {
 beforeEach(() => {
   vi.resetAllMocks();
   process.exitCode = undefined;
+  aiUnavailableMessage.mockReturnValue('AI provider not available');
   loadConfig.mockResolvedValue({
     _projectRoot: '/project',
     defaultOrg: 'dev',
@@ -62,18 +64,16 @@ describe('review command', () => {
   });
 
   it('errors when Claude CLI not available', async () => {
-    isClaudeAvailable.mockResolvedValue(false);
+    isAiAvailable.mockResolvedValue(false);
 
     await createProgram().parseAsync(['node', 'sfdt', 'review']);
 
-    expect(print.error).toHaveBeenCalledWith(
-      expect.stringContaining('Claude CLI is not installed'),
-    );
+    expect(print.error).toHaveBeenCalledWith(expect.stringContaining('not available'));
     expect(process.exitCode).toBe(1);
   });
 
   it('warns when no diff found', async () => {
-    isClaudeAvailable.mockResolvedValue(true);
+    isAiAvailable.mockResolvedValue(true);
     execa.mockResolvedValue({ stdout: '', stderr: '' });
 
     await createProgram().parseAsync(['node', 'sfdt', 'review']);
@@ -82,7 +82,7 @@ describe('review command', () => {
   });
 
   it('sends diff to AI for review', async () => {
-    isClaudeAvailable.mockResolvedValue(true);
+    isAiAvailable.mockResolvedValue(true);
     execa.mockResolvedValue({ stdout: '+ added line\n- removed line', stderr: '' });
     runAiPrompt.mockResolvedValue({ stdout: 'review', exitCode: 0 });
 
@@ -100,7 +100,7 @@ describe('review command', () => {
   });
 
   it('uses custom base branch with --base', async () => {
-    isClaudeAvailable.mockResolvedValue(true);
+    isAiAvailable.mockResolvedValue(true);
     execa.mockResolvedValue({ stdout: 'diff content', stderr: '' });
     runAiPrompt.mockResolvedValue({ stdout: '', exitCode: 0 });
 
@@ -110,7 +110,7 @@ describe('review command', () => {
   });
 
   it('sets exitCode 1 on failure', async () => {
-    isClaudeAvailable.mockResolvedValue(true);
+    isAiAvailable.mockResolvedValue(true);
     execa.mockRejectedValue(new Error('git error'));
 
     await createProgram().parseAsync(['node', 'sfdt', 'review']);

--- a/test/commands/test.test.js
+++ b/test/commands/test.test.js
@@ -10,7 +10,7 @@ vi.mock('../../src/lib/script-runner.js', () => ({
 }));
 
 vi.mock('../../src/lib/ai.js', () => ({
-  isClaudeAvailable: vi.fn(),
+  isAiAvailable: vi.fn(),
   runAiPrompt: vi.fn(),
 }));
 
@@ -31,7 +31,7 @@ vi.mock('../../src/lib/output.js', () => ({
 
 import { loadConfig } from '../../src/lib/config.js';
 import { runScript } from '../../src/lib/script-runner.js';
-import { isClaudeAvailable, runAiPrompt } from '../../src/lib/ai.js';
+import { isAiAvailable, runAiPrompt } from '../../src/lib/ai.js';
 import inquirer from 'inquirer';
 import { print } from '../../src/lib/output.js';
 import { registerTestCommand } from '../../src/commands/test.js';
@@ -94,7 +94,7 @@ describe('test command', () => {
 
   it('offers AI analysis on test failure when AI enabled', async () => {
     runScript.mockRejectedValueOnce(new Error('tests failed'));
-    isClaudeAvailable.mockResolvedValue(true);
+    isAiAvailable.mockResolvedValue(true);
     inquirer.prompt.mockResolvedValue({ analyzeFailure: true });
     runAiPrompt.mockResolvedValue({ stdout: 'analysis', exitCode: 0 });
 
@@ -110,7 +110,7 @@ describe('test command', () => {
 
   it('skips AI analysis when user declines', async () => {
     runScript.mockRejectedValueOnce(new Error('tests failed'));
-    isClaudeAvailable.mockResolvedValue(true);
+    isAiAvailable.mockResolvedValue(true);
     inquirer.prompt.mockResolvedValue({ analyzeFailure: false });
 
     await createProgram().parseAsync(['node', 'sfdt', 'test']);

--- a/test/lib/plugin-loader.test.js
+++ b/test/lib/plugin-loader.test.js
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Command } from 'commander';
+
+vi.mock('../../src/lib/config.js', () => ({
+  loadConfig: vi.fn(),
+}));
+
+vi.mock('../../src/lib/output.js', () => ({
+  print: {
+    info: vi.fn(),
+    warning: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { loadConfig } from '../../src/lib/config.js';
+import { print } from '../../src/lib/output.js';
+
+// We test the plugin-loader behaviour through its public API.
+// Actual dynamic imports of external packages are integration-level,
+// so we keep the unit tests focused on the discovery and error-handling logic.
+
+describe('loadPlugins', () => {
+  let program;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    program = new Command();
+  });
+
+  it('returns early without error when not in an sfdt project', async () => {
+    loadConfig.mockRejectedValue(new Error('not in a project'));
+
+    const { loadPlugins } = await import('../../src/lib/plugin-loader.js');
+    await expect(loadPlugins(program)).resolves.toBeUndefined();
+  });
+
+  it('does not register commands when config.plugins is empty', async () => {
+    loadConfig.mockResolvedValue({
+      _projectRoot: '/project',
+      _configDir: '/project/.sfdt',
+      plugins: [],
+    });
+
+    const { loadPlugins } = await import('../../src/lib/plugin-loader.js');
+    const before = program.commands.length;
+    await loadPlugins(program);
+
+    expect(program.commands.length).toBe(before);
+    expect(print.warning).not.toHaveBeenCalled();
+  });
+
+  it('warns instead of throwing when a listed plugin cannot be loaded', async () => {
+    loadConfig.mockResolvedValue({
+      _projectRoot: '/project',
+      _configDir: '/project/.sfdt',
+      plugins: ['sfdt-plugin-does-not-exist'],
+    });
+
+    const { loadPlugins } = await import('../../src/lib/plugin-loader.js');
+    await expect(loadPlugins(program)).resolves.toBeUndefined();
+    expect(print.warning).toHaveBeenCalledWith(
+      expect.stringContaining('sfdt-plugin-does-not-exist'),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Phase 4 is complete. This PR merges `develop` into `main` to tag and publish **v0.3.0**.

### What's in this release

**Phase 4 — Platform & Ecosystem (all items complete):**

- **Multi-provider AI** — `ai.provider` selects `claude` (Claude Code CLI), `gemini` (Google Gemini REST), or `openai` (OpenAI REST). API providers use native `fetch` with SSE streaming — no new npm deps. `sfdt init` now prompts for provider and API key. All 8 AI-calling commands updated to route through the configured provider transparently.
- **AI credential auto-discovery** — API keys stored in `ai.apiKey` or resolved from env vars (`GEMINI_API_KEY` / `OPENAI_API_KEY`) at runtime.
- **Plugin architecture** — `src/lib/plugin-loader.js` discovers plugins from: (1) `config.plugins[]` packages, (2) auto-discovered `sfdt-plugin-*` / `@scope/sfdt-plugin-*` in `node_modules/`, (3) `.sfdt/plugins/*.js` local scripts. Loaded before CLI parsing so plugins appear in `--help` and tab-completion.
- **Web dashboard** (`sfdt ui`) — Express server on port 7654 serving a React 18 + Salesforce Lightning Design System dashboard with pages for Dashboard, Test Runs, Preflight, and Drift Detection.
- **Docker support** — `Dockerfile` ships Node 20 slim + Salesforce CLI + git/jq/bash. Mounts a Salesforce DX project at `/project`.

**Release prep (this commit):**

- Version bump `0.2.2` → `0.3.0`
- CHANGELOG entry for `[0.3.0]`
- ROADMAP Phase 5 (Planned) section added
- **Bugfix:** `.gitignore` had `dist/` matching `gui/dist/` at any depth despite a comment saying it was "not ignored" — now explicit
- **Bugfix:** CI never built the GUI before `npm publish`, so `gui/dist/` was absent from the published tarball — `npm run build:gui` added before both the dry-run and the real publish step

## Test plan

- [ ] CI passes on this PR (test matrix Node 20 + 22, lint, audit, dry-run with GUI build)
- [ ] After merge, CI publish job detects version bump, tags `v0.3.0`, publishes to npm, and creates GitHub Release
- [ ] `npm install -g @sfdt/cli@0.3.0` and verify `sfdt ui` opens the dashboard