### PR TITLE
chore: release v0.4.1

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          allowed_tools: "Bash(gh pr review*)"
+          claude_args: "--allowedTools 'Bash(gh pr review*),Bash(gh pr view*),Bash(gh api*),Bash(git diff*),Bash(git log*),Read,Glob,Grep'"
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-04-20
+
+### Added
+- **Shell completions** (`sfdt completion <bash|zsh|fish>`): generates ready-to-source completion scripts covering all commands and their flags — pipe to a file or `source` directly in your shell profile.
+- **Version subcommand** (`sfdt version`): prints `sfdt vX.Y.Z`; complements the existing `-v` / `--version` flag and works as a proper subcommand in shell scripts.
+- **`--dry-run` flag** on `deploy`, `rollback`, `preflight`, `smoke`, `pull`, and `test`: prints the script path, working directory, and all `SFDT_` env vars that would be set — no changes are made to the org.
+- **Structured exit codes** (`src/lib/exit-codes.js`): `EXIT_SUCCESS` (0), `ERROR` (1), `CONFIG_ERROR` (2), `CONNECT_ERROR` (3). All 18 commands now map to the correct code instead of hardcoded `1`, making it easier to handle errors in CI scripts.
+
+### Changed
+- Config validation is now stricter with richer error messages: `defaultOrg` must be a non-empty string, `coverageThreshold` must be 0–100, `environments.orgs` must be an array, and `logDir` must be a string. Validation errors exit with code `2` (`CONFIG_ERROR`).
+- Updated `express` from 4.x to 5.x.
+- Updated `open` from 10.x to 11.x.
+
 ## [0.4.0] - 2026-04-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -47,16 +47,18 @@ sfdt deploy
 | Command | Description | Key Options |
 |---|---|---|
 | `sfdt init` | Initialize `.sfdt/` config (interactive) | — |
-| `sfdt deploy` | Deploy to a Salesforce org | `--managed`, `--skip-preflight` |
+| `sfdt deploy` | Deploy to a Salesforce org | `--managed`, `--skip-preflight`, `--dry-run` |
 | `sfdt release` | Generate release manifest + optional AI release notes | — |
-| `sfdt test` | Run Apex tests with the enhanced test runner | `--legacy`, `--analyze` |
-| `sfdt pull` | Pull metadata from the configured org | — |
-| `sfdt preflight` | Run pre-deployment validation checks | `--strict` |
-| `sfdt rollback` | Roll back a deployment to a target org | `--org <alias>` |
-| `sfdt smoke` | Post-deploy smoke tests | `--org <alias>` |
+| `sfdt test` | Run Apex tests with the enhanced test runner | `--legacy`, `--analyze`, `--dry-run` |
+| `sfdt pull` | Pull metadata from the configured org | `--dry-run` |
+| `sfdt preflight` | Run pre-deployment validation checks | `--strict`, `--dry-run` |
+| `sfdt rollback` | Roll back a deployment to a target org | `--org <alias>`, `--dry-run` |
+| `sfdt smoke` | Post-deploy smoke tests | `--org <alias>`, `--dry-run` |
 | `sfdt drift` | Detect metadata drift between local source and an org | `--org <alias>` |
 | `sfdt compare` | Compare metadata between two orgs or local source vs an org | `--source <alias\|local>`, `--target <alias>`, `--output <file>` |
 | `sfdt notify` | Send Slack deployment notifications | `--org <alias>`, `--version <ver>`, `--message <msg>` |
+| `sfdt completion <shell>` | Print shell completion script (`bash`, `zsh`, `fish`) | — |
+| `sfdt version` | Print the current sfdt version | — |
 
 ### AI & Intelligence (Phase 3)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sfdt/cli",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Salesforce DevTools — Production-grade CLI for Salesforce DX deployment, testing, quality analysis, and release management",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Release v0.4.1

## [0.4.1] - 2026-04-20

### Added
- **Shell completions** (`sfdt completion <bash|zsh|fish>`): generates ready-to-source completion scripts covering all commands and their flags.
- **Version subcommand** (`sfdt version`): prints `sfdt vX.Y.Z`; complements the existing `-v` / `--version` flag.
- **`--dry-run` flag** on `deploy`, `rollback`, `preflight`, `smoke`, `pull`, and `test`: prints the script path, working directory, and all `SFDT_` env vars — no changes made to the org.
- **Structured exit codes** (`src/lib/exit-codes.js`): `EXIT_SUCCESS` (0), `ERROR` (1), `CONFIG_ERROR` (2), `CONNECT_ERROR` (3). All 18 commands now map to the correct code instead of hardcoded `1`.

### Changed
- Config validation is now stricter with richer per-field error messages; validation errors exit with code `2` (`CONFIG_ERROR`).
- Updated `express` from 4.x to 5.x.
- Updated `open` from 10.x to 11.x.

## Test checklist
- [x] `npm test` passes (302 tests)
- [x] `npm run lint` passes (0 errors)
- [ ] Install from npm and run `sfdt --version` confirms new version