### PR TITLE
fix(ci): allow Claude to post PR review comments; update checkout to v6

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
@@ -40,6 +40,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          allowed_tools: "Bash(gh pr review*)"
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: |
@@ -49,4 +50,3 @@ jobs:
               gh pr review ${{ github.event.pull_request.number }} --comment --body "<your findings>"
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 


### PR DESCRIPTION
## Problem

Two issues found in the Claude GitHub Actions workflows:

### 1. Claude not posting PR review comments
The `claude-review` job was completing successfully (`permission_denials_count: 1` in logs) but never posting a comment. Root cause: the workflow prompt asks Claude to run `gh pr review ... --comment`, but without `allowed_tools` configured, the Bash/gh command was silently denied by the permission system.

### 2. Node.js 20 deprecation warning
`actions/checkout@v4` uses Node.js 20, which is deprecated and will be forced to Node.js 24 on June 2, 2026. The `oven-sh/setup-bun` warning is embedded inside `claude-code-action@v1` and is out of our control.

## Fix

- `claude-code-review.yml`: Added `allowed_tools: "Bash(gh pr review*)"` to unblock the gh command; updated `actions/checkout@v4` → `@v6`
- `claude.yml`: Updated `actions/checkout@v4` → `@v6`

## Test checklist
- [ ] Open a new PR and confirm Claude posts a review comment
- [ ] Confirm Node.js 20 deprecation warning is gone from claude-review job logs