### PR TITLE
ci: skip claude-review for Dependabot PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,12 +12,7 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

- Adds `if: github.actor != 'dependabot[bot]'` guard to the `claude-review` job
- Dependabot PRs don't have access to `CLAUDE_CODE_OAUTH_TOKEN`, so the check was failing on every dependency bump — this skips it cleanly rather than failing

## Test plan
- [ ] Verify next Dependabot PR shows `claude-review` as skipped (not failed)
- [ ] Verify human PRs still trigger the review normally