### PR TITLE
chore: release v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2] - 2026-04-19
+
+### Changed
+- **GUI build toolchain updated to Vite 8**: `@vitejs/plugin-react` upgraded to v5, `esbuildOptions` removed (no longer supported), dedicated `gui-build` CI job added for Node 20 and 22
+- Bumped `esbuild` and `vite` in GUI dependencies
+- Bumped `inquirer` production dependency
+- Bumped `prettier` development dependency
+- CI: upgraded `actions/stale` from v9 to v10
+- CI: upgraded `github/codeql-action` from v3 to v4
+
 ## [0.3.1] - 2026-04-14
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sfdt/cli",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Salesforce DevTools — Production-grade CLI for Salesforce DX deployment, testing, quality analysis, and release management",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Release v0.3.2

## [0.3.2] - 2026-04-19

### Changed
- **GUI build toolchain updated to Vite 8**: `@vitejs/plugin-react` upgraded to v5, `esbuildOptions` removed (no longer supported), dedicated `gui-build` CI job added for Node 20 and 22
- Bumped `esbuild` and `vite` in GUI dependencies
- Bumped `inquirer` production dependency
- Bumped `prettier` development dependency
- CI: upgraded `actions/stale` from v9 to v10
- CI: upgraded `github/codeql-action` from v3 to v4

## Test checklist
- [ ] `npm test` passes
- [ ] `npm run lint` passes
- [ ] Install from npm and run `sfdt --version` confirms new version