### PR TITLE
chore(gui): vite 8 follow-up — plugin-react v5, drop esbuildOptions, dedicated CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,15 +26,32 @@ jobs:
         run: npm audit --audit-level=high
       - run: npm run lint
       - run: npm test
-      - name: Build GUI (Node 22 only)
-        if: matrix.node-version == 22
-        run: npm run build:gui
       - name: Publish dry-run (Node 22 only)
         if: matrix.node-version == 22
         run: npm publish --dry-run
 
+  gui-build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      matrix:
+        node-version: [20, 22]
+    steps:
+      - uses: actions/checkout@v6
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+          cache-dependency-path: gui/package-lock.json
+      - name: Install GUI dependencies
+        run: cd gui && npm ci
+      - name: Build GUI
+        run: cd gui && npm run build
+
   publish:
-    needs: test
+    needs: [test, gui-build]
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     environment: production

--- a/gui/package-lock.json
+++ b/gui/package-lock.json
@@ -14,7 +14,7 @@
         "react-dom": "^18.3.1"
       },
       "devDependencies": {
-        "@vitejs/plugin-react": "^4.3.4",
+        "@vitejs/plugin-react": "^5.2.0",
         "vite": "^8.0.8",
         "vite-plugin-static-copy": "^2.2.0"
       }
@@ -710,9 +710,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-beta.27",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
-      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "version": "1.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
+      "integrity": "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -824,24 +824,24 @@
       }
     },
     "node_modules/@vitejs/plugin-react": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
-      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.2.0.tgz",
+      "integrity": "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/core": "^7.28.0",
+        "@babel/core": "^7.29.0",
         "@babel/plugin-transform-react-jsx-self": "^7.27.1",
         "@babel/plugin-transform-react-jsx-source": "^7.27.1",
-        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@rolldown/pluginutils": "1.0.0-rc.3",
         "@types/babel__core": "^7.20.5",
-        "react-refresh": "^0.17.0"
+        "react-refresh": "^0.18.0"
       },
       "engines": {
-        "node": "^14.18.0 || >=16.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "peerDependencies": {
-        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/anymatch": {
@@ -1921,9 +1921,9 @@
       }
     },
     "node_modules/react-refresh": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
-      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
+      "integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/gui/package.json
+++ b/gui/package.json
@@ -15,7 +15,7 @@
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
-    "@vitejs/plugin-react": "^4.3.4",
+    "@vitejs/plugin-react": "^5.2.0",
     "vite": "^8.0.8",
     "vite-plugin-static-copy": "^2.2.0"
   }

--- a/gui/vite.config.js
+++ b/gui/vite.config.js
@@ -37,9 +37,6 @@ export default defineConfig({
       '@salesforce/design-system-react/components/alert/container',
       '@salesforce/design-system-react/components/utilities/utility-icon',
     ],
-    esbuildOptions: {
-      target: 'es2020',
-    },
   },
   build: {
     outDir: 'dist',


### PR DESCRIPTION
## Summary

Follow-up cleanup after merging #32 (vite 5→8). Three issues surfaced during the pre-merge build verification that didn't fail CI but will cause problems going forward.

- **`@vitejs/plugin-react` bumped `^4.3.4` → `^5.2.0`** — v4.7.0 only declares peer support through vite 7. v5.2.0 adds vite 8 to the peer range. Without this, npm produces a peer-dep mismatch warning on every install and future strict-peer-dep npm configs will break.
- **Removed `optimizeDeps.esbuildOptions`** — vite 8 switched the dep pre-bundler from esbuild to Rolldown; the `esbuildOptions.target` block was emitting a deprecation warning on every build. The `build.target: 'es2020'` already covers the final bundle, making this option redundant.
- **Dedicated `gui-build` CI job** — the previous "Build GUI (Node 22 only)" inline step used `npm run build:gui` which internally runs `npm install` (not `npm ci`), and only ran on node 22. The new job uses `npm ci` with a lockfile-aware cache key and runs the build on both Node 20 and 22. `publish` now requires both `test` and `gui-build` to pass.

## Test plan

- [ ] GUI build runs clean (zero warnings) — verified locally: `vite v8.0.8, ✓ 163 modules transformed, built in 608ms`
- [ ] 218/218 unit tests pass
- [ ] `gui-build` job appears in CI with matrix [20, 22]
- [ ] `publish` job blocked until both `test` and `gui-build` pass