### PR TITLE
fix: correct action org name in docs-verify workflow

### DIFF
--- a/.github/workflows/docs-verify.yml
+++ b/.github/workflows/docs-verify.yml
@@ -32,7 +32,7 @@ jobs:
       - run: npm ci
 
       - name: Verify documentation accuracy
-        uses: anthropics/claude-code-base-action@v1
+        uses: anthropic/claude-code-base-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |


### PR DESCRIPTION
## Fix

`anthropics/claude-code-base-action@v1` → `anthropic/claude-code-base-action@v1`

The org name was misspelled, causing Documentation Verification to fail on every merge to main. This has been the root cause since the workflow was introduced.