### PR TITLE
ci: dedicated gui-build job on Node 20 and 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,15 +26,32 @@ jobs:
         run: npm audit --audit-level=high
       - run: npm run lint
       - run: npm test
-      - name: Build GUI (Node 22 only)
-        if: matrix.node-version == 22
-        run: npm run build:gui
       - name: Publish dry-run (Node 22 only)
         if: matrix.node-version == 22
         run: npm publish --dry-run
 
+  gui-build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      matrix:
+        node-version: [20, 22]
+    steps:
+      - uses: actions/checkout@v6
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+          cache-dependency-path: gui/package-lock.json
+      - name: Install GUI dependencies
+        run: cd gui && npm ci
+      - name: Build GUI
+        run: cd gui && npm run build
+
   publish-beta:
-    needs: test
+    needs: [test, gui-build]
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/develop' && github.event_name == 'push'
     environment: beta
@@ -89,7 +106,7 @@ jobs:
         run: gh release create "v${VERSION}" --generate-notes --prerelease
 
   publish:
-    needs: test
+    needs: [test, gui-build]
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     environment: production


### PR DESCRIPTION
## Summary

Ports the CI improvement from #34 (which went to `main`) to `develop` — touching only `.github/workflows/ci.yml`, nothing in `gui/`.

- Removes the inline "Build GUI (Node 22 only)" step from the `test` job
- Adds a dedicated `gui-build` job that runs `npm ci` + `npm run build` in `gui/` on both Node 20 and 22, with a lockfile-aware cache key
- `publish-beta` and `publish` now both require `gui-build` to pass

The `gui/` package.json and vite.config.js changes from #34 are intentionally excluded — those were specific to the vite 8 upgrade on `main` and don't apply to `develop` (still on vite 5).