### PR TITLE
chore: release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-04-14
+
+### Changed
+- **GUI rebuilt with SLDS React components**: Web dashboard (`sfdt ui`) now uses Salesforce Lightning Design System (SLDS) React components throughout, replacing the prior implementation for improved consistency and maintainability
+
 ## [0.3.0] - 2026-04-13
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sfdt/cli",
-  "version": "0.2.2",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sfdt/cli",
-      "version": "0.2.2",
+      "version": "0.3.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sfdt/cli",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Salesforce DevTools — Production-grade CLI for Salesforce DX deployment, testing, quality analysis, and release management",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- Rebuilt web dashboard (`sfdt ui`) with Salesforce Lightning Design System (SLDS) React components throughout
- Bump version to 0.3.1 and update CHANGELOG

## Test plan
- [ ] `sfdt ui` launches and dashboard renders correctly with SLDS components
- [ ] Version reported by `sfdt --version` is `0.3.1`