### PR TITLE
chore: release v0.4.0-beta.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0-beta.5] - 2026-04-19
+
+### Changed
+- Synced dependency bumps from `main` (inquirer, prettier, esbuild, vite, plugin-react v5) into `develop`
+- CI: dedicated `gui-build` job now runs on Node 20 and 22
+
+### Fixed
+- Token handling fix
+
 ## [0.4.0-beta.1] - 2026-04-17
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sfdt/cli",
-  "version": "0.4.0-beta.4",
+  "version": "0.4.0-beta.5",
   "description": "Salesforce DevTools — Production-grade CLI for Salesforce DX deployment, testing, quality analysis, and release management",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Release v0.4.0-beta.5

## [0.4.0-beta.5] - 2026-04-19

### Changed
- Synced dependency bumps from `main` (inquirer, prettier, esbuild, vite, plugin-react v5) into `develop`
- CI: dedicated `gui-build` job now runs on Node 20 and 22

### Fixed
- Token handling fix

## Test checklist
- [ ] `npm test` passes
- [ ] `npm run lint` passes
- [ ] Install from npm `beta` dist-tag and run `sfdt --version` confirms new version