### PR TITLE
fix(ci): use claude-code-base-action for push-triggered docs-verify workflow

### DIFF
--- a/.github/workflows/docs-verify.yml
+++ b/.github/workflows/docs-verify.yml
@@ -32,7 +32,7 @@ jobs:
       - run: npm ci
 
       - name: Verify documentation accuracy
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-base-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |


### PR DESCRIPTION
## Summary

- Switches `docs-verify.yml` from `anthropics/claude-code-action@v1` to `anthropics/claude-code-base-action@v1`
- `claude-code-action` only supports PR/issue comment triggers; the docs-verify workflow fires on `push` to `main`, which caused `Unsupported event type: push` failures after every merge

## Test checklist
- [ ] Merge this PR and confirm Documentation Verification run on `main` succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration for documentation verification processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->