### PR TITLE
chore: release v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-04-24
+
+### Fixed
+- Parallel retrieve timeout increased to 6 minutes (was 2 minutes) to prevent timeouts on large orgs; now configurable via `pullCache.retrieveTimeoutSeconds` in `sfdt.config.json`.
+- Org alias is now sanitized before use as a SQLite filename, preventing path traversal in the pull cache.
+- `toMs()` in delta detection now guards against `null`/`undefined` dates to prevent `NaN` comparisons.
+- Components deleted from the org are now pruned from the pull cache on each successful update.
+- Partial retrieve successes are now cached correctly; cache update is only skipped when zero components were retrieved.
+- `smartPull` is now gated behind the `pullCache.enabled` flag.
+- Moved retrieved-component counter accumulation outside the concurrent `Promise.all` window to prevent race conditions.
+- GitHub Actions docs-update workflow now triggers correctly when commits are made by the `github-actions` bot.
+
 ## [0.5.0] - 2026-04-23
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,38 @@ npm run test:coverage # Coverage report
 npm link              # Link for local development
 ```
 
+### Package-Internal Path Resolution — CRITICAL RULE
+
+**Any path that references a file INSIDE the sfdt package** (scripts/, templates/, gui/dist/, bin/) MUST be resolved using `import.meta.url`, never from `process.cwd()`, `config._projectRoot`, or any CWD-based reference.
+
+When globally installed, `config._projectRoot` points to the *user's Salesforce project*, not the sfdt package. Using it to find package files causes "No such file or directory" errors on any machine other than the developer's.
+
+**WRONG — breaks on other machines:**
+```js
+path.join(config._projectRoot, 'scripts/new/preflight.sh')
+path.join(projectRoot, 'scripts/lib/changelog-utils.sh')
+path.resolve(process.cwd(), 'scripts/...')
+```
+
+**CORRECT — always resolves from the npm package location:**
+```js
+// At the top of every file that needs package assets:
+import { fileURLToPath } from 'url';
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const SCRIPTS_DIR = path.resolve(__dirname, '..', '..', 'scripts');  // from src/commands/ or src/lib/
+
+// Then use it:
+path.join(SCRIPTS_DIR, 'new/preflight.sh')
+path.join(SCRIPTS_DIR, 'lib/changelog-utils.sh')
+```
+
+The depth of `../..` depends on the file's location:
+- From `src/commands/` or `src/lib/` → `'..', '..', 'scripts'` reaches package root
+- From `bin/` → `'..', 'scripts'`
+
+**Run `/validate-npm-paths` before every release** to catch violations.
+
 ## Guidelines
 
 - Do not hardcode org aliases, branch names, or project-specific values

--- a/gui/src/components/CompareTable.jsx
+++ b/gui/src/components/CompareTable.jsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react';
+import React, { useState, useMemo } from 'react';
 import StatusBadge from './StatusBadge.jsx';
 import { IconSearch, IconFilter, IconPackage } from '../Icons.jsx';
 
@@ -11,17 +11,29 @@ const STATUS_OPTIONS = [
   { id: 'both',        label: 'Checking…' },
 ];
 
+const TYPE_GROUPS = [
+  { label: 'Code',            types: ['ApexClass', 'ApexTrigger', 'ApexPage', 'ApexComponent'] },
+  { label: 'UI & Components', types: ['LightningComponentBundle', 'AuraDefinitionBundle', 'FlexiPage', 'Layout'] },
+  { label: 'Automation',      types: ['Flow', 'Workflow', 'QuickAction', 'ValidationRule'] },
+  { label: 'Data Model',      types: ['CustomObject', 'CustomField', 'CustomMetadata', 'RecordType', 'GlobalValueSet', 'CustomLabels'] },
+  { label: 'Security',        types: ['Profile', 'PermissionSet', 'PermissionSetGroup', 'Role', 'Group', 'Queue'] },
+];
+
 function countsByStatus(items) {
   const c = {};
   for (const i of items) c[i.status] = (c[i.status] ?? 0) + 1;
   return c;
 }
 
+const getNamespace = (name) => name.match(/^([A-Za-z0-9]+)__/)?.[1] ?? null;
+
 export default function CompareTable({ items = [], onSelect, onBuildManifest }) {
   const [search, setSearch]             = useState('');
   const [statusFilter, setStatusFilter] = useState('all');
   const [typeFilter, setTypeFilter]     = useState('all');
   const [selection, setSelection]       = useState(new Set());
+  const [managedOnly, setManagedOnly]   = useState(false);
+  const [grouped, setGrouped]           = useState(false);
 
   const types = useMemo(() => {
     const t = [...new Set(items.map((i) => i.type))].sort();
@@ -31,9 +43,10 @@ export default function CompareTable({ items = [], onSelect, onBuildManifest }) 
   const filtered = useMemo(() => items.filter((i) => {
     if (statusFilter !== 'all' && i.status !== statusFilter) return false;
     if (typeFilter !== 'all' && i.type !== typeFilter) return false;
+    if (managedOnly && !getNamespace(i.member)) return false;
     if (search && !`${i.type}.${i.member}`.toLowerCase().includes(search.toLowerCase())) return false;
     return true;
-  }), [items, statusFilter, typeFilter, search]);
+  }), [items, statusFilter, typeFilter, managedOnly, search]);
 
   const autoSelected = useMemo(() => new Set(
     items
@@ -41,22 +54,89 @@ export default function CompareTable({ items = [], onSelect, onBuildManifest }) 
       .map((i) => `${i.type}.${i.member}`),
   ), [items]);
 
-  const effectiveSel = selection.size === 0 ? autoSelected : selection;
+  // Bug 2: effectiveSel is always selection (no fallback to autoSelected for display)
+  const effectiveSel = selection;
 
   const toggleRow = (key) => {
     setSelection((prev) => {
-      const base = prev.size === 0 ? new Set(autoSelected) : new Set(prev);
-      if (base.has(key)) base.delete(key); else base.add(key);
-      return base;
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key); else next.add(key);
+      return next;
     });
   };
 
   const handleBuildManifest = () => {
-    const selected = items.filter((i) => effectiveSel.has(`${i.type}.${i.member}`));
+    // Use explicit selection if any; otherwise fall back to autoSelected
+    const source = selection.size > 0 ? selection : autoSelected;
+    const selected = items.filter((i) => source.has(`${i.type}.${i.member}`));
     onBuildManifest?.(selected);
   };
 
   const counts = useMemo(() => countsByStatus(items), [items]);
+
+  // Bug 5: grouped rendering helpers
+  const groupedRows = useMemo(() => {
+    if (!grouped) return null;
+    const groups = TYPE_GROUPS.map((g) => ({
+      label: g.label,
+      items: filtered.filter((i) => g.types.includes(i.type)),
+    })).filter((g) => g.items.length > 0);
+
+    const assignedKeys = new Set(TYPE_GROUPS.flatMap((g) => g.types));
+    const other = filtered.filter((i) => !assignedKeys.has(i.type));
+    if (other.length > 0) groups.push({ label: 'Other', items: other });
+    return groups;
+  }, [grouped, filtered]);
+
+  const renderRow = (item) => {
+    const key = `${item.type}.${item.member}`;
+    const checked = effectiveSel.has(key);
+    const ns = getNamespace(item.member);
+    return (
+      <tr key={key}>
+        <td>
+          <input
+            type="checkbox"
+            className="cbx"
+            checked={checked}
+            onChange={() => toggleRow(key)}
+          />
+        </td>
+        <td>
+          <button
+            className="td-name"
+            style={{ background: 'none', border: 'none', color: 'var(--fg-brand)', cursor: 'pointer', padding: 0, fontSize: 'inherit', fontWeight: 500 }}
+            onClick={() => onSelect?.(item)}
+          >
+            {item.member}
+          </button>
+          {/* Bug 4: namespace badge */}
+          {ns && (
+            <span style={{
+              display: 'inline-block',
+              marginLeft: 6,
+              padding: '1px 6px',
+              borderRadius: 4,
+              fontSize: 10,
+              fontFamily: 'var(--font-mono)',
+              background: 'var(--bg-muted)',
+              color: 'var(--fg-subtle)',
+              border: '1px solid var(--border-subtle)',
+              verticalAlign: 'middle',
+            }}>
+              {ns}
+            </span>
+          )}
+        </td>
+        <td>
+          <span className="mono" style={{ fontSize: 'var(--fs-xs)', color: 'var(--fg-muted)' }}>
+            {item.type}
+          </span>
+        </td>
+        <td><StatusBadge status={item.status} /></td>
+      </tr>
+    );
+  };
 
   return (
     <div>
@@ -87,6 +167,22 @@ export default function CompareTable({ items = [], onSelect, onBuildManifest }) 
           );
         })}
 
+        {/* Bug 4: Managed toggle */}
+        <button
+          className={`filter-chip${managedOnly ? ' active' : ''}`}
+          onClick={() => setManagedOnly((v) => !v)}
+        >
+          Managed
+        </button>
+
+        {/* Bug 5: Group by type toggle */}
+        <button
+          className={`filter-chip${grouped ? ' active' : ''}`}
+          onClick={() => setGrouped((v) => !v)}
+        >
+          Group by type
+        </button>
+
         {types.length > 2 && (
           <div style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: 6 }}>
             <IconFilter size={12} style={{ color: 'var(--fg-subtle)' }} />
@@ -105,10 +201,32 @@ export default function CompareTable({ items = [], onSelect, onBuildManifest }) 
         )}
       </div>
 
-      {/* Bulk bar */}
-      {effectiveSel.size > 0 && (
+      {/* Bug 2: "Select recommended" button — visible only before user makes a selection */}
+      {autoSelected.size > 0 && selection.size === 0 && (
+        <div style={{ marginBottom: 'var(--s-2)' }}>
+          <button
+            className="btn btn-secondary btn-sm"
+            onClick={() => setSelection(new Set(autoSelected))}
+          >
+            Select recommended ({autoSelected.size})
+          </button>
+        </div>
+      )}
+      {autoSelected.size === 0 && selection.size === 0 && filtered.length > 0 && (
+        <div style={{ marginBottom: 'var(--s-2)' }}>
+          <button
+            className="btn btn-secondary btn-sm"
+            onClick={() => setSelection(new Set(filtered.map((i) => `${i.type}.${i.member}`)))}
+          >
+            Select all ({filtered.length})
+          </button>
+        </div>
+      )}
+
+      {/* Bug 2: Bulk bar only renders when user has explicitly selected something */}
+      {selection.size > 0 && (
         <div className="bulk-bar">
-          <span className="bulk-label">{effectiveSel.size} selected</span>
+          <span className="bulk-label">{selection.size} selected</span>
           <span className="bulk-spacer" />
           <button className="btn btn-primary btn-sm" onClick={handleBuildManifest}>
             Build manifest
@@ -132,10 +250,14 @@ export default function CompareTable({ items = [], onSelect, onBuildManifest }) 
                   <input
                     type="checkbox"
                     className="cbx"
-                    checked={filtered.every((i) => effectiveSel.has(`${i.type}.${i.member}`))}
+                    checked={filtered.length > 0 && filtered.every((i) => effectiveSel.has(`${i.type}.${i.member}`))}
                     onChange={(e) => {
                       const keys = filtered.map((i) => `${i.type}.${i.member}`);
-                      setSelection(e.target.checked ? new Set([...effectiveSel, ...keys]) : new Set());
+                      setSelection((prev) => {
+                        if (e.target.checked) return new Set([...prev, ...keys]);
+                        const keySet = new Set(keys);
+                        return new Set([...prev].filter((k) => !keySet.has(k)));
+                      });
                     }}
                   />
                 </th>
@@ -145,37 +267,34 @@ export default function CompareTable({ items = [], onSelect, onBuildManifest }) 
               </tr>
             </thead>
             <tbody>
-              {filtered.map((item) => {
-                const key = `${item.type}.${item.member}`;
-                const checked = effectiveSel.has(key);
-                return (
-                  <tr key={key}>
-                    <td>
-                      <input
-                        type="checkbox"
-                        className="cbx"
-                        checked={checked}
-                        onChange={() => toggleRow(key)}
-                      />
-                    </td>
-                    <td>
-                      <button
-                        className="td-name"
-                        style={{ background: 'none', border: 'none', color: 'var(--fg-brand)', cursor: 'pointer', padding: 0, fontSize: 'inherit', fontWeight: 500 }}
-                        onClick={() => onSelect?.(item)}
-                      >
-                        {item.member}
-                      </button>
-                    </td>
-                    <td>
-                      <span className="mono" style={{ fontSize: 'var(--fs-xs)', color: 'var(--fg-muted)' }}>
-                        {item.type}
-                      </span>
-                    </td>
-                    <td><StatusBadge status={item.status} /></td>
-                  </tr>
-                );
-              })}
+              {/* Bug 5: grouped or flat rendering */}
+              {grouped
+                ? (groupedRows ?? []).map((group) => (
+                    <React.Fragment key={`group-${group.label}`}>
+                      <tr>
+                        <td
+                          colSpan={4}
+                          style={{
+                            background: 'var(--bg-subtle)',
+                            color: 'var(--fg-muted)',
+                            fontSize: 'var(--fs-xs)',
+                            fontWeight: 600,
+                            padding: '4px 8px',
+                            letterSpacing: '0.05em',
+                            textTransform: 'uppercase',
+                          }}
+                        >
+                          {group.label}
+                          <span style={{ fontFamily: 'var(--font-mono)', fontWeight: 400, opacity: 0.6, marginLeft: 6 }}>
+                            {group.items.length}
+                          </span>
+                        </td>
+                      </tr>
+                      {group.items.map(renderRow)}
+                    </React.Fragment>
+                  ))
+                  : filtered.map(renderRow)
+              }
             </tbody>
           </table>
         )}

--- a/gui/src/components/CompareTable.jsx
+++ b/gui/src/components/CompareTable.jsx
@@ -54,7 +54,7 @@ export default function CompareTable({ items = [], onSelect, onBuildManifest }) 
       .map((i) => `${i.type}.${i.member}`),
   ), [items]);
 
-  // Bug 2: effectiveSel is always selection (no fallback to autoSelected for display)
+  // Selection is always explicit; fallback to autoSelected happens only in handleBuildManifest
   const effectiveSel = selection;
 
   const toggleRow = (key) => {
@@ -74,7 +74,6 @@ export default function CompareTable({ items = [], onSelect, onBuildManifest }) 
 
   const counts = useMemo(() => countsByStatus(items), [items]);
 
-  // Bug 5: grouped rendering helpers
   const groupedRows = useMemo(() => {
     if (!grouped) return null;
     const groups = TYPE_GROUPS.map((g) => ({
@@ -110,7 +109,6 @@ export default function CompareTable({ items = [], onSelect, onBuildManifest }) 
           >
             {item.member}
           </button>
-          {/* Bug 4: namespace badge */}
           {ns && (
             <span style={{
               display: 'inline-block',
@@ -167,7 +165,6 @@ export default function CompareTable({ items = [], onSelect, onBuildManifest }) 
           );
         })}
 
-        {/* Bug 4: Managed toggle */}
         <button
           className={`filter-chip${managedOnly ? ' active' : ''}`}
           onClick={() => setManagedOnly((v) => !v)}
@@ -175,7 +172,6 @@ export default function CompareTable({ items = [], onSelect, onBuildManifest }) 
           Managed
         </button>
 
-        {/* Bug 5: Group by type toggle */}
         <button
           className={`filter-chip${grouped ? ' active' : ''}`}
           onClick={() => setGrouped((v) => !v)}
@@ -201,7 +197,6 @@ export default function CompareTable({ items = [], onSelect, onBuildManifest }) 
         )}
       </div>
 
-      {/* Bug 2: "Select recommended" button — visible only before user makes a selection */}
       {autoSelected.size > 0 && selection.size === 0 && (
         <div style={{ marginBottom: 'var(--s-2)' }}>
           <button
@@ -218,12 +213,11 @@ export default function CompareTable({ items = [], onSelect, onBuildManifest }) 
             className="btn btn-secondary btn-sm"
             onClick={() => setSelection(new Set(filtered.map((i) => `${i.type}.${i.member}`)))}
           >
-            Select all ({filtered.length})
+            Select all visible ({filtered.length})
           </button>
         </div>
       )}
 
-      {/* Bug 2: Bulk bar only renders when user has explicitly selected something */}
       {selection.size > 0 && (
         <div className="bulk-bar">
           <span className="bulk-label">{selection.size} selected</span>
@@ -267,7 +261,6 @@ export default function CompareTable({ items = [], onSelect, onBuildManifest }) 
               </tr>
             </thead>
             <tbody>
-              {/* Bug 5: grouped or flat rendering */}
               {grouped
                 ? (groupedRows ?? []).map((group) => (
                     <React.Fragment key={`group-${group.label}`}>
@@ -293,7 +286,7 @@ export default function CompareTable({ items = [], onSelect, onBuildManifest }) 
                       {group.items.map(renderRow)}
                     </React.Fragment>
                   ))
-                  : filtered.map(renderRow)
+                : filtered.map(renderRow)
               }
             </tbody>
           </table>

--- a/gui/src/pages/Compare.jsx
+++ b/gui/src/pages/Compare.jsx
@@ -29,6 +29,23 @@ export default function ComparePage() {
       .catch(() => {});
   }, []);
 
+  useEffect(() => {
+    return () => { esRef.current?.close(); };
+  }, []);
+
+  // Bug 3: load cached compare results on mount
+  useEffect(() => {
+    api.compareResult()
+      .then((data) => {
+        if (data?.items?.length) {
+          setItems(data.items);
+          setHasResult(true);
+          if (data.target) setTarget({ id: data.target, label: data.target });
+        }
+      })
+      .catch(() => {});
+  }, []);
+
   const allOrgs = useMemo(() => [LOCAL_OPT, ...orgs.map((o) => ({ id: o.alias, label: o.alias, alias: o.alias }))], [orgs]);
 
   const startPhase2 = () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sfdt/cli",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Salesforce DevTools — Production-grade CLI for Salesforce DX deployment, testing, quality analysis, and release management",
   "type": "module",
   "bin": {

--- a/src/commands/changelog.js
+++ b/src/commands/changelog.js
@@ -1,11 +1,16 @@
 import inquirer from 'inquirer';
 import fs from 'fs-extra';
 import path from 'path';
+import { fileURLToPath } from 'url';
 import { loadConfig } from '../lib/config.js';
 import { isAiAvailable, runAiPrompt } from '../lib/ai.js';
 import { print } from '../lib/output.js';
 import { execa } from 'execa';
 import { resolveExitCode } from '../lib/exit-codes.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const SCRIPTS_DIR = path.resolve(__dirname, '..', '..', 'scripts');
 
 export function registerChangelogCommand(program) {
   const changelog = program.command('changelog').description('Manage project CHANGELOG.md');
@@ -118,7 +123,7 @@ export function registerChangelogCommand(program) {
         print.info(`Releasing version ${version} in CHANGELOG.md...`);
 
         // Pass the script path as a positional arg to avoid shell interpolation
-        const scriptPath = path.resolve(config._projectRoot, 'scripts/lib/changelog-utils.sh');
+        const scriptPath = path.join(SCRIPTS_DIR, 'lib', 'changelog-utils.sh');
         await execa(
           'bash',
           ['-c', 'source "$1" && move_unreleased_to_version "$SFDT_VERSION"', 'bash', scriptPath],
@@ -147,7 +152,7 @@ export function registerChangelogCommand(program) {
         });
 
         // Pass the script path as a positional arg to avoid shell interpolation
-        const scriptPath = path.resolve(projectRoot, 'scripts/lib/changelog-utils.sh');
+        const scriptPath = path.join(SCRIPTS_DIR, 'lib', 'changelog-utils.sh');
         const { stdout: contentStatus } = await execa(
           'bash',
           [

--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -1,7 +1,7 @@
 import { loadConfig } from '../lib/config.js';
 import { runScript } from '../lib/script-runner.js';
 import { print } from '../lib/output.js';
-import { ExitCode, resolveExitCode } from '../lib/exit-codes.js';
+import { resolveExitCode } from '../lib/exit-codes.js';
 
 export function registerDeployCommand(program) {
   program

--- a/src/lib/gui-server.js
+++ b/src/lib/gui-server.js
@@ -18,6 +18,8 @@ import { fetchLatestVersion } from './update-checker.js';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
+const SCRIPTS_DIR = path.resolve(__dirname, '..', '..', 'scripts');
+
 // gui/dist lives at <package-root>/gui/dist
 const GUI_DIST = path.resolve(__dirname, '..', '..', 'gui', 'dist');
 
@@ -282,27 +284,27 @@ async function readLocalComponentXml(config, _type, member) {
 
 const COMMANDS = {
   preflight: {
-    script: 'scripts/new/preflight.sh',
+    script: 'new/preflight.sh',
     logFile: 'logs/preflight-latest.json',
   },
   drift: {
-    script: 'scripts/new/drift.sh',
+    script: 'new/drift.sh',
     logFile: 'logs/drift-latest.json',
   },
   test: {
-    script: 'scripts/core/enhanced-test-runner.sh',
+    script: 'core/enhanced-test-runner.sh',
     logFile: 'logs/test-results/latest.json',
   },
   quality: {
-    script: 'scripts/quality/code-analyzer.sh',
+    script: 'quality/code-analyzer.sh',
     logFile: 'logs/quality-latest.json',
   },
   deploy: {
-    script: 'scripts/core/deployment-assistant.sh',
+    script: 'core/deployment-assistant.sh',
     logFile: 'logs/deploy-latest.log',
   },
   rollback: {
-    script: 'scripts/new/rollback.sh',
+    script: 'new/rollback.sh',
     logFile: 'logs/rollback-latest.log',
   },
 };
@@ -502,7 +504,7 @@ export function createGuiApp(config, version, port = 7654) {
       const { createInterface } = await import('readline');
 
       const projectRoot = config._projectRoot ?? process.cwd();
-      const scriptPath = path.join(projectRoot, cmd.script);
+      const scriptPath = path.join(SCRIPTS_DIR, cmd.script);
 
       const scriptEnv = {
         SFDT_PROJECT_ROOT: projectRoot,
@@ -865,7 +867,7 @@ export function createGuiApp(config, version, port = 7654) {
 
     try {
       const projectRoot = config._projectRoot ?? process.cwd();
-      const scriptPath = path.join(projectRoot, 'scripts/core/deployment-assistant.sh');
+      const scriptPath = path.join(SCRIPTS_DIR, 'core', 'deployment-assistant.sh');
 
       const scriptEnv = {
         SFDT_PROJECT_ROOT: projectRoot,


### PR DESCRIPTION
## Release v0.5.1

### Fixed
- Parallel retrieve timeout increased to 6 minutes (was 2 minutes); now configurable via `pullCache.retrieveTimeoutSeconds`
- Org alias sanitized before use as SQLite filename (path traversal prevention)
- `toMs()` in delta detection now guards against `null`/`undefined` dates
- Components deleted from the org are now pruned from the pull cache on each successful update
- Partial retrieve successes cached correctly; cache update only skipped when zero components retrieved
- `smartPull` gated behind `pullCache.enabled` flag
- Retrieved counter moved outside concurrent `Promise.all` window to prevent race conditions
- GitHub Actions docs-update workflow now triggers correctly for `github-actions` bot commits
- GUI script paths resolved via `import.meta.url` instead of `config._projectRoot` (fixes broken paths when globally installed)
- `changelog` command script path fixed with same `import.meta.url` resolution
- CompareTable: selection logic, managed-only filter, group-by-type view, and namespace badge fixes
- Compare page: cached results loaded on mount; SSE connection cleaned up on unmount
- Remove unused `ExitCode` import from `deploy.js`

## Test checklist
- [ ] `npm test` passes
- [ ] `npm run lint` passes
- [ ] Install from npm and run `sfdt --version` confirms `0.5.1`