### PR TITLE
Rebuild GUI using SLDS React components throughout

### DIFF
--- a/gui/src/App.jsx
+++ b/gui/src/App.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import IconSettings from '@salesforce/design-system-react/components/icon-settings';
+import Icon from '@salesforce/design-system-react/components/icon';
 import { api } from './api.js';
 import Dashboard from './pages/Dashboard.jsx';
 import TestRuns from './pages/TestRuns.jsx';
@@ -7,10 +8,10 @@ import PreflightPage from './pages/Preflight.jsx';
 import DriftPage from './pages/Drift.jsx';
 
 const NAV_ITEMS = [
-  { id: 'dashboard', label: 'Dashboard', icon: '⚡' },
-  { id: 'tests', label: 'Test Runs', icon: '✓' },
-  { id: 'preflight', label: 'Preflight', icon: '🔍' },
-  { id: 'drift', label: 'Drift Detection', icon: '⚖' },
+  { id: 'dashboard', label: 'Dashboard',       icon: 'home' },
+  { id: 'tests',     label: 'Test Runs',        icon: 'list' },
+  { id: 'preflight', label: 'Preflight',        icon: 'check' },
+  { id: 'drift',     label: 'Drift Detection',  icon: 'refresh' },
 ];
 
 export default function App() {
@@ -23,122 +24,111 @@ export default function App() {
 
   const renderPage = () => {
     switch (page) {
-      case 'dashboard':
-        return <Dashboard project={project} />;
-      case 'tests':
-        return <TestRuns />;
-      case 'preflight':
-        return <PreflightPage />;
-      case 'drift':
-        return <DriftPage />;
-      default:
-        return <Dashboard project={project} />;
+      case 'dashboard': return <Dashboard project={project} />;
+      case 'tests':     return <TestRuns />;
+      case 'preflight': return <PreflightPage />;
+      case 'drift':     return <DriftPage />;
+      default:          return <Dashboard project={project} />;
     }
   };
 
   return (
     <IconSettings iconPath="/assets/icons">
       <div className="slds-grid slds-nowrap" style={{ height: '100vh' }}>
-        {/* Sidebar */}
+
+        {/* ── Left navigation panel ─────────────────────────────────────── */}
         <aside
           className="slds-col slds-no-flex"
-          style={{
-            width: '220px',
-            background: '#032d60',
-            color: '#fff',
-            display: 'flex',
-            flexDirection: 'column',
-          }}
+          style={{ width: '240px', background: '#032d60', display: 'flex', flexDirection: 'column' }}
         >
-          {/* Logo / App Name */}
+          {/* Project / app header */}
           <div
-            style={{
-              padding: '20px 16px 16px',
-              borderBottom: '1px solid rgba(255,255,255,0.15)',
-            }}
+            className="slds-media slds-media_center slds-p-around_medium"
+            style={{ borderBottom: '1px solid rgba(255,255,255,0.15)', flexShrink: 0 }}
           >
-            <div
-              style={{
-                fontSize: '11px',
-                fontWeight: 700,
-                letterSpacing: '1px',
-                textTransform: 'uppercase',
-                color: 'rgba(255,255,255,0.6)',
-                marginBottom: '4px',
-              }}
-            >
-              Salesforce DevTools
-            </div>
-            <div style={{ fontSize: '16px', fontWeight: 700, color: '#fff' }}>
-              {project?.name ?? 'SFDT'}
-            </div>
-            {project?.org && (
-              <div
-                style={{
-                  fontSize: '12px',
-                  color: 'rgba(255,255,255,0.55)',
-                  marginTop: '2px',
-                }}
+            <div className="slds-media__body">
+              <p
+                className="slds-text-body_small slds-m-bottom_xx-small"
+                style={{ color: 'rgba(255,255,255,0.55)', textTransform: 'uppercase', letterSpacing: '1px', fontWeight: 700 }}
               >
-                {project.org}
-              </div>
-            )}
+                Salesforce DevTools
+              </p>
+              <p
+                className="slds-text-heading_small slds-truncate"
+                style={{ color: '#fff' }}
+                title={project?.name ?? 'SFDT'}
+              >
+                {project?.name ?? 'SFDT'}
+              </p>
+              {project?.org && (
+                <p
+                  className="slds-text-body_small slds-truncate"
+                  style={{ color: 'rgba(255,255,255,0.55)' }}
+                  title={project.org}
+                >
+                  {project.org}
+                </p>
+              )}
+            </div>
           </div>
 
-          {/* Nav */}
-          <nav style={{ flex: 1, padding: '8px 0' }}>
-            {NAV_ITEMS.map((item) => (
-              <button
-                key={item.id}
-                onClick={() => setPage(item.id)}
-                style={{
-                  width: '100%',
-                  textAlign: 'left',
-                  background: page === item.id ? 'rgba(255,255,255,0.12)' : 'transparent',
-                  border: 'none',
-                  borderLeft: page === item.id ? '3px solid #1b96ff' : '3px solid transparent',
-                  color: page === item.id ? '#fff' : 'rgba(255,255,255,0.72)',
-                  padding: '10px 16px 10px 13px',
-                  cursor: 'pointer',
-                  fontSize: '14px',
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: '10px',
-                  transition: 'background 0.1s',
-                }}
-                onMouseEnter={(e) => {
-                  if (page !== item.id)
-                    e.currentTarget.style.background = 'rgba(255,255,255,0.07)';
-                }}
-                onMouseLeave={(e) => {
-                  if (page !== item.id) e.currentTarget.style.background = 'transparent';
-                }}
-              >
-                <span style={{ fontSize: '16px', width: '20px', textAlign: 'center' }}>
-                  {item.icon}
-                </span>
-                {item.label}
-              </button>
-            ))}
+          {/* Vertical navigation */}
+          <nav className="slds-nav-vertical" style={{ flex: 1, paddingTop: '8px' }}>
+            <div className="slds-nav-vertical__section">
+              <ul>
+                {NAV_ITEMS.map((item) => {
+                  const active = page === item.id;
+                  return (
+                    <li
+                      key={item.id}
+                      className={`slds-nav-vertical__item${active ? ' slds-is-active' : ''}`}
+                    >
+                      <a
+                        href="#"
+                        className="slds-nav-vertical__action"
+                        aria-current={active ? 'page' : undefined}
+                        onClick={(e) => { e.preventDefault(); setPage(item.id); }}
+                        style={{
+                          color: active ? '#fff' : 'rgba(255,255,255,0.72)',
+                          background: active ? 'rgba(255,255,255,0.12)' : 'transparent',
+                          borderLeft: active ? '3px solid #1b96ff' : '3px solid transparent',
+                          paddingLeft: '13px',
+                        }}
+                      >
+                        <span className="slds-media slds-media_center slds-media_small">
+                          <span className="slds-media__figure">
+                            <Icon
+                              assistiveText={{ label: item.label }}
+                              category="utility"
+                              name={item.icon}
+                              size="x-small"
+                              colorVariant="light"
+                            />
+                          </span>
+                          <span className="slds-media__body">{item.label}</span>
+                        </span>
+                      </a>
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
           </nav>
 
           {/* Footer */}
           <div
-            style={{
-              padding: '12px 16px',
-              borderTop: '1px solid rgba(255,255,255,0.12)',
-              fontSize: '11px',
-              color: 'rgba(255,255,255,0.4)',
-            }}
+            className="slds-p-around_small slds-text-body_small"
+            style={{ borderTop: '1px solid rgba(255,255,255,0.12)', color: 'rgba(255,255,255,0.4)', flexShrink: 0 }}
           >
             sfdt v{project?.version ?? '…'}
           </div>
         </aside>
 
-        {/* Main */}
+        {/* ── Main content ──────────────────────────────────────────────── */}
         <main className="slds-col" style={{ flex: 1, overflow: 'auto', background: '#f3f3f3' }}>
           {renderPage()}
         </main>
+
       </div>
     </IconSettings>
   );

--- a/gui/src/components/EmptyState.jsx
+++ b/gui/src/components/EmptyState.jsx
@@ -1,19 +1,24 @@
 import React from 'react';
+import Icon from '@salesforce/design-system-react/components/icon';
 
 export default function EmptyState({ title, message }) {
   return (
-    <div
-      style={{
-        textAlign: 'center',
-        padding: '60px 32px',
-        color: '#706e6b',
-      }}
-    >
-      <div style={{ fontSize: '48px', marginBottom: '16px' }}>📭</div>
-      <div style={{ fontSize: '16px', fontWeight: 600, color: '#3e3e3c', marginBottom: '8px' }}>
-        {title ?? 'No data yet'}
+    <div className="slds-text-align_center slds-p-vertical_xx-large">
+      <div className="slds-m-bottom_medium">
+        <Icon
+          assistiveText={{ label: title ?? 'No data' }}
+          category="utility"
+          name="table"
+          size="large"
+          style={{ fill: '#b0adab' }}
+        />
       </div>
-      <div style={{ fontSize: '14px' }}>{message ?? 'Run a command to see results here.'}</div>
+      <h3 className="slds-text-heading_medium slds-m-bottom_small">
+        {title ?? 'No data yet'}
+      </h3>
+      <p className="slds-text-body_regular slds-text-color_weak">
+        {message ?? 'Run a command to see results here.'}
+      </p>
     </div>
   );
 }

--- a/gui/src/components/StatCard.jsx
+++ b/gui/src/components/StatCard.jsx
@@ -1,45 +1,27 @@
 import React from 'react';
+import Card from '@salesforce/design-system-react/components/card';
+import Icon from '@salesforce/design-system-react/components/icon';
 
-export default function StatCard({ label, value, sub, accent }) {
+export default function StatCard({ label, value, sub, accent = '#0176d3', iconName = 'info' }) {
   return (
-    <div
-      className="slds-box slds-box_small"
-      style={{
-        background: '#fff',
-        borderRadius: '8px',
-        padding: '20px 24px',
-        flex: 1,
-        minWidth: '150px',
-        borderTop: `4px solid ${accent ?? '#0176d3'}`,
-        boxShadow: '0 1px 3px rgba(0,0,0,0.08)',
-      }}
+    <Card
+      style={{ borderTop: `4px solid ${accent}`, flex: '1 1 150px' }}
+      heading={label}
+      icon={
+        <Icon
+          assistiveText={{ label }}
+          category="utility"
+          name={iconName}
+          size="small"
+        />
+      }
     >
-      <div
-        style={{
-          fontSize: '12px',
-          fontWeight: 600,
-          textTransform: 'uppercase',
-          letterSpacing: '0.5px',
-          color: '#706e6b',
-          marginBottom: '8px',
-        }}
-      >
-        {label}
+      <div className="slds-card__body_inner">
+        <p className="slds-text-heading_large slds-m-bottom_xx-small">{value ?? '—'}</p>
+        {sub && (
+          <p className="slds-text-body_small slds-text-color_weak">{sub}</p>
+        )}
       </div>
-      <div
-        style={{
-          fontSize: '36px',
-          fontWeight: 700,
-          color: '#181818',
-          lineHeight: 1,
-          marginBottom: '4px',
-        }}
-      >
-        {value ?? '—'}
-      </div>
-      {sub && (
-        <div style={{ fontSize: '12px', color: '#706e6b', marginTop: '4px' }}>{sub}</div>
-      )}
-    </div>
+    </Card>
   );
 }

--- a/gui/src/components/StatusBadge.jsx
+++ b/gui/src/components/StatusBadge.jsx
@@ -1,38 +1,23 @@
 import React from 'react';
+import Badge from '@salesforce/design-system-react/components/badge';
 
-const VARIANTS = {
-  pass: { bg: '#2e844a', color: '#fff', label: 'Pass' },
-  passed: { bg: '#2e844a', color: '#fff', label: 'Passed' },
-  success: { bg: '#2e844a', color: '#fff', label: 'Success' },
-  fail: { bg: '#ba0517', color: '#fff', label: 'Fail' },
-  failed: { bg: '#ba0517', color: '#fff', label: 'Failed' },
-  error: { bg: '#ba0517', color: '#fff', label: 'Error' },
-  warn: { bg: '#dd7a01', color: '#fff', label: 'Warning' },
-  warning: { bg: '#dd7a01', color: '#fff', label: 'Warning' },
-  running: { bg: '#0176d3', color: '#fff', label: 'Running' },
-  unknown: { bg: '#919191', color: '#fff', label: 'Unknown' },
-  clean: { bg: '#2e844a', color: '#fff', label: 'Clean' },
-  drift: { bg: '#dd7a01', color: '#fff', label: 'Drift' },
+const CONFIG = {
+  pass:    { color: 'success', label: 'Pass' },
+  passed:  { color: 'success', label: 'Passed' },
+  success: { color: 'success', label: 'Success' },
+  fail:    { color: 'error',   label: 'Fail' },
+  failed:  { color: 'error',   label: 'Failed' },
+  error:   { color: 'error',   label: 'Error' },
+  warn:    { color: 'warning', label: 'Warning' },
+  warning: { color: 'warning', label: 'Warning' },
+  running: { color: 'default', label: 'Running' },
+  unknown: { color: 'inverse', label: 'Unknown' },
+  clean:   { color: 'success', label: 'Clean' },
+  drift:   { color: 'warning', label: 'Drift' },
 };
 
 export default function StatusBadge({ status }) {
   const key = (status ?? 'unknown').toLowerCase();
-  const variant = VARIANTS[key] ?? VARIANTS.unknown;
-  return (
-    <span
-      style={{
-        display: 'inline-block',
-        padding: '2px 10px',
-        borderRadius: '12px',
-        fontSize: '12px',
-        fontWeight: 600,
-        background: variant.bg,
-        color: variant.color,
-        textTransform: 'uppercase',
-        letterSpacing: '0.5px',
-      }}
-    >
-      {variant.label}
-    </span>
-  );
+  const { color, label } = CONFIG[key] ?? CONFIG.unknown;
+  return <Badge content={label} color={color} />;
 }

--- a/gui/src/pages/Dashboard.jsx
+++ b/gui/src/pages/Dashboard.jsx
@@ -1,29 +1,11 @@
 import React, { useState, useEffect } from 'react';
+import PageHeader from '@salesforce/design-system-react/components/page-header';
 import Card from '@salesforce/design-system-react/components/card';
+import Icon from '@salesforce/design-system-react/components/icon';
 import Spinner from '@salesforce/design-system-react/components/spinner';
 import { api } from '../api.js';
 import StatCard from '../components/StatCard.jsx';
 import StatusBadge from '../components/StatusBadge.jsx';
-
-function Section({ title, children }) {
-  return (
-    <div style={{ marginBottom: '24px' }}>
-      <h2
-        style={{
-          fontSize: '13px',
-          fontWeight: 700,
-          textTransform: 'uppercase',
-          letterSpacing: '0.8px',
-          color: '#706e6b',
-          marginBottom: '12px',
-        }}
-      >
-        {title}
-      </h2>
-      {children}
-    </div>
-  );
-}
 
 export default function Dashboard({ project }) {
   const [tests, setTests] = useState(null);
@@ -33,162 +15,215 @@ export default function Dashboard({ project }) {
 
   useEffect(() => {
     Promise.all([api.testRuns(), api.preflight(), api.drift()])
-      .then(([t, p, d]) => {
-        setTests(t);
-        setPreflight(p);
-        setDrift(d);
-      })
+      .then(([t, p, d]) => { setTests(t); setPreflight(p); setDrift(d); })
       .catch(() => {})
       .finally(() => setLoading(false));
   }, []);
 
-  const lastTest = tests?.runs?.[0];
-  const totalPassed = tests?.runs?.reduce((s, r) => s + (r.passed ?? 0), 0) ?? 0;
-  const totalFailed = tests?.runs?.reduce((s, r) => s + (r.failed ?? 0), 0) ?? 0;
-
-  if (loading) {
-    return (
-      <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '60vh' }}>
-        <Spinner size="large" variant="brand" />
-      </div>
-    );
-  }
+  const lastTest     = tests?.runs?.[0];
+  const totalPassed  = tests?.runs?.reduce((s, r) => s + (r.passed ?? 0), 0) ?? 0;
+  const totalFailed  = tests?.runs?.reduce((s, r) => s + (r.failed ?? 0), 0) ?? 0;
 
   return (
-    <div style={{ padding: '28px 32px' }}>
-      {/* Page header */}
-      <div style={{ marginBottom: '28px' }}>
-        <h1 style={{ fontSize: '24px', fontWeight: 700, color: '#032d60', margin: 0 }}>
-          Dashboard
-        </h1>
-        {project?.org && (
-          <div style={{ fontSize: '14px', color: '#706e6b', marginTop: '4px' }}>
-            Connected org: <strong>{project.org}</strong>
-          </div>
-        )}
-      </div>
+    <div>
+      <PageHeader
+        title="Dashboard"
+        label="SFDT"
+        info={project?.org ? `Connected org: ${project.org}` : undefined}
+        variant="object-home"
+        icon={
+          <Icon
+            assistiveText={{ label: 'Dashboard' }}
+            category="utility"
+            name="home"
+            size="large"
+          />
+        }
+      />
 
-      {/* Summary stats */}
-      <Section title="Summary">
-        <div style={{ display: 'flex', gap: '16px', flexWrap: 'wrap' }}>
-          <StatCard label="Tests Passed" value={totalPassed} accent="#2e844a" />
-          <StatCard label="Tests Failed" value={totalFailed} accent={totalFailed > 0 ? '#ba0517' : '#2e844a'} />
-          <StatCard
-            label="Coverage Threshold"
-            value={project?.coverageThreshold ? `${project.coverageThreshold}%` : '75%'}
-            accent="#0176d3"
-          />
-          <StatCard
-            label="Last Test Run"
-            value={lastTest ? new Date(lastTest.date).toLocaleDateString() : '—'}
-            sub={lastTest ? new Date(lastTest.date).toLocaleTimeString() : undefined}
-            accent="#9050e9"
-          />
+      {loading ? (
+        <div style={{ position: 'relative', height: '300px' }}>
+          <Spinner size="large" variant="brand" />
         </div>
-      </Section>
+      ) : (
+        <div className="slds-p-around_large">
 
-      {/* Recent activity */}
-      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '20px' }}>
-        {/* Test runs */}
-        <Card
-          heading="Recent Test Runs"
-          style={{ background: '#fff', borderRadius: '8px' }}
-        >
-          <div style={{ padding: '0 16px 16px' }}>
-            {!tests?.runs?.length ? (
-              <p style={{ color: '#706e6b', fontSize: '14px', padding: '12px 0' }}>
-                No test runs found. Run <code>sfdt test</code> to generate results.
-              </p>
-            ) : (
-              <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '13px' }}>
-                <thead>
-                  <tr style={{ borderBottom: '1px solid #e5e5e5' }}>
-                    <th style={{ textAlign: 'left', padding: '8px 4px', color: '#706e6b', fontWeight: 600 }}>Date</th>
-                    <th style={{ textAlign: 'right', padding: '8px 4px', color: '#706e6b', fontWeight: 600 }}>Passed</th>
-                    <th style={{ textAlign: 'right', padding: '8px 4px', color: '#706e6b', fontWeight: 600 }}>Failed</th>
-                    <th style={{ textAlign: 'right', padding: '8px 4px', color: '#706e6b', fontWeight: 600 }}>Status</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {tests.runs.slice(0, 5).map((run, i) => (
-                    <tr key={i} style={{ borderBottom: '1px solid #f3f3f3' }}>
-                      <td style={{ padding: '8px 4px', color: '#3e3e3c' }}>
-                        {new Date(run.date).toLocaleDateString()}
-                      </td>
-                      <td style={{ padding: '8px 4px', textAlign: 'right', color: '#2e844a', fontWeight: 600 }}>
-                        {run.passed ?? 0}
-                      </td>
-                      <td style={{ padding: '8px 4px', textAlign: 'right', color: run.failed ? '#ba0517' : '#3e3e3c', fontWeight: run.failed ? 700 : 400 }}>
-                        {run.failed ?? 0}
-                      </td>
-                      <td style={{ padding: '8px 4px', textAlign: 'right' }}>
-                        <StatusBadge status={run.failed ? 'fail' : 'pass'} />
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            )}
+          {/* ── Summary stats ──────────────────────────────────────────── */}
+          <p className="slds-text-title_caps slds-text-color_weak slds-m-bottom_small">
+            Summary
+          </p>
+          <div className="slds-grid slds-wrap slds-gutters slds-m-bottom_large">
+            <div className="slds-col slds-size_1-of-2 slds-medium-size_1-of-4">
+              <StatCard
+                label="Tests Passed"
+                value={totalPassed}
+                accent="#2e844a"
+                iconName="check"
+              />
+            </div>
+            <div className="slds-col slds-size_1-of-2 slds-medium-size_1-of-4">
+              <StatCard
+                label="Tests Failed"
+                value={totalFailed}
+                accent={totalFailed > 0 ? '#ba0517' : '#2e844a'}
+                iconName={totalFailed > 0 ? 'close' : 'check'}
+              />
+            </div>
+            <div className="slds-col slds-size_1-of-2 slds-medium-size_1-of-4">
+              <StatCard
+                label="Coverage Threshold"
+                value={project?.coverageThreshold ? `${project.coverageThreshold}%` : '75%'}
+                accent="#0176d3"
+                iconName="chart"
+              />
+            </div>
+            <div className="slds-col slds-size_1-of-2 slds-medium-size_1-of-4">
+              <StatCard
+                label="Last Test Run"
+                value={lastTest ? new Date(lastTest.date).toLocaleDateString() : '—'}
+                sub={lastTest ? new Date(lastTest.date).toLocaleTimeString() : undefined}
+                accent="#9050e9"
+                iconName="clock"
+              />
+            </div>
           </div>
-        </Card>
 
-        {/* Preflight + Drift */}
-        <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
-          <Card heading="Last Preflight Check">
-            <div style={{ padding: '0 16px 16px' }}>
-              {!preflight?.checks?.length ? (
-                <p style={{ color: '#706e6b', fontSize: '14px', padding: '12px 0' }}>
-                  No preflight data. Run <code>sfdt preflight</code>.
-                </p>
-              ) : (
-                <>
-                  <div style={{ marginBottom: '8px', fontSize: '12px', color: '#706e6b' }}>
-                    {preflight.date ? new Date(preflight.date).toLocaleString() : ''}
+          {/* ── Recent activity ────────────────────────────────────────── */}
+          <p className="slds-text-title_caps slds-text-color_weak slds-m-bottom_small">
+            Recent Activity
+          </p>
+          <div className="slds-grid slds-wrap slds-gutters">
+
+            {/* Recent test runs */}
+            <div className="slds-col slds-size_1-of-1 slds-medium-size_1-of-2">
+              <Card
+                heading="Recent Test Runs"
+                icon={
+                  <Icon
+                    assistiveText={{ label: 'Test Runs' }}
+                    category="utility"
+                    name="list"
+                    size="small"
+                  />
+                }
+              >
+                {!tests?.runs?.length ? (
+                  <div className="slds-card__body_inner slds-text-body_regular slds-text-color_weak">
+                    No test runs found. Run <code>sfdt test</code> to generate results.
                   </div>
-                  {preflight.checks.slice(0, 4).map((c, i) => (
-                    <div
-                      key={i}
-                      style={{
-                        display: 'flex',
-                        justifyContent: 'space-between',
-                        alignItems: 'center',
-                        padding: '5px 0',
-                        borderBottom: '1px solid #f3f3f3',
-                        fontSize: '13px',
-                      }}
-                    >
-                      <span style={{ color: '#3e3e3c' }}>{c.name}</span>
-                      <StatusBadge status={c.status} />
-                    </div>
-                  ))}
-                </>
-              )}
+                ) : (
+                  <table
+                    className="slds-table slds-table_cell-buffer slds-table_bordered slds-table_striped slds-no-row-hover"
+                    style={{ width: '100%' }}
+                  >
+                    <thead>
+                      <tr className="slds-line-height_reset">
+                        <th scope="col"><div className="slds-truncate">Date</div></th>
+                        <th scope="col" className="slds-text-align_right"><div className="slds-truncate">Passed</div></th>
+                        <th scope="col" className="slds-text-align_right"><div className="slds-truncate">Failed</div></th>
+                        <th scope="col" className="slds-text-align_right"><div className="slds-truncate">Status</div></th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {tests.runs.slice(0, 5).map((run, i) => (
+                        <tr key={i} className="slds-hint-parent">
+                          <td className="slds-text-body_small">{new Date(run.date).toLocaleDateString()}</td>
+                          <td className="slds-text-align_right slds-text-body_small" style={{ color: '#2e844a', fontWeight: 600 }}>
+                            {run.passed ?? 0}
+                          </td>
+                          <td className="slds-text-align_right slds-text-body_small" style={{ color: run.failed ? '#ba0517' : undefined, fontWeight: run.failed ? 700 : undefined }}>
+                            {run.failed ?? 0}
+                          </td>
+                          <td className="slds-text-align_right">
+                            <StatusBadge status={run.failed ? 'fail' : 'pass'} />
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                )}
+              </Card>
             </div>
-          </Card>
 
-          <Card heading="Drift Status">
-            <div style={{ padding: '0 16px 16px' }}>
-              {!drift?.result ? (
-                <p style={{ color: '#706e6b', fontSize: '14px', padding: '12px 0' }}>
-                  No drift data. Run <code>sfdt drift</code>.
-                </p>
-              ) : (
-                <div style={{ display: 'flex', alignItems: 'center', gap: '12px', padding: '12px 0' }}>
-                  <StatusBadge status={drift.result} />
-                  <span style={{ fontSize: '13px', color: '#706e6b' }}>
-                    {drift.date ? new Date(drift.date).toLocaleString() : ''}
-                  </span>
-                  {drift.count !== undefined && (
-                    <span style={{ fontSize: '13px', color: '#706e6b' }}>
-                      {drift.count} component{drift.count !== 1 ? 's' : ''} differ
-                    </span>
-                  )}
+            {/* Preflight + Drift stacked */}
+            <div className="slds-col slds-size_1-of-1 slds-medium-size_1-of-2">
+              <div className="slds-grid slds-wrap slds-gutters_direct">
+
+                <div className="slds-col slds-size_1-of-1 slds-m-bottom_small">
+                  <Card
+                    heading="Last Preflight Check"
+                    icon={
+                      <Icon
+                        assistiveText={{ label: 'Preflight' }}
+                        category="utility"
+                        name="check"
+                        size="small"
+                      />
+                    }
+                  >
+                    {!preflight?.checks?.length ? (
+                      <div className="slds-card__body_inner slds-text-body_regular slds-text-color_weak">
+                        No preflight data. Run <code>sfdt preflight</code>.
+                      </div>
+                    ) : (
+                      <>
+                        <div className="slds-card__body_inner slds-text-body_small slds-text-color_weak slds-m-bottom_xx-small">
+                          {preflight.date ? new Date(preflight.date).toLocaleString() : ''}
+                        </div>
+                        {preflight.checks.slice(0, 4).map((c, i) => (
+                          <div
+                            key={i}
+                            className="slds-grid slds-grid_align-spread slds-grid_vertical-align-center slds-p-horizontal_medium slds-p-vertical_x-small slds-border_bottom"
+                          >
+                            <span className="slds-text-body_small">{c.name}</span>
+                            <StatusBadge status={c.status} />
+                          </div>
+                        ))}
+                      </>
+                    )}
+                  </Card>
                 </div>
-              )}
+
+                <div className="slds-col slds-size_1-of-1">
+                  <Card
+                    heading="Drift Status"
+                    icon={
+                      <Icon
+                        assistiveText={{ label: 'Drift' }}
+                        category="utility"
+                        name="refresh"
+                        size="small"
+                      />
+                    }
+                  >
+                    {!drift?.result ? (
+                      <div className="slds-card__body_inner slds-text-body_regular slds-text-color_weak">
+                        No drift data. Run <code>sfdt drift</code>.
+                      </div>
+                    ) : (
+                      <div className="slds-card__body_inner slds-grid slds-grid_vertical-align-center slds-wrap slds-gutters_direct">
+                        <StatusBadge status={drift.result} />
+                        {drift.date && (
+                          <span className="slds-text-body_small slds-text-color_weak slds-m-left_small">
+                            {new Date(drift.date).toLocaleString()}
+                          </span>
+                        )}
+                        {drift.count !== undefined && (
+                          <span className="slds-text-body_small slds-text-color_weak slds-m-left_small">
+                            {drift.count} component{drift.count !== 1 ? 's' : ''} differ
+                          </span>
+                        )}
+                      </div>
+                    )}
+                  </Card>
+                </div>
+
+              </div>
             </div>
-          </Card>
+
+          </div>
         </div>
-      </div>
+      )}
     </div>
   );
 }

--- a/gui/src/pages/Drift.jsx
+++ b/gui/src/pages/Drift.jsx
@@ -1,8 +1,13 @@
 import React, { useState, useEffect } from 'react';
+import PageHeader from '@salesforce/design-system-react/components/page-header';
+import Icon from '@salesforce/design-system-react/components/icon';
+import Card from '@salesforce/design-system-react/components/card';
 import DataTable from '@salesforce/design-system-react/components/data-table';
 import DataTableColumn from '@salesforce/design-system-react/components/data-table/column';
 import DataTableCell from '@salesforce/design-system-react/components/data-table/cell';
 import Spinner from '@salesforce/design-system-react/components/spinner';
+import ButtonGroup from '@salesforce/design-system-react/components/button-group';
+import Button from '@salesforce/design-system-react/components/button';
 import { api } from '../api.js';
 import StatusBadge from '../components/StatusBadge.jsx';
 import EmptyState from '../components/EmptyState.jsx';
@@ -16,144 +21,112 @@ export default function DriftPage() {
   const [filter, setFilter] = useState('all');
 
   useEffect(() => {
-    api
-      .drift()
+    api.drift()
       .then(setData)
       .catch(() => null)
       .finally(() => setLoading(false));
   }, []);
 
   const components = data?.components ?? [];
-  const filtered =
-    filter === 'all'
-      ? components
-      : components.filter((c) => c.drift?.toLowerCase() === filter);
+  const filtered   = filter === 'all'
+    ? components
+    : components.filter((c) => c.drift?.toLowerCase() === filter);
 
   const rows = filtered.map((c, i) => ({
-    id: String(i),
-    name: c.name ?? '—',
-    type: c.type ?? '—',
+    id:    String(i),
+    name:  c.name  ?? '—',
+    type:  c.type  ?? '—',
     drift: c.drift ?? 'unknown',
   }));
 
-  const driftCount = components.filter(
-    (c) => c.drift?.toLowerCase() === 'drift',
-  ).length;
-  const cleanCount = components.filter(
-    (c) => c.drift?.toLowerCase() === 'clean',
-  ).length;
+  const driftCount = components.filter((c) => c.drift?.toLowerCase() === 'drift').length;
+  const cleanCount = components.filter((c) => c.drift?.toLowerCase() === 'clean').length;
+
+  const infoText = data?.date
+    ? `Last checked: ${new Date(data.date).toLocaleString()}`
+    : 'Metadata drift between local source and target org';
 
   return (
-    <div style={{ padding: '28px 32px' }}>
-      <div
-        style={{
-          display: 'flex',
-          justifyContent: 'space-between',
-          alignItems: 'flex-start',
-          marginBottom: '28px',
-        }}
-      >
-        <div>
-          <h1 style={{ fontSize: '24px', fontWeight: 700, color: '#032d60', margin: 0 }}>
-            Drift Detection
-          </h1>
-          <p style={{ fontSize: '14px', color: '#706e6b', marginTop: '4px' }}>
-            Metadata drift between local source and target org
-          </p>
-        </div>
-        {data?.date && (
-          <div style={{ fontSize: '13px', color: '#706e6b' }}>
-            Last checked: {new Date(data.date).toLocaleString()}
+    <div>
+      <PageHeader
+        title="Drift Detection"
+        label="SFDT"
+        info={infoText}
+        variant="object-home"
+        icon={
+          <Icon
+            assistiveText={{ label: 'Drift Detection' }}
+            category="utility"
+            name="refresh"
+            size="large"
+          />
+        }
+      />
+
+      <div className="slds-p-around_large">
+        {components.length > 0 && (
+          <div className="slds-m-bottom_medium">
+            <ButtonGroup id="drift-filter">
+              <Button
+                label={`All (${components.length})`}
+                variant={filter === 'all' ? 'brand' : 'neutral'}
+                onClick={() => setFilter('all')}
+              />
+              <Button
+                label={`Clean (${cleanCount})`}
+                variant={filter === 'clean' ? 'success' : 'neutral'}
+                onClick={() => setFilter('clean')}
+              />
+              <Button
+                label={`Drift (${driftCount})`}
+                variant={filter === 'drift' ? 'destructive' : 'neutral'}
+                onClick={() => setFilter('drift')}
+              />
+            </ButtonGroup>
           </div>
         )}
+
+        {loading && (
+          <div style={{ position: 'relative', height: '200px' }}>
+            <Spinner size="large" variant="brand" />
+          </div>
+        )}
+
+        {!loading && components.length === 0 && (
+          <EmptyState
+            title="No drift data"
+            message="Run sfdt drift to compare your local source against the target org."
+          />
+        )}
+
+        {!loading && components.length > 0 && (
+          <Card
+            heading="Component Comparison"
+            icon={
+              <Icon
+                assistiveText={{ label: 'Components' }}
+                category="utility"
+                name="table"
+                size="small"
+              />
+            }
+          >
+            {rows.length === 0 ? (
+              <div className="slds-card__body_inner slds-text-align_center slds-text-color_weak slds-p-vertical_large">
+                No components match the selected filter.
+              </div>
+            ) : (
+              <DataTable items={rows} id="drift-table" striped>
+                <DataTableColumn label="Component"   property="name" />
+                <DataTableColumn label="Type"        property="type" />
+                <DataTableColumn label="Drift Status" property="drift">
+                  <DriftStatusCell />
+                </DataTableColumn>
+              </DataTable>
+            )}
+          </Card>
+        )}
       </div>
-
-      {/* Stats row */}
-      {components.length > 0 && (
-        <div
-          style={{ display: 'flex', gap: '12px', marginBottom: '24px', flexWrap: 'wrap' }}
-        >
-          {[
-            {
-              id: 'all',
-              label: 'All',
-              count: components.length,
-              accent: '#0176d3',
-            },
-            { id: 'clean', label: 'Clean', count: cleanCount, accent: '#2e844a' },
-            { id: 'drift', label: 'Drift', count: driftCount, accent: '#dd7a01' },
-          ].map((tab) => (
-            <button
-              key={tab.id}
-              onClick={() => setFilter(tab.id)}
-              style={{
-                padding: '8px 20px',
-                borderRadius: '20px',
-                border: `2px solid ${filter === tab.id ? tab.accent : '#e5e5e5'}`,
-                background: filter === tab.id ? tab.accent : '#fff',
-                color: filter === tab.id ? '#fff' : '#3e3e3c',
-                fontWeight: 600,
-                fontSize: '13px',
-                cursor: 'pointer',
-                display: 'flex',
-                alignItems: 'center',
-                gap: '8px',
-                transition: 'all 0.15s',
-              }}
-            >
-              {tab.label}
-              <span
-                style={{
-                  fontSize: '12px',
-                  background: filter === tab.id ? 'rgba(255,255,255,0.25)' : '#f3f3f3',
-                  padding: '1px 7px',
-                  borderRadius: '10px',
-                }}
-              >
-                {tab.count}
-              </span>
-            </button>
-          ))}
-        </div>
-      )}
-
-      {loading && (
-        <div style={{ display: 'flex', justifyContent: 'center', padding: '60px' }}>
-          <Spinner size="large" variant="brand" />
-        </div>
-      )}
-
-      {!loading && components.length === 0 && (
-        <EmptyState
-          title="No drift data"
-          message="Run sfdt drift to compare your local source against the target org."
-        />
-      )}
-
-      {!loading && components.length > 0 && (
-        <div
-          style={{
-            background: '#fff',
-            borderRadius: '8px',
-            boxShadow: '0 1px 3px rgba(0,0,0,0.08)',
-            overflow: 'hidden',
-          }}
-        >
-          {rows.length === 0 ? (
-            <div style={{ padding: '32px', textAlign: 'center', color: '#706e6b', fontSize: '14px' }}>
-              No components match the selected filter.
-            </div>
-          ) : (
-            <DataTable items={rows} id="drift-table" striped>
-              <DataTableColumn label="Component" property="name" />
-              <DataTableColumn label="Type" property="type" />
-              <DataTableColumn label="Drift" property="drift">
-                <DriftStatusCell />
-              </DataTableColumn>
-            </DataTable>
-          )}
-        </div>
-      )}
     </div>
   );
 }

--- a/gui/src/pages/Preflight.jsx
+++ b/gui/src/pages/Preflight.jsx
@@ -1,163 +1,159 @@
 import React, { useState, useEffect } from 'react';
+import PageHeader from '@salesforce/design-system-react/components/page-header';
+import Icon from '@salesforce/design-system-react/components/icon';
+import Card from '@salesforce/design-system-react/components/card';
+import DataTable from '@salesforce/design-system-react/components/data-table';
+import DataTableColumn from '@salesforce/design-system-react/components/data-table/column';
+import DataTableCell from '@salesforce/design-system-react/components/data-table/cell';
+import Badge from '@salesforce/design-system-react/components/badge';
 import Spinner from '@salesforce/design-system-react/components/spinner';
 import { api } from '../api.js';
 import StatusBadge from '../components/StatusBadge.jsx';
 import EmptyState from '../components/EmptyState.jsx';
 
-function CheckRow({ check }) {
-  const icon =
-    check.status === 'pass' || check.status === 'success'
-      ? '✓'
-      : check.status === 'fail' || check.status === 'error'
-        ? '✗'
-        : '⚠';
-  const iconColor =
-    check.status === 'pass' || check.status === 'success'
-      ? '#2e844a'
-      : check.status === 'fail' || check.status === 'error'
-        ? '#ba0517'
-        : '#dd7a01';
+const STATUS_ICON = {
+  pass:    { name: 'check',   color: '#2e844a' },
+  passed:  { name: 'check',   color: '#2e844a' },
+  success: { name: 'check',   color: '#2e844a' },
+  fail:    { name: 'error',   color: '#ba0517' },
+  failed:  { name: 'error',   color: '#ba0517' },
+  error:   { name: 'error',   color: '#ba0517' },
+  warn:    { name: 'warning', color: '#dd7a01' },
+  warning: { name: 'warning', color: '#dd7a01' },
+};
 
+const CheckNameCell = ({ item }) => {
+  const cfg = STATUS_ICON[item.status?.toLowerCase()] ?? { name: 'info', color: '#706e6b' };
   return (
-    <div
-      style={{
-        display: 'flex',
-        alignItems: 'flex-start',
-        gap: '12px',
-        padding: '12px 20px',
-        borderBottom: '1px solid #f3f3f3',
-      }}
-    >
-      <span style={{ fontSize: '18px', color: iconColor, flexShrink: 0, marginTop: '1px' }}>
-        {icon}
+    <span className="slds-media slds-media_center slds-media_small">
+      <span className="slds-media__figure">
+        <Icon
+          assistiveText={{ label: item.status }}
+          category="utility"
+          name={cfg.name}
+          size="x-small"
+          style={{ fill: cfg.color }}
+        />
       </span>
-      <div style={{ flex: 1 }}>
-        <div
-          style={{ fontSize: '14px', fontWeight: 600, color: '#3e3e3c', marginBottom: '2px' }}
-        >
-          {check.name}
-        </div>
-        {check.message && (
-          <div style={{ fontSize: '13px', color: '#706e6b' }}>{check.message}</div>
-        )}
-      </div>
-      <StatusBadge status={check.status} />
-    </div>
+      <span className="slds-media__body slds-text-body_regular">{item.name}</span>
+    </span>
   );
-}
+};
+CheckNameCell.displayName = DataTableCell.displayName;
+
+const MessageCell = ({ item }) => (
+  <span className="slds-text-body_small slds-text-color_weak">{item.message || '—'}</span>
+);
+MessageCell.displayName = DataTableCell.displayName;
+
+const StatusBadgeCell = ({ item }) => <StatusBadge status={item.status} />;
+StatusBadgeCell.displayName = DataTableCell.displayName;
 
 export default function PreflightPage() {
   const [data, setData] = useState(null);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    api
-      .preflight()
+    api.preflight()
       .then(setData)
       .catch(() => null)
       .finally(() => setLoading(false));
   }, []);
 
+  const checks       = data?.checks ?? [];
+  const passedCount  = checks.filter((c) => c.status === 'pass' || c.status === 'success').length;
+  const failedCount  = checks.filter((c) => c.status === 'fail' || c.status === 'error').length;
   const overallStatus = data?.status;
-  const checks = data?.checks ?? [];
+
+  const rows = checks.map((c, i) => ({
+    id:      String(i),
+    name:    c.name,
+    message: c.message ?? '',
+    status:  c.status,
+  }));
+
+  const infoText = data?.date
+    ? `Last run: ${new Date(data.date).toLocaleString()}`
+    : 'Results of the last sfdt preflight run';
 
   return (
-    <div style={{ padding: '28px 32px' }}>
-      <div
-        style={{
-          display: 'flex',
-          justifyContent: 'space-between',
-          alignItems: 'flex-start',
-          marginBottom: '28px',
-        }}
-      >
-        <div>
-          <h1 style={{ fontSize: '24px', fontWeight: 700, color: '#032d60', margin: 0 }}>
-            Preflight Check
-          </h1>
-          <p style={{ fontSize: '14px', color: '#706e6b', marginTop: '4px' }}>
-            Results of the last <code>sfdt preflight</code> run
-          </p>
-        </div>
-        {overallStatus && (
-          <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
-            <StatusBadge status={overallStatus} />
-            {data?.date && (
-              <span style={{ fontSize: '13px', color: '#706e6b' }}>
-                {new Date(data.date).toLocaleString()}
-              </span>
-            )}
+    <div>
+      <PageHeader
+        title="Preflight Check"
+        label="SFDT"
+        info={infoText}
+        variant="object-home"
+        icon={
+          <Icon
+            assistiveText={{ label: 'Preflight' }}
+            category="utility"
+            name="check"
+            size="large"
+          />
+        }
+        onRenderActions={() =>
+          overallStatus ? (
+            <div className="slds-page-header__control">
+              <StatusBadge status={overallStatus} />
+            </div>
+          ) : null
+        }
+      />
+
+      <div className="slds-p-around_large">
+        {loading && (
+          <div style={{ position: 'relative', height: '200px' }}>
+            <Spinner size="large" variant="brand" />
           </div>
         )}
-      </div>
 
-      {loading && (
-        <div style={{ display: 'flex', justifyContent: 'center', padding: '60px' }}>
-          <Spinner size="large" variant="brand" />
-        </div>
-      )}
+        {!loading && checks.length === 0 && (
+          <EmptyState
+            title="No preflight data"
+            message="Run sfdt preflight to generate a report that will appear here."
+          />
+        )}
 
-      {!loading && checks.length === 0 && (
-        <EmptyState
-          title="No preflight data"
-          message="Run sfdt preflight to generate a report that will appear here."
-        />
-      )}
-
-      {!loading && checks.length > 0 && (
-        <div
-          style={{
-            background: '#fff',
-            borderRadius: '8px',
-            boxShadow: '0 1px 3px rgba(0,0,0,0.08)',
-            overflow: 'hidden',
-          }}
-        >
-          {/* Header */}
-          <div
-            style={{
-              padding: '16px 20px',
-              borderBottom: '1px solid #e5e5e5',
-              display: 'flex',
-              alignItems: 'center',
-              gap: '8px',
-            }}
+        {!loading && checks.length > 0 && (
+          <Card
+            heading={`${checks.length} Check${checks.length !== 1 ? 's' : ''}`}
+            icon={
+              <Icon
+                assistiveText={{ label: 'Checks' }}
+                category="utility"
+                name="checklist"
+                size="small"
+              />
+            }
+            headerActions={
+              <div className="slds-grid slds-grid_vertical-align-center">
+                {passedCount > 0 && (
+                  <Badge
+                    content={`${passedCount} passed`}
+                    color="success"
+                    className="slds-m-right_xx-small"
+                  />
+                )}
+                {failedCount > 0 && (
+                  <Badge content={`${failedCount} failed`} color="error" />
+                )}
+              </div>
+            }
           >
-            <span style={{ fontSize: '14px', fontWeight: 700, color: '#3e3e3c' }}>
-              {checks.length} check{checks.length !== 1 ? 's' : ''}
-            </span>
-            {checks.filter((c) => c.status === 'pass').length > 0 && (
-              <span
-                style={{
-                  fontSize: '12px',
-                  color: '#2e844a',
-                  background: '#f3fbf5',
-                  padding: '2px 8px',
-                  borderRadius: '10px',
-                }}
-              >
-                {checks.filter((c) => c.status === 'pass' || c.status === 'success').length} passed
-              </span>
-            )}
-            {checks.filter((c) => c.status === 'fail' || c.status === 'error').length > 0 && (
-              <span
-                style={{
-                  fontSize: '12px',
-                  color: '#ba0517',
-                  background: '#fef1ee',
-                  padding: '2px 8px',
-                  borderRadius: '10px',
-                }}
-              >
-                {checks.filter((c) => c.status === 'fail' || c.status === 'error').length} failed
-              </span>
-            )}
-          </div>
-          {checks.map((c, i) => (
-            <CheckRow key={i} check={c} />
-          ))}
-        </div>
-      )}
+            <DataTable items={rows} id="preflight-checks-table">
+              <DataTableColumn label="Check" property="name">
+                <CheckNameCell />
+              </DataTableColumn>
+              <DataTableColumn label="Message" property="message">
+                <MessageCell />
+              </DataTableColumn>
+              <DataTableColumn label="Status" property="status">
+                <StatusBadgeCell />
+              </DataTableColumn>
+            </DataTable>
+          </Card>
+        )}
+      </div>
     </div>
   );
 }

--- a/gui/src/pages/TestRuns.jsx
+++ b/gui/src/pages/TestRuns.jsx
@@ -1,8 +1,12 @@
 import React, { useState, useEffect } from 'react';
+import PageHeader from '@salesforce/design-system-react/components/page-header';
+import Icon from '@salesforce/design-system-react/components/icon';
+import Card from '@salesforce/design-system-react/components/card';
 import DataTable from '@salesforce/design-system-react/components/data-table';
 import DataTableColumn from '@salesforce/design-system-react/components/data-table/column';
 import DataTableCell from '@salesforce/design-system-react/components/data-table/cell';
 import Spinner from '@salesforce/design-system-react/components/spinner';
+import Alert from '@salesforce/design-system-react/components/alert';
 import { api } from '../api.js';
 import StatusBadge from '../components/StatusBadge.jsx';
 import EmptyState from '../components/EmptyState.jsx';
@@ -12,7 +16,9 @@ StatusCell.displayName = DataTableCell.displayName;
 
 const CoverageCell = ({ item }) => {
   const pct = item.coverage;
-  if (pct === undefined || pct === null) return <span style={{ color: '#919191' }}>—</span>;
+  if (pct === undefined || pct === null) {
+    return <span className="slds-text-color_weak">—</span>;
+  }
   const color = pct >= 75 ? '#2e844a' : pct >= 60 ? '#dd7a01' : '#ba0517';
   return <span style={{ fontWeight: 700, color }}>{pct}%</span>;
 };
@@ -24,99 +30,98 @@ export default function TestRuns() {
   const [error, setError] = useState(null);
 
   useEffect(() => {
-    api
-      .testRuns()
+    api.testRuns()
       .then(setData)
       .catch((e) => setError(e.message))
       .finally(() => setLoading(false));
   }, []);
 
   const rows = (data?.runs ?? []).map((r, i) => ({
-    id: String(i),
-    date: r.date ? new Date(r.date).toLocaleString() : '—',
-    passed: r.passed ?? 0,
-    failed: r.failed ?? 0,
-    errors: r.errors ?? 0,
+    id:       String(i),
+    date:     r.date ? new Date(r.date).toLocaleString() : '—',
+    passed:   r.passed ?? 0,
+    failed:   r.failed ?? 0,
+    errors:   r.errors ?? 0,
     coverage: r.coverage,
     duration: r.duration ? `${(r.duration / 1000).toFixed(1)}s` : '—',
-    status: r.failed || r.errors ? 'fail' : 'pass',
+    status:   r.failed || r.errors ? 'fail' : 'pass',
   }));
 
   return (
-    <div style={{ padding: '28px 32px' }}>
-      <div style={{ marginBottom: '28px' }}>
-        <h1 style={{ fontSize: '24px', fontWeight: 700, color: '#032d60', margin: 0 }}>
-          Test Runs
-        </h1>
-        <p style={{ fontSize: '14px', color: '#706e6b', marginTop: '4px' }}>
-          History of Apex test executions from <code>sfdt test</code>
-        </p>
+    <div>
+      <PageHeader
+        title="Test Runs"
+        label="SFDT"
+        info="History of Apex test executions from sfdt test"
+        variant="object-home"
+        icon={
+          <Icon
+            assistiveText={{ label: 'Test Runs' }}
+            category="utility"
+            name="list"
+            size="large"
+          />
+        }
+      />
+
+      <div className="slds-p-around_large">
+        {loading && (
+          <div style={{ position: 'relative', height: '200px' }}>
+            <Spinner size="large" variant="brand" />
+          </div>
+        )}
+
+        {error && (
+          <Alert
+            labels={{ heading: `Failed to load test results: ${error}` }}
+            variant="error"
+            className="slds-m-bottom_medium"
+          />
+        )}
+
+        {!loading && !error && rows.length === 0 && (
+          <EmptyState
+            title="No test runs found"
+            message="Run sfdt test to generate results that will appear here."
+          />
+        )}
+
+        {!loading && !error && rows.length > 0 && (
+          <Card
+            heading="Test History"
+            icon={
+              <Icon
+                assistiveText={{ label: 'Test History' }}
+                category="utility"
+                name="list"
+                size="small"
+              />
+            }
+          >
+            <DataTable items={rows} id="test-runs-table" striped>
+              <DataTableColumn label="Date"     property="date" />
+              <DataTableColumn label="Passed"   property="passed" />
+              <DataTableColumn label="Failed"   property="failed" />
+              <DataTableColumn label="Errors"   property="errors" />
+              <DataTableColumn label="Coverage" property="coverage">
+                <CoverageCell />
+              </DataTableColumn>
+              <DataTableColumn label="Duration" property="duration" />
+              <DataTableColumn label="Status"   property="status">
+                <StatusCell />
+              </DataTableColumn>
+            </DataTable>
+          </Card>
+        )}
+
+        {data?.summary && (
+          <Card className="slds-m-top_medium" heading="Summary">
+            <div className="slds-card__body_inner slds-text-body_regular slds-text-color_weak">
+              {data.summary}
+            </div>
+          </Card>
+        )}
       </div>
-
-      {loading && (
-        <div style={{ display: 'flex', justifyContent: 'center', padding: '60px' }}>
-          <Spinner size="large" variant="brand" />
-        </div>
-      )}
-
-      {error && (
-        <div
-          className="slds-notify slds-notify_alert slds-alert_error"
-          role="alert"
-          style={{ marginBottom: '20px' }}
-        >
-          <span className="slds-assistive-text">Error</span>
-          <h2>Failed to load test results: {error}</h2>
-        </div>
-      )}
-
-      {!loading && !error && rows.length === 0 && (
-        <EmptyState
-          title="No test runs found"
-          message="Run sfdt test to generate results that will appear here."
-        />
-      )}
-
-      {!loading && !error && rows.length > 0 && (
-        <div
-          style={{
-            background: '#fff',
-            borderRadius: '8px',
-            boxShadow: '0 1px 3px rgba(0,0,0,0.08)',
-            overflow: 'hidden',
-          }}
-        >
-          <DataTable items={rows} id="test-runs-table" striped>
-            <DataTableColumn label="Date" property="date" />
-            <DataTableColumn label="Passed" property="passed" />
-            <DataTableColumn label="Failed" property="failed" />
-            <DataTableColumn label="Errors" property="errors" />
-            <DataTableColumn label="Coverage" property="coverage">
-              <CoverageCell />
-            </DataTableColumn>
-            <DataTableColumn label="Duration" property="duration" />
-            <DataTableColumn label="Status" property="status">
-              <StatusCell />
-            </DataTableColumn>
-          </DataTable>
-        </div>
-      )}
-
-      {data?.summary && (
-        <div
-          style={{
-            marginTop: '20px',
-            padding: '16px 20px',
-            background: '#fff',
-            borderRadius: '8px',
-            boxShadow: '0 1px 3px rgba(0,0,0,0.08)',
-            fontSize: '13px',
-            color: '#706e6b',
-          }}
-        >
-          <strong style={{ color: '#3e3e3c' }}>Summary:</strong> {data.summary}
-        </div>
-      )}
     </div>
   );
 }

--- a/gui/vite.config.js
+++ b/gui/vite.config.js
@@ -24,6 +24,7 @@ export default defineConfig({
       '@salesforce/design-system-react/components/utilities/utility-icon/svg',
       '@salesforce/design-system-react/components/icon',
       '@salesforce/design-system-react/components/button',
+      '@salesforce/design-system-react/components/button-group',
       '@salesforce/design-system-react/components/badge',
       '@salesforce/design-system-react/components/card',
       '@salesforce/design-system-react/components/data-table',


### PR DESCRIPTION
Replace all generic/custom-built components with proper @salesforce/design-system-react equivalents:

- StatusBadge: now uses SLDS Badge component with color prop (success/error/warning/inverse/default)
- StatCard: now uses SLDS Card + Icon component with slds utility classes for typography
- EmptyState: now uses SLDS Icon + slds-text-heading_medium / slds-text-color_weak utility classes
- App.jsx: nav sidebar uses slds-nav-vertical CSS classes with SLDS Icon (colorVariant=light) per item; project header uses slds-media pattern
- Dashboard: SLDS PageHeader for page title; slds-grid/slds-gutters for stat card layout; SLDS Card+Icon for Recent Test Runs, Preflight, and Drift cards; proper slds-table classes replace raw HTML table
- TestRuns: SLDS PageHeader; SLDS Alert component replaces hand-rolled error div; DataTable wrapped in SLDS Card
- Preflight: SLDS PageHeader with overall status in onRenderActions; checks converted from custom CheckRow list to SLDS DataTable with inline Icon status cells (CheckNameCell) and Badge header counts via Card.headerActions
- Drift: SLDS PageHeader; custom pill-buttons replaced with SLDS ButtonGroup + Button (brand/success/destructive variants reflect selected filter)
- vite.config.js: add button-group to optimizeDeps

https://claude.ai/code/session_0189CrWKqDuYKKza4H6D9FTZ