### PR TITLE
chore: release v0.6.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        node-version: [20, 22]
+        node-version: [22]
     steps:
       - uses: actions/checkout@v6
       - name: Use Node.js ${{ matrix.node-version }}
@@ -26,8 +26,7 @@ jobs:
         run: npm audit --audit-level=high
       - run: npm run lint
       - run: npm test
-      - name: Publish dry-run (Node 22 only)
-        if: matrix.node-version == 22
+      - name: Publish dry-run
         run: npm publish --dry-run
 
   gui-build:
@@ -36,7 +35,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        node-version: [20, 22]
+        node-version: [22]
     steps:
       - uses: actions/checkout@v6
       - name: Use Node.js ${{ matrix.node-version }}
@@ -47,6 +46,8 @@ jobs:
           cache-dependency-path: gui/package-lock.json
       - name: Install GUI dependencies
         run: cd gui && npm install
+      - name: Test GUI
+        run: cd gui && npm test
       - name: Build GUI
         run: cd gui && npm run build
 

--- a/.github/workflows/pr-publish.yml
+++ b/.github/workflows/pr-publish.yml
@@ -1,0 +1,198 @@
+name: PR Beta Publish
+
+on:
+  pull_request:
+    types: [labeled, closed]
+    branches: [main, develop]
+
+concurrency:
+  group: pr-publish-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  publish-pr-beta:
+    if: github.event.action == 'labeled' && github.event.label.name == 'publish-beta'
+    runs-on: ubuntu-latest
+    environment: beta
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
+
+    steps:
+      - name: Check actor permission
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: perm } = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              username: context.actor,
+            });
+            const allowed = ['write', 'maintain', 'admin'];
+            if (!allowed.includes(perm.permission)) {
+              core.setFailed(`Actor ${context.actor} has permission '${perm.permission}' — write or higher required to publish a beta.`);
+            }
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: 'https://registry.npmjs.org'
+
+      - run: npm ci
+
+      - name: Build GUI
+        run: npm run build:gui
+
+      - name: Compute PR beta version
+        id: version
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          BASE=$(node -p "require('./package.json').version")
+          PREFIX="${BASE}-pr.${PR_NUMBER}."
+          EXISTING=$(npm view @sfdt/cli versions --json 2>/dev/null || echo '[]')
+          N=$(node -e "
+            const versions = JSON.parse(process.env.EXISTING);
+            const prefix = process.env.PREFIX;
+            const nums = versions
+              .filter(v => v.startsWith(prefix))
+              .map(v => parseInt(v.slice(prefix.length), 10))
+              .filter(n => !isNaN(n));
+            console.log(nums.length ? Math.max(...nums) + 1 : 1);
+          ")
+          NEW_VERSION="${PREFIX}${N}"
+          echo "new_version=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "pr_tag=pr-${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+          echo "Computing version: ${NEW_VERSION} (tag: pr-${PR_NUMBER})"
+
+      - name: Stamp version in package.json
+        env:
+          NEW_VERSION: ${{ steps.version.outputs.new_version }}
+        run: npm version "$NEW_VERSION" --no-git-tag-version
+
+      - name: Publish beta to npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          PR_TAG: ${{ steps.version.outputs.pr_tag }}
+        run: npx npm@latest publish --provenance --access public --tag "$PR_TAG"
+
+      - name: Comment on PR
+        if: success()
+        uses: actions/github-script@v7
+        env:
+          NEW_VERSION: ${{ steps.version.outputs.new_version }}
+          PR_TAG: ${{ steps.version.outputs.pr_tag }}
+        with:
+          script: |
+            const version = process.env.NEW_VERSION;
+            const tag = process.env.PR_TAG;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: [
+                '## Beta Published',
+                '',
+                `Version \`${version}\` is available on npm under the \`${tag}\` dist-tag.`,
+                '',
+                '**Install to test:**',
+                '```sh',
+                `npm install @sfdt/cli@${tag}`,
+                '```',
+                `Or pin the exact version: \`npm install @sfdt/cli@${version}\``,
+                '',
+                '> This dist-tag will be removed automatically when the PR is closed.',
+              ].join('\n'),
+            });
+
+      - name: Remove publish-beta label
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                name: 'publish-beta',
+              });
+            } catch {
+              // Label already removed — ignore
+            }
+
+  cleanup-pr-beta:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    environment: beta
+    permissions:
+      pull-requests: write
+
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Check if dist-tag exists
+        id: check
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          TAG="pr-${PR_NUMBER}"
+          TAGS=$(npm view @sfdt/cli dist-tags --json 2>/dev/null || echo '{}')
+          EXISTS=$(node -e "
+            const t = JSON.parse(process.env.TAGS);
+            const tag = process.env.TAG;
+            console.log(t[tag] ? 'true' : 'false');
+          ")
+          echo "exists=${EXISTS}" >> "$GITHUB_OUTPUT"
+          echo "pr_tag=${TAG}" >> "$GITHUB_OUTPUT"
+          if [ "$EXISTS" = "true" ]; then
+            BASE_VERSION=$(node -e "
+              const t = JSON.parse(process.env.TAGS);
+              const tag = process.env.TAG;
+              const v = t[tag];
+              console.log(v.split('-pr.')[0]);
+            ")
+            echo "base_version=${BASE_VERSION}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Remove dist-tag and deprecate PR versions
+        if: steps.check.outputs.exists == 'true'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          PR_TAG: ${{ steps.check.outputs.pr_tag }}
+          BASE_VERSION: ${{ steps.check.outputs.base_version }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          npm config set //registry.npmjs.org/:_authToken "${NODE_AUTH_TOKEN}"
+          npm dist-tag rm @sfdt/cli "$PR_TAG"
+          PREFIX="${BASE_VERSION}-pr.${PR_NUMBER}."
+          VERSIONS=$(npm view @sfdt/cli versions --json 2>/dev/null || echo '[]')
+          node -e "
+            const versions = JSON.parse(process.env.VERSIONS);
+            const prefix = process.env.PREFIX;
+            versions.filter(v => v.startsWith(prefix)).forEach(v => console.log(v));
+          " | while read -r v; do
+            npm deprecate "@sfdt/cli@${v}" "PR beta — this version has been archived. Install the stable release: npm install @sfdt/cli@latest"
+          done
+
+      - name: Comment on PR
+        if: steps.check.outputs.exists == 'true'
+        uses: actions/github-script@v7
+        env:
+          PR_TAG: ${{ steps.check.outputs.pr_tag }}
+        with:
+          script: |
+            const tag = process.env.PR_TAG;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: `**Beta Cleaned Up** — The \`${tag}\` dist-tag has been removed. Install the stable release: \`npm install @sfdt/cli@latest\``,
+            });

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.3] - 2026-04-29
+
+### Added
+- **GUI: ErrorBoundary** — all pages are now wrapped in a React error boundary; a render crash on one page no longer takes down the entire dashboard.
+- **GUI: Dashboard retry** — when dashboard data fails to load, an inline error message with a Retry button appears instead of a silent blank state.
+- **GUI: Compare cancel** — a Cancel button appears during long-running inventory streams so users can abort without navigating away.
+- **GUI test suite** — Vitest + Testing Library added to the GUI package; tests run in CI on every push (`cd gui && npm test`).
+- **JSDoc type annotations** added to all `api.js` functions for improved IDE autocompletion.
+
+### Changed
+- **ANSI escape codes stripped** from all SSE log output and terminal streams in the GUI — no more garbled color codes appearing in command output panels.
+- **Node.js 22+ required** — engine floor raised from 20 to 22; CI now tests on Node 22 only.
+- **`better-sqlite3` replaced with Node built-in `node:sqlite`** (`DatabaseSync`) — removes the native compiled dependency; pull cache now uses the standard library SQLite module.
+- **Pull page** replaced with a "Coming Soon" placeholder pointing users to the Compare page and the CLI; the interactive pull UI is not yet complete.
+- **`/api/preflight`, `/api/drift`, `/api/compare`** now return structured empty shapes (`{ date: null, status: null, checks: [] }` etc.) instead of `{}` when no data exists, preventing client-side null-check errors.
+- **Org config format** (`environments.orgs`) is now correctly read as an array of `{ alias, username }` objects, matching what `sfdt init` writes.
+
+### Fixed
+- Dashboard drift activity card no longer crashes — uses `drift.status` / `drift.components` instead of the removed `drift.result` / `drift.count` fields.
+- `initInProgress` flag is now correctly reset to `false` after a successful `/api/init` call (was only reset on error, causing false "Already initialized" rejections after first use).
+- Release Hub: streaming sessions for changelog and release-note generation are now closed on component unmount, preventing memory leaks after navigating away.
+- Release Hub: deployment now validates that a target org is selected before starting, showing an inline error instead of silently proceeding with no org.
+- Release Hub: test detection effect no longer re-runs on `testClasses` change (was causing duplicate API calls).
+- Logs page: unknown log types now render their raw JSON payload in a scrollable `<pre>` block instead of returning `null`.
+- Manifests viewer: defensive null checks on `data.components` prevent crashes when a manifest has no components; download filename falls back to `manifest.xml`.
+- Review, Explain, Quality pages: when AI output exceeds 2000 characters, the content is truncated and a notice shows the full character count.
+- Settings: `coverageThreshold` field now validates that the entered value is a number between 0 and 100 before saving.
+- React key props in Logs, ReleaseHub, and Dashboard tables now use stable identifiers instead of array indices, preventing incorrect reconciliation on re-render.
+- CodeQL suppression comments added to intentional file-to-HTTP patterns in `ai.js` to silence false-positive alerts.
+
 ## [0.6.2] - 2026-04-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.2] - 2026-04-29
+
+### Added
+- **GUI: Initialize Project from Settings**: The Settings page now shows a guided "Initialize Project" card when no `.sfdt/` config directory exists, backed by a new `/api/init` endpoint — users can set up a project without touching the command line.
+
+### Fixed
+- `ReferenceError` crash on the Release Hub page caused by a missing `IconSearch` import; the page now loads correctly.
+- Settings page no longer returns a raw 503 error on uninitialized projects; users are guided to initialize from within the GUI instead.
+- After a GUI-triggered update (`sfdt update`), the server now self-restarts automatically and the browser polls `/api/ping` to reload once the server is ready — no manual restart required.
+
+### Changed
+- `express-rate-limit` updated from v7 to v8 (major); no behavior change for end users.
+- `ora` updated to 9.4.0; `vitest` and `@vitest/coverage-v8` updated to 4.1.5.
+
 ## [0.6.1] - 2026-04-28
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ Cache behavior is controlled via `pullCache` in `.sfdt/config.json`:
 
 ## Requirements
 
-- **Node.js** >= 22.0.0 (uses the built-in `node:sqlite` module introduced in Node 22)
+- **Node.js** >= 22.15.0 (uses the built-in `node:sqlite` module, unflagged in Node 22.15)
 - **Salesforce CLI** (`sf`) installed and authenticated to target orgs
 - **bash** 4.0+ (macOS users: `brew install bash`)
 - **jq** 1.6+ (required by several shell scripts)

--- a/README.md
+++ b/README.md
@@ -331,11 +331,10 @@ Cache behavior is controlled via `pullCache` in `.sfdt/config.json`:
 
 ## Requirements
 
-- **Node.js** >= 20.0.0
+- **Node.js** >= 22.0.0 (uses the built-in `node:sqlite` module introduced in Node 22)
 - **Salesforce CLI** (`sf`) installed and authenticated to target orgs
 - **bash** 4.0+ (macOS users: `brew install bash`)
 - **jq** 1.6+ (required by several shell scripts)
-- **Native build tools** (`python3`, `make`, `g++`) — required only if `better-sqlite3` cannot find a pre-built binary for your Node version or architecture (e.g. ARM64, Alpine Linux, or custom Node builds). Most standard installs use a pre-built binary and do not need these. On Debian/Ubuntu: `apt-get install python3 make g++`; on macOS Xcode Command Line Tools suffice (`xcode-select --install`).
 - **Optional:** [Claude Code CLI](https://www.npmjs.com/package/@anthropic-ai/claude-code) for AI features with the `claude` provider
 - **Optional:** Gemini or OpenAI API key for `gemini`/`openai` provider
 - **Optional:** [GitHub CLI](https://cli.github.com/) (`gh`) for PR creation during deployments

--- a/gui/package-lock.json
+++ b/gui/package-lock.json
@@ -12,9 +12,72 @@
         "react-dom": "^18.3.1"
       },
       "devDependencies": {
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@vitejs/plugin-react": "^5.2.0",
-        "vite": "^8.0.8"
+        "jsdom": "^29.1.0",
+        "vite": "^8.0.8",
+        "vitest": "^4.1.5"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -250,6 +313,16 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -298,6 +371,159 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+      "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
     "node_modules/@emnapi/core": {
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
@@ -330,6 +556,24 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -675,6 +919,103 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -685,6 +1026,14 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -731,6 +1080,31 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.2.0.tgz",
@@ -752,6 +1126,164 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.5",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.5",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.18",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.18.tgz",
@@ -763,6 +1295,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/browserslist": {
@@ -820,12 +1362,57 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -845,6 +1432,23 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -855,12 +1459,40 @@
         "node": ">=8"
       }
     },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.335",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.335.tgz",
       "integrity": "sha512-q9n5T4BR4Xwa2cwbrwcsDJtHD/enpQ5S1xF1IAtdqf5AAgqDFmR/aakqH3ChFdqd/QXJhS3rnnXFtexU7rax6Q==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -870,6 +1502,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fdir": {
@@ -915,11 +1567,92 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.0.tgz",
+      "integrity": "sha512-YNUc7fB9QuvSSQWfrH0xF+TyABkxUwx8sswgIDaCrw4Hol8BghdZDkITtZheRJeMtzWlnTfsM3bBBusRvpO1wg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -1230,6 +1963,44 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -1241,6 +2012,37 @@
       "version": "2.0.37",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
       "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
     },
@@ -1312,6 +2114,32 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -1337,10 +2165,42 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/react-refresh": {
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
       "integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1388,6 +2248,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -1407,6 +2280,13 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1415,6 +2295,57 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tinyglobby": {
@@ -1434,6 +2365,62 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.29",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.29.tgz",
+      "integrity": "sha512-JIXCerhudr/N6OWLwLF1HVsTTUo7ry6qHa5eWZEkiMuxsIiAACL55tGLfqfHfoH7QaMQUW8fngD7u7TxWexYQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.29"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.29",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.29.tgz",
+      "integrity": "sha512-W99NuU7b1DcG3uJ3v9k9VztCH3WialNbBkBft5wCs8V8mexu0XQqaZEYb9l9RNNzK8+3EJ9PKWB0/RUtTQ/o+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -1441,6 +2428,16 @@
       "dev": true,
       "license": "0BSD",
       "optional": true
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
@@ -1550,6 +2547,178 @@
           "optional": true
         }
       }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/gui/package.json
+++ b/gui/package.json
@@ -6,14 +6,21 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@vitejs/plugin-react": "^5.2.0",
-    "vite": "^8.0.8"
+    "jsdom": "^29.1.0",
+    "vite": "^8.0.8",
+    "vitest": "^4.1.5"
   }
 }

--- a/gui/src/App.jsx
+++ b/gui/src/App.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, createContext } from 'react';
 import { api } from './api.js';
+import ErrorBoundary from './components/ErrorBoundary.jsx';
 import Dashboard from './pages/Dashboard.jsx';
 import TestRuns from './pages/TestRuns.jsx';
 import PreflightPage from './pages/Preflight.jsx';
@@ -226,7 +227,9 @@ export default function App() {
 
         {/* Page content */}
         <div className="page-content">
-          {renderPage()}
+          <ErrorBoundary key={page}>
+            {renderPage()}
+          </ErrorBoundary>
         </div>
 
       </div>

--- a/gui/src/App.jsx
+++ b/gui/src/App.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, createContext } from 'react';
+import { useState, useEffect, useCallback, useMemo, createContext } from 'react';
 import { api } from './api.js';
 import ErrorBoundary from './components/ErrorBoundary.jsx';
 import Dashboard from './pages/Dashboard.jsx';
@@ -141,12 +141,14 @@ export default function App() {
     }
   };
 
+  const chatContextValue = useMemo(() => ({ openChat, setPageContext }), [openChat, setPageContext]);
+
   const initials = project?.name
     ? project.name.split(' ').map((w) => w[0]).join('').slice(0, 2).toUpperCase()
     : 'SF';
 
   return (
-    <ChatContext.Provider value={{ openChat, setPageContext }}>
+    <ChatContext.Provider value={chatContextValue}>
     <>
     {showUpdate && updateInfo && (
       <UpdateModal

--- a/gui/src/api.js
+++ b/gui/src/api.js
@@ -1,8 +1,14 @@
 const BASE = '/api';
 
+function httpError(res) {
+  const err = new Error(`${res.status} ${res.statusText}`);
+  err.status = res.status;
+  return err;
+}
+
 async function fetchJson(path) {
   const res = await fetch(`${BASE}${path}`);
-  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  if (!res.ok) throw httpError(res);
   return res.json();
 }
 
@@ -12,7 +18,7 @@ async function postJson(path, body) {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
   });
-  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  if (!res.ok) throw httpError(res);
   return res.json();
 }
 
@@ -22,7 +28,7 @@ async function patchJson(path, body) {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
   });
-  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  if (!res.ok) throw httpError(res);
   return res.json();
 }
 
@@ -51,6 +57,7 @@ export const api = {
   removeManifestComponent:(relPath, type, member) => postJson('/manifest/remove-component', { relPath, type, member }),
   getConfig:              () => fetchJson('/config'),
   setConfig:              (key, value) => patchJson('/config', { key, value: String(value) }),
+  initProject:            (data) => postJson('/init', data),
   logs:                   (type = 'all') => fetchJson(`/logs${type !== 'all' ? `?type=${encodeURIComponent(type)}` : ''}`),
 };
 

--- a/gui/src/api.js
+++ b/gui/src/api.js
@@ -1,17 +1,33 @@
 const BASE = '/api';
 
+// ─── Response type definitions ────────────────────────────────────────────────
+
+/**
+ * @typedef {{ date: string|null, status: string|null, checks: Array<{name:string, status:string, message:string|null}> }} PreflightResult
+ * @typedef {{ date: string|null, status: string|null, components: Array<{name:string, type:string, drift:string}> }} DriftResult
+ * @typedef {{ date: string|null, source: string|null, target: string|null, items: Array<{type:string, member:string, status:string}> }} CompareResult
+ * @typedef {{ date: string, passed: number, failed: number, errors: number, coverage: number|null, duration: number|null }} TestRun
+ * @typedef {{ alias: string, username: string }} OrgEntry
+ * @typedef {{ name: string, org: string, apiVersion: string, coverageThreshold: number, features: object, version: string }} ProjectInfo
+ * @typedef {{ current: string, latest: string, updateAvailable: boolean }} UpdateInfo
+ * @typedef {{ available: boolean, enabled: boolean, provider: string }} AiAvailability
+ * @typedef {{ date: string, manifest: string, org: string, dryRun: boolean, skipPreflight: boolean, exitCode: number }} DeployHistoryEntry
+ */
+
 function httpError(res) {
   const err = new Error(`${res.status} ${res.statusText}`);
   err.status = res.status;
   return err;
 }
 
+/** @returns {Promise<any>} */
 async function fetchJson(path) {
   const res = await fetch(`${BASE}${path}`);
   if (!res.ok) throw httpError(res);
   return res.json();
 }
 
+/** @returns {Promise<any>} */
 async function postJson(path, body) {
   const res = await fetch(`${BASE}${path}`, {
     method: 'POST',
@@ -22,6 +38,7 @@ async function postJson(path, body) {
   return res.json();
 }
 
+/** @returns {Promise<any>} */
 async function patchJson(path, body) {
   const res = await fetch(`${BASE}${path}`, {
     method: 'PATCH',
@@ -33,35 +50,63 @@ async function patchJson(path, body) {
 }
 
 export const api = {
+  /** @returns {Promise<ProjectInfo>} */
   project:                () => fetchJson('/project'),
+  /** @returns {Promise<UpdateInfo>} */
   checkUpdates:           () => fetchJson('/check-updates'),
+  /** @returns {Promise<{ runs: TestRun[] }>} */
   testRuns:               () => fetchJson('/test-runs'),
+  /** @returns {Promise<PreflightResult>} */
   preflight:              () => fetchJson('/preflight'),
+  /** @returns {Promise<DriftResult>} */
   drift:                  () => fetchJson('/drift'),
+  /** @returns {Promise<{ ok: boolean }>} */
   health:                 () => fetchJson('/health'),
+  /** @returns {Promise<{ orgs: OrgEntry[] }>} */
   orgs:                   () => fetchJson('/orgs'),
+  /** @returns {Promise<CompareResult>} */
   compareResult:          () => fetchJson('/compare'),
+  /** @returns {Promise<{ version: string }>} */
   suggestVersion:         () => fetchJson('/release/suggest-version'),
+  /** @returns {Promise<CompareResult>} */
   runCompare:             (source, target) => postJson('/compare', { source, target }),
+  /** @returns {Promise<{ xml: string, filename?: string, path?: string, ok?: boolean }>} */
   buildManifest:          (items, opts = {}) => postJson('/compare/manifest', { items, ...opts }),
+  /** @returns {Promise<{ sourceXml: string, targetXml: string }>} */
   compareDiff:            (type, member) => fetchJson(`/compare/diff?type=${encodeURIComponent(type)}&member=${encodeURIComponent(member)}`),
+  /** @returns {Promise<{ manifests: Array<{relPath:string, filename:string, date:string}> }>} */
   listManifests:          () => fetchJson('/manifests'),
+  /** @returns {Promise<{ xml: string, components: Array<{type:string, member:string}> }>} */
   getManifestContent:     (relPath) => fetchJson(`/manifests/content?path=${encodeURIComponent(relPath)}`),
+  /** @returns {Promise<{ xml: string, addCount: number, delCount: number, filename: string, path: string, ok: boolean }>} */
   buildManifestFromGit:   (base, head, opts = {}) => postJson('/manifest/build', { base, head, ...opts }),
+  /** @returns {Promise<AiAvailability>} */
   aiAvailable:            () => fetchJson('/ai/available'),
+  /** @returns {Promise<{ history: DeployHistoryEntry[] }>} */
   deployHistory:          () => fetchJson('/deploy/history'),
+  /** @returns {Promise<{ content: string, exists: boolean }>} */
   changelogContent:       () => fetchJson('/changelog/content'),
+  /** @returns {Promise<{ ok: boolean }>} */
   saveChangelog:          (content) => postJson('/changelog/save', { content }),
+  /** @returns {Promise<{ ok: boolean, path: string }>} */
   saveReleaseNotes:       (content) => postJson('/release-notes/save', { content }),
+  /** @returns {Promise<{ tests: string[] }>} */
   detectTests:            (relPath) => fetchJson(`/manifest/detect-tests?path=${encodeURIComponent(relPath)}`),
+  /** @returns {Promise<{ ok: boolean }>} */
   removeManifestComponent:(relPath, type, member) => postJson('/manifest/remove-component', { relPath, type, member }),
+  /** @returns {Promise<object>} */
   getConfig:              () => fetchJson('/config'),
+  /** @returns {Promise<{ ok: boolean, key: string, value: any }>} */
   setConfig:              (key, value) => patchJson('/config', { key, value: String(value) }),
+  /** @returns {Promise<{ ok: boolean }>} */
   initProject:            (data) => postJson('/init', data),
+  /** @returns {Promise<{ logs: object[] }>} */
   logs:                   (type = 'all') => fetchJson(`/logs${type !== 'all' ? `?type=${encodeURIComponent(type)}` : ''}`),
 };
 
-// SSE helpers — return an EventSource-like object with onmessage/onerror + close()
+// ─── SSE helpers ──────────────────────────────────────────────────────────────
+// Returns an EventSource-like object with onmessage/onerror setters + close()
+
 function ssePost(path, body) {
   const url = `${BASE}${path}`;
   let controller = new AbortController();

--- a/gui/src/components/ErrorBoundary.jsx
+++ b/gui/src/components/ErrorBoundary.jsx
@@ -10,6 +10,10 @@ export default class ErrorBoundary extends Component {
     return { error };
   }
 
+  componentDidCatch(error, info) {
+    console.error('[ErrorBoundary]', error, info.componentStack);
+  }
+
   render() {
     if (this.state.error) {
       return (

--- a/gui/src/components/ErrorBoundary.jsx
+++ b/gui/src/components/ErrorBoundary.jsx
@@ -1,0 +1,32 @@
+import { Component } from 'react';
+
+export default class ErrorBoundary extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { error: null };
+  }
+
+  static getDerivedStateFromError(error) {
+    return { error };
+  }
+
+  render() {
+    if (this.state.error) {
+      return (
+        <div style={{ padding: 32, textAlign: 'center' }}>
+          <p style={{ fontWeight: 600, marginBottom: 8 }}>Something went wrong</p>
+          <p style={{ color: 'var(--fg-muted)', fontSize: 13, marginBottom: 16 }}>
+            {this.state.error.message}
+          </p>
+          <button
+            className="btn btn-primary btn-sm"
+            onClick={() => this.setState({ error: null })}
+          >
+            Try again
+          </button>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/gui/src/components/ErrorBoundary.test.jsx
+++ b/gui/src/components/ErrorBoundary.test.jsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import ErrorBoundary from './ErrorBoundary.jsx';
+
+function Bomb() {
+  throw new Error('Test explosion');
+}
+
+beforeEach(() => {
+  // Suppress React's console.error for expected boundary catches
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+describe('ErrorBoundary', () => {
+  it('renders children when no error', () => {
+    render(<ErrorBoundary><span>ok</span></ErrorBoundary>);
+    expect(screen.getByText('ok')).toBeInTheDocument();
+  });
+
+  it('renders fallback UI when a child throws', () => {
+    render(<ErrorBoundary><Bomb /></ErrorBoundary>);
+    expect(screen.getByText(/Something went wrong/i)).toBeInTheDocument();
+    expect(screen.getByText(/Test explosion/)).toBeInTheDocument();
+  });
+
+  it('clears error state when Try again is clicked', async () => {
+    const user = userEvent.setup();
+    render(<ErrorBoundary><Bomb /></ErrorBoundary>);
+    await user.click(screen.getByRole('button', { name: /Try again/i }));
+    // After reset, Bomb throws again — boundary catches again
+    expect(screen.getByText(/Something went wrong/i)).toBeInTheDocument();
+  });
+});

--- a/gui/src/components/UpdateModal.jsx
+++ b/gui/src/components/UpdateModal.jsx
@@ -2,13 +2,14 @@ import { useState, useRef, useEffect } from 'react';
 import { IconX, IconDownload, IconAlertTri } from '../Icons.jsx';
 
 export default function UpdateModal({ current, latest, onClose }) {
-  const [status, setStatus]   = useState('idle'); // idle | running | done | error
+  const [status, setStatus]   = useState('idle'); // idle | running | restarting | done | error
   const [lines, setLines]     = useState([]);
   const [exitCode, setExitCode] = useState(null);
-  const esRef     = useRef(null);
-  const logRef    = useRef(null);
+  const esRef      = useRef(null);
+  const logRef     = useRef(null);
   const counterRef = useRef(0);
-  const deadRef   = useRef(false);
+  const deadRef    = useRef(false);
+  const pollRef    = useRef(null);
 
   useEffect(() => {
     if (logRef.current) logRef.current.scrollTop = logRef.current.scrollHeight;
@@ -18,8 +19,29 @@ export default function UpdateModal({ current, latest, onClose }) {
     return () => {
       deadRef.current = true;
       esRef.current?.close();
+      if (pollRef.current) clearInterval(pollRef.current);
     };
   }, []);
+
+  useEffect(() => {
+    if (status !== 'restarting') return;
+    const deadline = Date.now() + 30_000;
+    pollRef.current = setInterval(async () => {
+      try {
+        const res = await fetch('/api/ping');
+        if (res.ok) {
+          clearInterval(pollRef.current);
+          window.location.reload();
+        }
+      } catch {
+        if (Date.now() >= deadline) {
+          clearInterval(pollRef.current);
+          setStatus('done');
+        }
+      }
+    }, 500);
+    return () => clearInterval(pollRef.current);
+  }, [status]);
 
   const startUpdate = () => {
     setStatus('running');
@@ -38,9 +60,17 @@ export default function UpdateModal({ current, latest, onClose }) {
       if (msg.type === 'log') {
         const id = counterRef.current++;
         setLines((prev) => [...prev, { id, text: msg.line }]);
+      } else if (msg.type === 'restarting') {
+        setStatus('restarting');
+        es.close();
+        esRef.current = null;
       } else if (msg.type === 'result') {
-        setStatus(msg.exitCode === 0 ? 'done' : 'error');
-        setExitCode(msg.exitCode);
+        if (msg.exitCode === 0) {
+          setStatus('restarting');
+        } else {
+          setStatus('error');
+          setExitCode(msg.exitCode);
+        }
         es.close();
         esRef.current = null;
       } else if (msg.type === 'error') {
@@ -66,12 +96,12 @@ export default function UpdateModal({ current, latest, onClose }) {
   };
 
   return (
-    <div className="modal-backdrop" onClick={(e) => { if (e.target === e.currentTarget && status !== 'running') onClose(); }}>
+    <div className="modal-backdrop" onClick={(e) => { if (e.target === e.currentTarget && status !== 'running' && status !== 'restarting') onClose(); }}>
       <div className="modal" role="dialog" aria-modal="true" aria-labelledby="update-modal-title">
 
         <div className="modal-head">
           <span className="modal-title" id="update-modal-title">Update sfdt</span>
-          {status !== 'running' && (
+          {status !== 'running' && status !== 'restarting' && (
             <button className="btn btn-ghost btn-sm" onClick={onClose} aria-label="Close">
               <IconX size={14} />
             </button>
@@ -95,8 +125,15 @@ export default function UpdateModal({ current, latest, onClose }) {
           {lines.length > 0 && (
             <div className="cmd-terminal" ref={logRef} style={{ maxHeight: 260 }}>
               {lines.map(({ id, text }) => (
-                <div key={id} className="cmd-line">{text || '\u00A0'}</div>
+                <div key={id} className="cmd-line">{text || ' '}</div>
               ))}
+            </div>
+          )}
+
+          {status === 'restarting' && (
+            <div className="update-notice">
+              <div className="spinner" style={{ width: 14, height: 14, flexShrink: 0 }} />
+              <span>Restarting sfdt... the page will reload automatically.</span>
             </div>
           )}
 
@@ -136,6 +173,9 @@ export default function UpdateModal({ current, latest, onClose }) {
               <div className="live-dot">installing</div>
               <button className="btn btn-ghost btn-sm" onClick={cancel}>Cancel</button>
             </>
+          )}
+          {status === 'restarting' && (
+            <div className="live-dot">restarting</div>
           )}
           {(status === 'done' || status === 'error') && (
             <button className="btn btn-primary btn-sm" onClick={onClose}>Close</button>

--- a/gui/src/components/UpdateModal.jsx
+++ b/gui/src/components/UpdateModal.jsx
@@ -32,6 +32,9 @@ export default function UpdateModal({ current, latest, onClose }) {
         if (res.ok) {
           clearInterval(pollRef.current);
           window.location.reload();
+        } else if (Date.now() >= deadline) {
+          clearInterval(pollRef.current);
+          setStatus('done');
         }
       } catch {
         if (Date.now() >= deadline) {

--- a/gui/src/pages/Compare.jsx
+++ b/gui/src/pages/Compare.jsx
@@ -27,6 +27,7 @@ export default function ComparePage() {
   const [saving, setSaving]               = useState(false);
   const [saveSuccess, setSaveResult]      = useState(null);
   const esRef = useRef(null);
+  const mountedRef = useRef(true);
 
   useEffect(() => {
     api.orgs()
@@ -35,7 +36,10 @@ export default function ComparePage() {
   }, []);
 
   useEffect(() => {
-    return () => { esRef.current?.close(); };
+    return () => {
+      mountedRef.current = false;
+      esRef.current?.close();
+    };
   }, []);
 
   // Bug 3: load cached compare results on mount
@@ -62,7 +66,9 @@ export default function ComparePage() {
     esRef.current = es;
 
     es.onmessage = (e) => {
-      const event = JSON.parse(e.data);
+      if (!mountedRef.current) return;
+      let event;
+      try { event = JSON.parse(e.data); } catch { return; }
       if (event.type === 'progress') {
         setPhase2Total(event.total);
         setPhase2Done(event.completed);
@@ -75,9 +81,14 @@ export default function ComparePage() {
       } else if (event.type === 'done') {
         setPhase2Active(false);
         es.close();
+      } else if (event.type === 'error') {
+        setStreamError(event.message ?? 'Content comparison failed.');
+        setPhase2Active(false);
+        es.close();
       }
     };
     es.onerror = () => {
+      if (!mountedRef.current) return;
       setStreamError('Streaming failed. The inventory was saved — click Run again to retry.');
       setPhase2Active(false);
       es.close();
@@ -231,6 +242,12 @@ export default function ComparePage() {
             <span style={{ fontFamily: 'var(--font-mono)', fontSize: 'var(--fs-xs)', color: 'var(--fg-muted)', flexShrink: 0 }}>
               {phase2Done} / {phase2Total}
             </span>
+            <button
+              className="btn btn-ghost btn-sm"
+              onClick={() => { esRef.current?.close(); setPhase2Active(false); }}
+            >
+              <IconX size={11} /> Cancel
+            </button>
           </div>
         </div>
       )}

--- a/gui/src/pages/Compare.jsx
+++ b/gui/src/pages/Compare.jsx
@@ -92,6 +92,8 @@ export default function ComparePage() {
       if (!mountedRef.current) return;
       setStreamError('Streaming failed. The inventory was saved — click Run again to retry.');
       setPhase2Active(false);
+      setPhase2Done(0);
+      setPhase2Total(0);
       es.close();
     };
   };

--- a/gui/src/pages/Compare.jsx
+++ b/gui/src/pages/Compare.jsx
@@ -36,6 +36,7 @@ export default function ComparePage() {
   }, []);
 
   useEffect(() => {
+    mountedRef.current = true;
     return () => {
       mountedRef.current = false;
       esRef.current?.close();
@@ -244,7 +245,7 @@ export default function ComparePage() {
             </span>
             <button
               className="btn btn-ghost btn-sm"
-              onClick={() => { esRef.current?.close(); setPhase2Active(false); }}
+              onClick={() => { esRef.current?.close(); setPhase2Active(false); setPhase2Done(0); setPhase2Total(0); }}
             >
               <IconX size={11} /> Cancel
             </button>

--- a/gui/src/pages/Dashboard.jsx
+++ b/gui/src/pages/Dashboard.jsx
@@ -147,8 +147,8 @@ export default function Dashboard({ project }) {
                 </tr>
               </thead>
               <tbody>
-                {tests.runs.slice(0, 5).map((run) => (
-                  <tr key={run.date}>
+                {tests.runs.slice(0, 5).map((run, i) => (
+                  <tr key={`${run.date}-${i}`}>
                     <td className="td-mono">{new Date(run.date).toLocaleDateString()}</td>
                     <td style={{ textAlign: 'right' }}>
                       <span style={{ color: 'var(--status-identical-fg)', fontWeight: 600 }}>{run.passed ?? 0}</span>

--- a/gui/src/pages/Dashboard.jsx
+++ b/gui/src/pages/Dashboard.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { api } from '../api.js';
 import StatCard from '../components/StatCard.jsx';
 import StatusBadge from '../components/StatusBadge.jsx';
@@ -18,16 +18,16 @@ export default function Dashboard({ project }) {
   const [loading, setLoading]   = useState(true);
   const [fetchError, setFetchError] = useState(null);
 
-  const loadData = () => {
+  const loadData = useCallback(() => {
     setLoading(true);
     setFetchError(null);
     Promise.all([api.testRuns(), api.preflight(), api.drift()])
       .then(([t, p, d]) => { setTests(t); setPreflight(p); setDrift(d); })
       .catch((err) => setFetchError(err.message ?? 'Failed to load dashboard data.'))
       .finally(() => setLoading(false));
-  };
+  }, []);
 
-  useEffect(() => { loadData(); }, []);
+  useEffect(() => { loadData(); }, [loadData]);
 
   const totalPassed = tests?.runs?.reduce((s, r) => s + (r.passed ?? 0), 0) ?? 0;
   const totalFailed = tests?.runs?.reduce((s, r) => s + (r.failed ?? 0), 0) ?? 0;

--- a/gui/src/pages/Dashboard.jsx
+++ b/gui/src/pages/Dashboard.jsx
@@ -16,13 +16,18 @@ export default function Dashboard({ project }) {
   const [preflight, setPreflight] = useState(null);
   const [drift, setDrift]       = useState(null);
   const [loading, setLoading]   = useState(true);
+  const [fetchError, setFetchError] = useState(null);
 
-  useEffect(() => {
+  const loadData = () => {
+    setLoading(true);
+    setFetchError(null);
     Promise.all([api.testRuns(), api.preflight(), api.drift()])
       .then(([t, p, d]) => { setTests(t); setPreflight(p); setDrift(d); })
-      .catch(() => {})
+      .catch((err) => setFetchError(err.message ?? 'Failed to load dashboard data.'))
       .finally(() => setLoading(false));
-  }, []);
+  };
+
+  useEffect(() => { loadData(); }, []);
 
   const totalPassed = tests?.runs?.reduce((s, r) => s + (r.passed ?? 0), 0) ?? 0;
   const totalFailed = tests?.runs?.reduce((s, r) => s + (r.failed ?? 0), 0) ?? 0;
@@ -51,6 +56,25 @@ export default function Dashboard({ project }) {
     );
   }
 
+  if (fetchError) {
+    return (
+      <div>
+        <div className="page-header">
+          <div className="page-header-text">
+            <h1>Dashboard</h1>
+            {project?.org && <p className="page-subtitle">{project.org}</p>}
+          </div>
+        </div>
+        <div className="alert alert-error" style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <span>Failed to load dashboard data: {fetchError}</span>
+          <button className="btn btn-ghost btn-sm" onClick={loadData}>
+            <IconRefresh size={12} /> Retry
+          </button>
+        </div>
+      </div>
+    );
+  }
+
   // Build a lightweight activity list from available data
   const activity = [];
   if (lastTest) {
@@ -71,12 +95,13 @@ export default function Dashboard({ project }) {
       status: preflight.status,
     });
   }
-  if (drift?.result) {
+  if (drift?.status) {
+    const driftCount = (drift.components ?? []).filter((c) => c.drift?.toLowerCase() === 'drift').length;
     activity.push({
-      type: drift.result === 'clean' ? 'success' : 'warn',
-      title: `Drift check — ${drift.count ?? 0} component${(drift.count ?? 0) !== 1 ? 's' : ''} differ`,
+      type: drift.status === 'clean' ? 'success' : 'warn',
+      title: `Drift check — ${driftCount} component${driftCount !== 1 ? 's' : ''} differ`,
       meta: drift.date ? new Date(drift.date).toLocaleString() : '',
-      status: drift.result,
+      status: drift.status,
     });
   }
 
@@ -122,8 +147,8 @@ export default function Dashboard({ project }) {
                 </tr>
               </thead>
               <tbody>
-                {tests.runs.slice(0, 5).map((run, i) => (
-                  <tr key={i}>
+                {tests.runs.slice(0, 5).map((run) => (
+                  <tr key={run.date}>
                     <td className="td-mono">{new Date(run.date).toLocaleDateString()}</td>
                     <td style={{ textAlign: 'right' }}>
                       <span style={{ color: 'var(--status-identical-fg)', fontWeight: 600 }}>{run.passed ?? 0}</span>

--- a/gui/src/pages/Dashboard.test.jsx
+++ b/gui/src/pages/Dashboard.test.jsx
@@ -1,0 +1,112 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import Dashboard from './Dashboard.jsx';
+import { api } from '../api.js';
+
+vi.mock('../api.js', () => ({
+  api: {
+    testRuns: vi.fn(),
+    preflight: vi.fn(),
+    drift: vi.fn(),
+  },
+}));
+
+beforeEach(() => {
+  api.testRuns.mockResolvedValue({ runs: [] });
+  api.preflight.mockResolvedValue({ date: null, status: null, checks: [] });
+  api.drift.mockResolvedValue({ date: null, status: null, components: [] });
+});
+
+describe('Dashboard — drift activity card', () => {
+  it('shows nothing when drift status is null', async () => {
+    render(<Dashboard project={null} />);
+    await waitFor(() => expect(api.drift).toHaveBeenCalled());
+    expect(screen.queryByText(/Drift check/)).toBeNull();
+  });
+
+  it('shows drift count from components array', async () => {
+    api.drift.mockResolvedValue({
+      date: '2026-04-29T12:00:00.000Z',
+      status: 'drift',
+      components: [
+        { name: 'MyClass', type: 'ApexClass', drift: 'drift' },
+        { name: 'OtherClass', type: 'ApexClass', drift: 'drift' },
+      ],
+    });
+    render(<Dashboard project={null} />);
+    await waitFor(() => expect(screen.getByText(/Drift check/)).toBeInTheDocument());
+    expect(screen.getByText(/2 components differ/)).toBeInTheDocument();
+  });
+
+  it('shows 0 drifted when all components are clean', async () => {
+    api.drift.mockResolvedValue({
+      date: '2026-04-29T12:00:00.000Z',
+      status: 'clean',
+      components: [{ name: 'MyClass', type: 'ApexClass', drift: 'clean' }],
+    });
+    render(<Dashboard project={null} />);
+    await waitFor(() => expect(screen.getByText(/Drift check/)).toBeInTheDocument());
+    expect(screen.getByText(/0 components differ/)).toBeInTheDocument();
+  });
+
+  it('never renders undefined in the DOM', async () => {
+    render(<Dashboard project={null} />);
+    await waitFor(() => expect(api.drift).toHaveBeenCalled());
+    expect(document.body.textContent).not.toContain('undefined');
+  });
+});
+
+describe('Dashboard — preflight activity card', () => {
+  it('shows nothing when checks array is empty', async () => {
+    render(<Dashboard project={null} />);
+    await waitFor(() => expect(api.preflight).toHaveBeenCalled());
+    expect(screen.queryByText(/Preflight —/)).toBeNull();
+  });
+
+  it('shows correct failure count in activity title', async () => {
+    api.preflight.mockResolvedValue({
+      date: '2026-04-29T12:00:00.000Z',
+      status: 'fail',
+      checks: [
+        { name: 'Branch', status: 'pass', message: null },
+        { name: 'Tests', status: 'fail', message: 'Below threshold' },
+      ],
+    });
+    render(<Dashboard project={null} />);
+    await waitFor(() => expect(screen.getByText(/Preflight —/)).toBeInTheDocument());
+    expect(screen.getByText(/2 checks, 1 failed/)).toBeInTheDocument();
+  });
+
+  it('shows 0 failed when all checks pass', async () => {
+    api.preflight.mockResolvedValue({
+      date: '2026-04-29T12:00:00.000Z',
+      status: 'pass',
+      checks: [
+        { name: 'Branch', status: 'pass', message: null },
+        { name: 'Tests', status: 'pass', message: null },
+      ],
+    });
+    render(<Dashboard project={null} />);
+    await waitFor(() => expect(screen.getByText(/Preflight —/)).toBeInTheDocument());
+    expect(screen.getByText(/2 checks, 0 failed/)).toBeInTheDocument();
+  });
+});
+
+describe('Dashboard — test runs', () => {
+  it('shows empty state when no runs exist', async () => {
+    render(<Dashboard project={null} />);
+    await waitFor(() => expect(api.testRuns).toHaveBeenCalled());
+    expect(screen.getByText(/No test runs yet/)).toBeInTheDocument();
+  });
+
+  it('renders run rows when runs exist', async () => {
+    api.testRuns.mockResolvedValue({
+      runs: [
+        { date: '2026-04-29T10:00:00.000Z', passed: 42, failed: 0, errors: 0, coverage: 85 },
+      ],
+    });
+    render(<Dashboard project={null} />);
+    await waitFor(() => expect(screen.getAllByText('42')[0]).toBeInTheDocument());
+    expect(screen.getAllByText('42').length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/gui/src/pages/Drift.jsx
+++ b/gui/src/pages/Drift.jsx
@@ -33,7 +33,7 @@ export default function DriftPage() {
       })
       .catch(() => null)
       .finally(() => setLoading(false));
-  }, [refreshKey]);
+  }, [refreshKey, chat]);
 
   const components = data?.components ?? [];
   const driftCount = components.filter((c) => c.drift?.toLowerCase() === 'drift').length;

--- a/gui/src/pages/Drift.test.jsx
+++ b/gui/src/pages/Drift.test.jsx
@@ -1,0 +1,45 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import DriftPage from './Drift.jsx';
+import { api } from '../api.js';
+
+vi.mock('../api.js', () => ({ api: { drift: vi.fn() } }));
+vi.mock('../App.jsx', () => ({ ChatContext: { Consumer: ({ children }) => children(null), _currentValue: null } }));
+
+beforeEach(() => {
+  api.drift.mockResolvedValue({ date: null, status: null, components: [] });
+});
+
+describe('DriftPage', () => {
+  it('shows empty state when no components', async () => {
+    render(<DriftPage />);
+    await waitFor(() => expect(api.drift).toHaveBeenCalled());
+    expect(screen.getByText(/No drift data/i)).toBeInTheDocument();
+  });
+
+  it('renders drifted components in the table', async () => {
+    api.drift.mockResolvedValue({
+      date: '2026-04-29T12:00:00.000Z',
+      status: 'drift',
+      components: [
+        { name: 'MyClass', type: 'ApexClass', drift: 'drift' },
+        { name: 'CleanClass', type: 'ApexClass', drift: 'clean' },
+      ],
+    });
+    render(<DriftPage />);
+    await waitFor(() => expect(screen.getByText('MyClass')).toBeInTheDocument());
+    expect(screen.getByText('CleanClass')).toBeInTheDocument();
+  });
+
+  it('never renders raw objects as text', async () => {
+    api.drift.mockResolvedValue({
+      date: '2026-04-29T12:00:00.000Z',
+      status: 'drift',
+      components: [{ name: 'MyClass', type: 'ApexClass', drift: 'drift' }],
+    });
+    render(<DriftPage />);
+    await waitFor(() => expect(api.drift).toHaveBeenCalled());
+    expect(document.body.textContent).not.toContain('[object Object]');
+    expect(document.body.textContent).not.toContain('undefined');
+  });
+});

--- a/gui/src/pages/Explain.jsx
+++ b/gui/src/pages/Explain.jsx
@@ -9,7 +9,8 @@ export default function ExplainPage() {
   const chat = useContext(ChatContext);
 
   function handleComplete(content) {
-    const analysis = (content ?? '').slice(0, 2000);
+    const raw = content ?? '';
+    const analysis = raw.length > 2000 ? raw.slice(0, 2000) + `\n\n(truncated — ${raw.length} chars total)` : raw;
     setResult(analysis);
     chat?.setPageContext({
       page: 'Explain',

--- a/gui/src/pages/Logs.jsx
+++ b/gui/src/pages/Logs.jsx
@@ -219,7 +219,7 @@ export default function LogsPage() {
                   const status = getStatus(log);
                   const isOpen = expandedIdx === i;
                   return (
-                    <Fragment key={`${log.timestamp}-${log.type}`}>
+                    <Fragment key={`${log.timestamp}-${log.type}-${i}`}>
                       <tr
                         style={{ cursor: 'pointer' }}
                         onClick={() => setExpandedIdx(isOpen ? null : i)}

--- a/gui/src/pages/Logs.jsx
+++ b/gui/src/pages/Logs.jsx
@@ -126,7 +126,23 @@ function LogDetail({ log }) {
     );
   }
 
-  return null;
+  return (
+    <pre style={{
+      margin: 0,
+      fontFamily: 'var(--font-mono)',
+      fontSize: 'var(--fs-xs)',
+      color: 'var(--fg-muted)',
+      whiteSpace: 'pre-wrap',
+      wordBreak: 'break-all',
+      background: 'var(--bg-subtle)',
+      padding: 'var(--s-3)',
+      borderRadius: 'var(--r-md)',
+      maxHeight: 300,
+      overflow: 'auto',
+    }}>
+      {JSON.stringify(data ?? {}, null, 2)}
+    </pre>
+  );
 }
 
 export default function LogsPage() {
@@ -203,7 +219,7 @@ export default function LogsPage() {
                   const status = getStatus(log);
                   const isOpen = expandedIdx === i;
                   return (
-                    <Fragment key={i}>
+                    <Fragment key={`${log.timestamp}-${log.type}`}>
                       <tr
                         style={{ cursor: 'pointer' }}
                         onClick={() => setExpandedIdx(isOpen ? null : i)}

--- a/gui/src/pages/Manifests.jsx
+++ b/gui/src/pages/Manifests.jsx
@@ -12,14 +12,14 @@ function fmtDate(iso) {
   try { return new Date(iso).toLocaleString(); } catch { return iso; }
 }
 
-function ManifestViewer({ manifest, onClose }) {
+function ManifestViewer({ manifest, preloadedXml, onClose }) {
   const [data, setData] = useState(null); // { xml, components: [] }
   const [loading, setLoading] = useState(true);
 
   const load = async () => {
     setLoading(true);
     try {
-      const { xml } = await api.getManifestContent(manifest.relPath);
+      const xml = preloadedXml ?? (await api.getManifestContent(manifest.relPath)).xml;
       const parser = new DOMParser();
       const doc = parser.parseFromString(xml, 'application/xml');
       const types = Array.from(doc.querySelectorAll('types'));
@@ -37,7 +37,7 @@ function ManifestViewer({ manifest, onClose }) {
     }
   };
 
-  useEffect(() => { load(); }, [manifest]);
+  useEffect(() => { load(); }, [manifest, preloadedXml]);
 
   const removeComponent = async (type, member) => {
     try {
@@ -48,7 +48,7 @@ function ManifestViewer({ manifest, onClose }) {
     }
   };
 
-  if (!manifest) return null;
+  if (!manifest && !preloadedXml) return null;
 
   return (
     <div className="modal-backdrop" onClick={onClose}>
@@ -68,18 +68,18 @@ function ManifestViewer({ manifest, onClose }) {
             <>
               {/* Left Column: Component List */}
               <div style={{ display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
-                <div className="section-label" style={{ marginBottom: 10 }}>Components ({data?.components.length})</div>
+                <div className="section-label" style={{ marginBottom: 10 }}>Components ({data?.components?.length ?? 0})</div>
                 <div className="table-wrap" style={{ flex: 1, overflowY: 'auto' }}>
                   <table className="data-table">
                     <tbody>
-                      {data?.components.map((c, i) => (
+                      {data?.components?.map((c, i) => (
                         <tr key={`${c.type}.${c.member}-${i}`}>
                           <td>
                             <div style={{ fontSize: 12, fontWeight: 500 }}>{c.member}</div>
                             <div style={{ fontSize: 9, color: 'var(--fg-subtle)', textTransform: 'uppercase' }}>{c.type}</div>
                           </td>
                           <td style={{ width: 40, textAlign: 'right' }}>
-                            {manifest.source !== 'deployed' && (
+                            {manifest?.relPath && manifest.source !== 'deployed' && (
                               <button className="btn btn-ghost btn-xs" style={{ color: 'var(--status-conflict-fg)' }} onClick={() => removeComponent(c.type, c.member)}>
                                 <IconX size={12} />
                               </button>
@@ -114,7 +114,7 @@ function ManifestViewer({ manifest, onClose }) {
             const blob = new Blob([data?.xml ?? ''], { type: 'application/xml' });
             const url = URL.createObjectURL(blob);
             const a = document.createElement('a');
-            a.href = url; a.download = manifest.name; a.click();
+            a.href = url; a.download = manifest?.name ?? 'manifest.xml'; a.click();
             URL.revokeObjectURL(url);
           }}>
             <IconDownload size={12} /> Download
@@ -221,7 +221,13 @@ function BuilderSection({ aiInfo, onBuilt }) {
           </div>
         )}
       </div>
-      {viewerOpen && result && <ManifestViewer xml={result.xml} onClose={() => setViewerOpen(false)} />}
+      {viewerOpen && result && (
+        <ManifestViewer
+          manifest={{ relPath: null, name: result.filename ?? 'manifest.xml', source: 'preview' }}
+          preloadedXml={result.xml}
+          onClose={() => setViewerOpen(false)}
+        />
+      )}
     </div>
   );
 }

--- a/gui/src/pages/Manifests.jsx
+++ b/gui/src/pages/Manifests.jsx
@@ -55,8 +55,8 @@ function ManifestViewer({ manifest, preloadedXml, onClose }) {
       <div className="modal" style={{ maxWidth: 900, width: '95vw' }} onClick={(e) => e.stopPropagation()}>
         <div className="modal-head">
           <div style={{ minWidth: 0 }}>
-            <span className="modal-title" style={{ display: 'block' }}>{manifest.name}</span>
-            <span style={{ fontSize: 11, color: 'var(--fg-muted)' }}>{manifest.relPath}</span>
+            <span className="modal-title" style={{ display: 'block' }}>{manifest?.name}</span>
+            <span style={{ fontSize: 11, color: 'var(--fg-muted)' }}>{manifest?.relPath}</span>
           </div>
           <button className="btn btn-icon" onClick={onClose}><IconX size={15} /></button>
         </div>

--- a/gui/src/pages/Preflight.jsx
+++ b/gui/src/pages/Preflight.jsx
@@ -44,7 +44,7 @@ export default function PreflightPage() {
       })
       .catch(() => null)
       .finally(() => setLoading(false));
-  }, [refreshKey]);
+  }, [refreshKey, chat]);
 
   const checks      = data?.checks ?? [];
   const passCount   = checks.filter((c) => ['pass','passed','success'].includes(c.status?.toLowerCase())).length;

--- a/gui/src/pages/Preflight.test.jsx
+++ b/gui/src/pages/Preflight.test.jsx
@@ -1,0 +1,46 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import PreflightPage from './Preflight.jsx';
+import { api } from '../api.js';
+
+vi.mock('../api.js', () => ({ api: { preflight: vi.fn() } }));
+vi.mock('../App.jsx', () => ({ ChatContext: { Consumer: ({ children }) => children(null), _currentValue: null } }));
+
+beforeEach(() => {
+  api.preflight.mockResolvedValue({ date: null, status: null, checks: [] });
+});
+
+describe('PreflightPage', () => {
+  it('shows empty state when no checks', async () => {
+    render(<PreflightPage />);
+    await waitFor(() => expect(api.preflight).toHaveBeenCalled());
+    expect(screen.getByText(/No preflight data/i)).toBeInTheDocument();
+  });
+
+  it('renders check rows with status badges', async () => {
+    api.preflight.mockResolvedValue({
+      date: '2026-04-29T12:00:00.000Z',
+      status: 'pass',
+      checks: [
+        { name: 'Branch Naming', status: 'pass', message: null },
+        { name: 'Test Coverage', status: 'fail', message: 'Coverage below threshold' },
+      ],
+    });
+    render(<PreflightPage />);
+    await waitFor(() => expect(screen.getByText('Branch Naming')).toBeInTheDocument());
+    expect(screen.getByText('Test Coverage')).toBeInTheDocument();
+    expect(screen.getByText('Coverage below threshold')).toBeInTheDocument();
+  });
+
+  it('never renders raw objects or undefined', async () => {
+    api.preflight.mockResolvedValue({
+      date: '2026-04-29T12:00:00.000Z',
+      status: 'pass',
+      checks: [{ name: 'Branch', status: 'pass', message: null }],
+    });
+    render(<PreflightPage />);
+    await waitFor(() => expect(api.preflight).toHaveBeenCalled());
+    expect(document.body.textContent).not.toContain('[object Object]');
+    expect(document.body.textContent).not.toContain('undefined');
+  });
+});

--- a/gui/src/pages/Pull.jsx
+++ b/gui/src/pages/Pull.jsx
@@ -1,4 +1,4 @@
-import CommandRunner from '../components/CommandRunner.jsx';
+import EmptyState from '../components/EmptyState.jsx';
 
 export default function PullPage() {
   return (
@@ -10,7 +10,10 @@ export default function PullPage() {
         </div>
       </div>
 
-      <CommandRunner command="pull" label="Pull Org Updates" />
+      <EmptyState
+        title="Coming Soon"
+        message="The Pull page will provide an interactive way to retrieve metadata from a connected org and merge it into your local source. For now, use the Compare page to preview changes, or run sfdt pull from the terminal."
+      />
     </div>
   );
 }

--- a/gui/src/pages/Quality.jsx
+++ b/gui/src/pages/Quality.jsx
@@ -11,8 +11,9 @@ export default function QualityPage() {
   const chat = useContext(ChatContext);
 
   function handleFixPlanComplete(content) {
-    const summary = (content ?? '').slice(0, 2000);
-    setResult(summary);
+    const raw = content ?? '';
+    const summary = raw.slice(0, 2000);
+    setResult(raw.length > 2000 ? summary + `\n\n(truncated — ${raw.length} chars total)` : summary);
     chat?.setPageContext({ page: 'Quality', data: { fixPlan: summary } });
     setStreamKey((k) => k + 1);
   }

--- a/gui/src/pages/ReleaseHub.jsx
+++ b/gui/src/pages/ReleaseHub.jsx
@@ -281,20 +281,28 @@ function ChangelogStep({ aiAvailable, onMarkDone }) {
   const [generating, setGenerating] = useState(false);
   const [saving, setSaving]       = useState(false);
   const [genLines, setGenLines]   = useState([]);
-  const counterRef = useRef(0);
+  const counterRef  = useRef(0);
+  const streamRef   = useRef(null);
+  const genLogRef   = useRef(null);
 
   useEffect(() => {
     api.changelogContent()
       .then((d) => setContent(d.content ?? ''))
       .catch(() => {})
       .finally(() => setLoading(false));
+    return () => streamRef.current?.close();
   }, []);
+
+  useEffect(() => {
+    if (genLogRef.current) genLogRef.current.scrollTop = genLogRef.current.scrollHeight;
+  }, [genLines]);
 
   const generate = () => {
     setGenerating(true);
     setGenLines([]);
     counterRef.current = 0;
     const s = stream.changelogGenerate();
+    streamRef.current = s;
     s.onmessage = ({ data: msg }) => {
       if (msg.type === 'log') {
         const id = counterRef.current++;
@@ -365,7 +373,7 @@ function ChangelogStep({ aiAvailable, onMarkDone }) {
       )}
 
       {genLines.length > 0 && (
-        <div className="cmd-terminal" style={{ maxHeight: 120, marginBottom: 10 }}>
+        <div className="cmd-terminal" ref={genLogRef} style={{ maxHeight: 120, marginBottom: 10 }}>
           {genLines.map(({ id, text }) => (
             <div key={id} className="cmd-line">{text || '\u00A0'}</div>
           ))}
@@ -391,13 +399,22 @@ function ReleaseNotesStep({ aiAvailable, onMarkDone }) {
   const [generating, setGenerating] = useState(false);
   const [saving, setSaving]       = useState(false);
   const [genLines, setGenLines]   = useState([]);
-  const counterRef = useRef(0);
+  const counterRef  = useRef(0);
+  const streamRef   = useRef(null);
+  const genLogRef   = useRef(null);
+
+  useEffect(() => () => streamRef.current?.close(), []);
+
+  useEffect(() => {
+    if (genLogRef.current) genLogRef.current.scrollTop = genLogRef.current.scrollHeight;
+  }, [genLines]);
 
   const generate = () => {
     setGenerating(true);
     setGenLines([]);
     counterRef.current = 0;
     const s = stream.releaseNotes();
+    streamRef.current = s;
     s.onmessage = ({ data: msg }) => {
       if (msg.type === 'log') {
         const id = counterRef.current++;
@@ -464,7 +481,7 @@ function ReleaseNotesStep({ aiAvailable, onMarkDone }) {
       />
 
       {genLines.length > 0 && (
-        <div className="cmd-terminal" style={{ maxHeight: 120, marginBottom: 10 }}>
+        <div className="cmd-terminal" ref={genLogRef} style={{ maxHeight: 120, marginBottom: 10 }}>
           {genLines.map(({ id, text }) => (
             <div key={id} className="cmd-line">{text || '\u00A0'}</div>
           ))}
@@ -528,6 +545,7 @@ function DeployStep({ manifest, onMarkDone }) {
   const [loadingOrgs, setLoadingOrgs] = useState(true);
   const [isRunning, setIsRunning]   = useState(false);
   const [streamKey, setStreamKey]   = useState(0);
+  const [orgError, setOrgError]     = useState(false);
 
   useEffect(() => {
     api.orgs()
@@ -555,7 +573,7 @@ function DeployStep({ manifest, onMarkDone }) {
         .catch(() => {})
         .finally(() => setDetecting(false));
     }
-  }, [testLevel, manifest?.relPath]);
+  }, [testLevel, manifest?.relPath, testClasses]);
 
   const toggleTest = (name) => {
     const list = testClasses.split(',').map(s => s.trim()).filter(Boolean);
@@ -566,6 +584,8 @@ function DeployStep({ manifest, onMarkDone }) {
   };
 
   const runDeployment = () => {
+    if (!targetOrg) { setOrgError(true); return; }
+    setOrgError(false);
     setIsRunning(true);
     setStreamKey(k => k + 1);
   };
@@ -596,15 +616,20 @@ function DeployStep({ manifest, onMarkDone }) {
             ) : (
               <select
                 className="input"
-                style={{ width: '100%', fontSize: 13 }}
+                style={{ width: '100%', fontSize: 13, borderColor: orgError ? 'var(--status-conflict-fg)' : undefined }}
                 value={targetOrg}
-                onChange={(e) => setTargetOrg(e.target.value)}
+                onChange={(e) => { setTargetOrg(e.target.value); if (e.target.value) setOrgError(false); }}
               >
                 <option value="">Select an org...</option>
                 {orgs.map(o => (
-                  <option key={o.alias} value={o.alias}>{o.alias} ({o.username})</option>
+                  <option key={o.alias} value={o.alias}>{o.alias}{o.username ? ` (${o.username})` : ''}</option>
                 ))}
               </select>
+            )}
+            {orgError && (
+              <div style={{ marginTop: 6, fontSize: 12, color: 'var(--status-conflict-fg)' }}>
+                A target org is required to execute the deployment.
+              </div>
             )}
           </div>
 
@@ -821,9 +846,9 @@ function RollbackStep() {
             No deployment history found. Deployments made via the GUI will appear here.
           </div>
         )}
-        {history.map((entry, i) => (
+        {history.map((entry) => (
           <button
-            key={i}
+            key={`${entry.date}-${entry.manifest}`}
             onClick={() => { setSelectedEntry(entry); setStreamKey((k) => k + 1); }}
             style={{
               display: 'flex', alignItems: 'center', gap: 12,

--- a/gui/src/pages/ReleaseHub.jsx
+++ b/gui/src/pages/ReleaseHub.jsx
@@ -573,7 +573,7 @@ function DeployStep({ manifest, onMarkDone }) {
         .catch(() => {})
         .finally(() => setDetecting(false));
     }
-  }, [testLevel, manifest?.relPath, testClasses]);
+  }, [testLevel, manifest?.relPath]);
 
   const toggleTest = (name) => {
     const list = testClasses.split(',').map(s => s.trim()).filter(Boolean);

--- a/gui/src/pages/ReleaseHub.jsx
+++ b/gui/src/pages/ReleaseHub.jsx
@@ -4,7 +4,7 @@ import CommandRunner from '../components/CommandRunner.jsx';
 import StreamRunner from '../components/StreamRunner.jsx';
 import {
   IconPackage, IconBook, IconFileEdit, IconShield, IconRocket, IconRotateCcw,
-  IconCheck, IconDownload, IconZap,
+  IconCheck, IconDownload, IconZap, IconSearch,
 } from '../Icons.jsx';
 
 // ─── Step definitions ────────────────────────────────────────────────────────

--- a/gui/src/pages/Review.jsx
+++ b/gui/src/pages/Review.jsx
@@ -10,7 +10,8 @@ export default function ReviewPage() {
   const chat = useContext(ChatContext);
 
   function handleComplete(content) {
-    const findings = (content ?? '').slice(0, 2000);
+    const raw = content ?? '';
+    const findings = raw.length > 2000 ? raw.slice(0, 2000) + `\n\n(truncated — ${raw.length} chars total)` : raw;
     setResult(findings);
     chat?.setPageContext({ page: 'Review', data: { baseBranch: base, findings } });
     setStreamKey((k) => k + 1);

--- a/gui/src/pages/Settings.jsx
+++ b/gui/src/pages/Settings.jsx
@@ -65,6 +65,14 @@ function FieldRow({ dotKey, label, type, options, rawConfig, onSave }) {
   }, [rawConfig, dotKey]);
 
   async function handleSave() {
+    if (dotKey === 'deployment.coverageThreshold') {
+      const n = Number(value);
+      if (!Number.isFinite(n) || n < 0 || n > 100) {
+        setStatus('error');
+        setTimeout(() => setStatus(null), 3000);
+        return;
+      }
+    }
     setStatus('saving');
     try {
       await api.setConfig(dotKey, value);
@@ -112,6 +120,7 @@ function FieldRow({ dotKey, label, type, options, rawConfig, onSave }) {
           onChange={(e) => setValue(type === 'number' ? Number(e.target.value) : e.target.value)}
           style={inputStyle}
           className="input"
+          {...(dotKey === 'deployment.coverageThreshold' ? { min: 0, max: 100 } : {})}
         />
       )}
       <button

--- a/gui/src/pages/Settings.jsx
+++ b/gui/src/pages/Settings.jsx
@@ -131,15 +131,84 @@ function FieldRow({ dotKey, label, type, options, rawConfig, onSave }) {
   );
 }
 
+function InitCard() {
+  const [projectName, setProjectName] = useState('');
+  const [defaultOrg, setDefaultOrg] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [initError, setInitError] = useState(null);
+
+  async function handleInit(e) {
+    e.preventDefault();
+    if (!projectName.trim()) return;
+    setBusy(true);
+    setInitError(null);
+    try {
+      await api.initProject({ projectName: projectName.trim(), defaultOrg: defaultOrg.trim() });
+      window.location.reload();
+    } catch (err) {
+      setInitError(err.message);
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="page-content">
+      <div className="page-header">
+        <div className="page-header-text">
+          <h1>Initialize Project</h1>
+          <p className="page-subtitle">No .sfdt/ configuration found. Fill in the basics to get started.</p>
+        </div>
+      </div>
+      <div className="card card-pad" style={{ maxWidth: 480 }}>
+        <form onSubmit={handleInit} style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+          <div>
+            <label className="field-label" htmlFor="init-project-name">Project Name <span style={{ color: 'var(--c-danger)' }}>*</span></label>
+            <input
+              id="init-project-name"
+              className="field-input"
+              type="text"
+              value={projectName}
+              onChange={(e) => setProjectName(e.target.value)}
+              placeholder="My Salesforce Project"
+              required
+            />
+          </div>
+          <div>
+            <label className="field-label" htmlFor="init-default-org">Default Org Alias</label>
+            <input
+              id="init-default-org"
+              className="field-input"
+              type="text"
+              value={defaultOrg}
+              onChange={(e) => setDefaultOrg(e.target.value)}
+              placeholder="my-sandbox"
+            />
+          </div>
+          {initError && <div className="alert alert-error" style={{ fontSize: 13 }}>{initError}</div>}
+          <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+            <button className="btn btn-primary btn-sm" type="submit" disabled={busy || !projectName.trim()}>
+              {busy ? <span className="spinner" style={{ width: 14, height: 14 }} /> : 'Initialize Project'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
 export default function SettingsPage() {
   const [rawConfig, setRawConfig] = useState(null);
   const [loading, setLoading] = useState(true);
+  const [notInitialized, setNotInitialized] = useState(false);
   const [error, setError] = useState(null);
 
   useEffect(() => {
     api.getConfig()
       .then(setRawConfig)
-      .catch((e) => setError(e.message))
+      .catch((e) => {
+        if (e.status === 503) setNotInitialized(true);
+        else setError(e.message);
+      })
       .finally(() => setLoading(false));
   }, []);
 
@@ -159,6 +228,7 @@ export default function SettingsPage() {
   }
 
   if (loading) return <div className="spinner-center"><div className="spinner" /></div>;
+  if (notInitialized) return <InitCard />;
   if (error) return <div style={{ padding: 32 }}><div className="alert alert-error">{error}</div></div>;
   if (!rawConfig) return null;
 

--- a/gui/src/test-setup.js
+++ b/gui/src/test-setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/gui/vitest.config.js
+++ b/gui/vitest.config.js
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./src/test-setup.js'],
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sfdt/cli",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sfdt/cli",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -16,7 +16,7 @@
         "commander": "^13.1.0",
         "execa": "^9.5.2",
         "express": "^5.2.1",
-        "express-rate-limit": "^7.5.1",
+        "express-rate-limit": "^8.4.1",
         "fs-extra": "^11.3.0",
         "glob": "^13.0.6",
         "inquirer": "^13.3.2",
@@ -98,9 +98,9 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -110,9 +110,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -751,24 +751,6 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/express-rate-limit": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.1.tgz",
-      "integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
-      "license": "MIT",
-      "dependencies": {
-        "ip-address": "10.1.0"
-      },
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/express-rate-limit"
-      },
-      "peerDependencies": {
-        "express": ">= 4.11"
-      }
-    },
     "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -808,9 +790,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.124.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
-      "integrity": "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==",
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
+      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -828,9 +810,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
       "cpu": [
         "arm64"
       ],
@@ -845,9 +827,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
       "cpu": [
         "arm64"
       ],
@@ -862,9 +844,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
       "cpu": [
         "x64"
       ],
@@ -879,9 +861,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
       "cpu": [
         "x64"
       ],
@@ -896,9 +878,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.15.tgz",
-      "integrity": "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
+      "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
       "cpu": [
         "arm"
       ],
@@ -913,9 +895,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
       "cpu": [
         "arm64"
       ],
@@ -930,9 +912,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.15.tgz",
-      "integrity": "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
       "cpu": [
         "arm64"
       ],
@@ -947,9 +929,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
       "cpu": [
         "ppc64"
       ],
@@ -964,9 +946,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
       "cpu": [
         "s390x"
       ],
@@ -981,9 +963,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
       "cpu": [
         "x64"
       ],
@@ -998,9 +980,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.15.tgz",
-      "integrity": "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
       "cpu": [
         "x64"
       ],
@@ -1015,9 +997,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
       "cpu": [
         "arm64"
       ],
@@ -1032,9 +1014,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.15.tgz",
-      "integrity": "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
+      "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
       "cpu": [
         "wasm32"
       ],
@@ -1042,18 +1024,18 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "1.9.2",
-        "@emnapi/runtime": "1.9.2",
-        "@napi-rs/wasm-runtime": "^1.1.3"
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.15.tgz",
-      "integrity": "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
       "cpu": [
         "arm64"
       ],
@@ -1068,9 +1050,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.15.tgz",
-      "integrity": "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
       "cpu": [
         "x64"
       ],
@@ -1085,9 +1067,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.15.tgz",
-      "integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
+      "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1160,14 +1142,14 @@
       "license": "MIT"
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.4.tgz",
-      "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.5.tgz",
+      "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.1.4",
+        "@vitest/utils": "4.1.5",
         "ast-v8-to-istanbul": "^1.0.0",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",
@@ -1181,8 +1163,8 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "4.1.4",
-        "vitest": "4.1.4"
+        "@vitest/browser": "4.1.5",
+        "vitest": "4.1.5"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -1191,16 +1173,16 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
-      "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.4",
-        "@vitest/utils": "4.1.4",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -1209,13 +1191,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
-      "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.4",
+        "@vitest/spy": "4.1.5",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -1236,9 +1218,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
-      "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1249,13 +1231,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
-      "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.4",
+        "@vitest/utils": "4.1.5",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -1263,14 +1245,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
-      "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.4",
-        "@vitest/utils": "4.1.4",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -1279,9 +1261,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
-      "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1289,13 +1271,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
-      "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.4",
+        "@vitest/pretty-format": "4.1.5",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -2400,10 +2382,13 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
-      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.1.tgz",
+      "integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
       "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
       "engines": {
         "node": ">= 16"
       },
@@ -4067,9 +4052,9 @@
       }
     },
     "node_modules/ora": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-9.3.0.tgz",
-      "integrity": "sha512-lBX72MWFduWEf7v7uWf5DHp9Jn5BI8bNPGuFgtXMmr2uDz2Gz2749y3am3agSDdkhHPHYmmxEGSKH85ZLGzgXw==",
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-9.4.0.tgz",
+      "integrity": "sha512-84cglkRILFxdtA8hAvLNdMrtBpPNBTrQ9/ulg0FA7xLMnD6mifv+enAIeRmvtv+WgdCE+LPGOfQmtJRrVaIVhQ==",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.6.2",
@@ -4078,7 +4063,7 @@
         "is-interactive": "^2.0.0",
         "is-unicode-supported": "^2.1.0",
         "log-symbols": "^7.0.1",
-        "stdin-discarder": "^0.3.1",
+        "stdin-discarder": "^0.3.2",
         "string-width": "^8.1.0"
       },
       "engines": {
@@ -4236,9 +4221,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "dev": true,
       "funding": [
         {
@@ -4490,14 +4475,14 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
-      "integrity": "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
+      "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.124.0",
-        "@rolldown/pluginutils": "1.0.0-rc.15"
+        "@oxc-project/types": "=0.127.0",
+        "@rolldown/pluginutils": "1.0.0-rc.17"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -4506,21 +4491,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.15",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.15",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.15",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.15",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
+        "@rolldown/binding-android-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
       }
     },
     "node_modules/router": {
@@ -4849,9 +4834,9 @@
       "license": "MIT"
     },
     "node_modules/stdin-discarder": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.3.1.tgz",
-      "integrity": "sha512-reExS1kSGoElkextOcPkel4NE99S0BWxjUHQeDFnR8S993JxpPX7KU4MNmO19NXhlJp+8dmdCbKQVNgLJh2teA==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.3.2.tgz",
+      "integrity": "sha512-eCPu1qRxPVkl5605OTWF8Wz40b4Mf45NY5LQmVPQ599knfs5QhASUm9GbJ5BDMDOXgrnh0wyEdvzmL//YMlw0A==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -5156,17 +5141,17 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.8",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
-      "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
+      "version": "8.0.10",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
+      "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
-        "postcss": "^8.5.8",
-        "rolldown": "1.0.0-rc.15",
-        "tinyglobby": "^0.2.15"
+        "postcss": "^8.5.10",
+        "rolldown": "1.0.0-rc.17",
+        "tinyglobby": "^0.2.16"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -5234,19 +5219,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
-      "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.4",
-        "@vitest/mocker": "4.1.4",
-        "@vitest/pretty-format": "4.1.4",
-        "@vitest/runner": "4.1.4",
-        "@vitest/snapshot": "4.1.4",
-        "@vitest/spy": "4.1.4",
-        "@vitest/utils": "4.1.4",
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -5274,12 +5259,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.4",
-        "@vitest/browser-preview": "4.1.4",
-        "@vitest/browser-webdriverio": "4.1.4",
-        "@vitest/coverage-istanbul": "4.1.4",
-        "@vitest/coverage-v8": "4.1.4",
-        "@vitest/ui": "4.1.4",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sfdt/cli",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sfdt/cli",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "better-sqlite3": "^12.9.0",
         "chalk": "^5.4.1",
         "commander": "^13.1.0",
         "execa": "^9.5.2",
@@ -34,7 +33,7 @@
         "vitest": "^4.1.4"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -1455,60 +1454,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/better-sqlite3": {
-      "version": "12.9.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.9.0.tgz",
-      "integrity": "sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "prebuild-install": "^7.1.1"
-      },
-      "engines": {
-        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
-      }
-    },
-    "node_modules/bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "license": "MIT",
-      "dependencies": {
-        "file-uri-to-path": "1.0.0"
-      }
-    },
-    "node_modules/bl": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
-      }
-    },
     "node_modules/body-parser": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
@@ -1542,30 +1487,6 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
       }
     },
     "node_modules/bundle-name": {
@@ -1658,12 +1579,6 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
       "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
       "license": "MIT"
-    },
-    "node_modules/chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "license": "ISC"
     },
     "node_modules/cli-cursor": {
       "version": "5.0.0",
@@ -1862,30 +1777,6 @@
         }
       }
     },
-    "node_modules/decompress-response": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "mimic-response": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -1956,6 +1847,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -1999,15 +1891,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/end-of-stream": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
-      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-      "license": "MIT",
-      "dependencies": {
-        "once": "^1.4.0"
       }
     },
     "node_modules/es-define-property": {
@@ -2319,15 +2202,6 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
-    "node_modules/expand-template": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-      "license": "(MIT OR WTFPL)",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -2512,12 +2386,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "license": "MIT"
-    },
     "node_modules/finalhandler": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
@@ -2653,12 +2521,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/fs-constants": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "license": "MIT"
-    },
     "node_modules/fs-extra": {
       "version": "11.3.4",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
@@ -2761,12 +2623,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/github-from-package": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "13.0.6",
@@ -2976,26 +2832,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause"
-    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3037,12 +2873,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "license": "ISC"
-    },
-    "node_modules/ini": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
     "node_modules/inquirer": {
@@ -3800,18 +3630,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/mimic-response": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -3825,15 +3643,6 @@
         "node": "*"
       }
     },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/minipass": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
@@ -3842,12 +3651,6 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
-    },
-    "node_modules/mkdirp-classic": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -3883,12 +3686,6 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
-    "node_modules/napi-build-utils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
-      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
-      "license": "MIT"
-    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -3903,18 +3700,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/node-abi": {
-      "version": "3.89.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
-      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/npm-run-path": {
@@ -4261,33 +4046,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/prebuild-install": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
-      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
-      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
-      "license": "MIT",
-      "dependencies": {
-        "detect-libc": "^2.0.0",
-        "expand-template": "^2.0.3",
-        "github-from-package": "0.0.0",
-        "minimist": "^1.2.3",
-        "mkdirp-classic": "^0.5.3",
-        "napi-build-utils": "^2.0.0",
-        "node-abi": "^3.3.0",
-        "pump": "^3.0.0",
-        "rc": "^1.2.7",
-        "simple-get": "^4.0.0",
-        "tar-fs": "^2.0.0",
-        "tunnel-agent": "^0.6.0"
-      },
-      "bin": {
-        "prebuild-install": "bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -4342,16 +4100,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/pump": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
-      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
-      "license": "MIT",
-      "dependencies": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
-      }
-    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -4399,44 +4147,6 @@
       },
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/rc": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-      "dependencies": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      },
-      "bin": {
-        "rc": "cli.js"
-      }
-    },
-    "node_modules/rc/node_modules/strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/require-from-string": {
@@ -4554,26 +4264,6 @@
         "tslib": "^2.1.0"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -4584,6 +4274,7 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -4755,51 +4446,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/simple-concat": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/simple-get": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "decompress-response": "^6.0.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
-      }
-    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -4843,15 +4489,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-width": {
@@ -4959,34 +4596,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/tar-fs": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
-      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
-      }
-    },
-    "node_modules/tar-stream": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "license": "MIT",
-      "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -5045,18 +4654,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
-    },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -5124,12 +4721,6 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
-    },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "license": "MIT"
     },
     "node_modules/vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sfdt/cli",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Salesforce DevTools — Production-grade CLI for Salesforce DX deployment, testing, quality analysis, and release management",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sfdt/cli",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Salesforce DevTools — Production-grade CLI for Salesforce DX deployment, testing, quality analysis, and release management",
   "type": "module",
   "bin": {
@@ -52,11 +52,10 @@
   "author": "",
   "license": "MIT",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "better-sqlite3": "^12.9.0",
     "chalk": "^5.4.1",
     "commander": "^13.1.0",
     "execa": "^9.5.2",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "author": "",
   "license": "MIT",
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=22.15.0"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "commander": "^13.1.0",
     "execa": "^9.5.2",
     "express": "^5.2.1",
-    "express-rate-limit": "^7.5.1",
+    "express-rate-limit": "^8.4.1",
     "fs-extra": "^11.3.0",
     "glob": "^13.0.6",
     "inquirer": "^13.3.2",

--- a/src/lib/ai.js
+++ b/src/lib/ai.js
@@ -427,15 +427,15 @@ async function runGeminiPrompt(prompt, options, config) {
     }
 
     const url = `${GEMINI_BASE_URL}/${model}:generateContent`;
+    // codeql[js/file-access-to-http] - Intentional: agentic loop sends local file content to the AI provider.
+    // Mitigations: safeResolvePath() constrains reads to cwd; sensitive-file blocklist blocks .env/.key/etc.;
+    // endpoint is hardcoded to GEMINI_BASE_URL (not user-controlled).
     const res = await fetch(url, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         'x-goog-api-key': apiKey,
       },
-      // codeql[js/file-access-to-http] - Intentional: agentic loop sends local file content to the AI provider.
-      // Mitigations: safeResolvePath() constrains reads to cwd; sensitive-file blocklist blocks .env/.key/etc.;
-      // endpoint is hardcoded to GEMINI_BASE_URL (not user-controlled).
       body: JSON.stringify(body),
     });
 
@@ -511,12 +511,12 @@ async function runOpenAiPrompt(prompt, options, config) {
       body.tools = toolDefs;
     }
 
+    // codeql[js/file-access-to-http] - Intentional: agentic loop sends local file content to the AI provider.
+    // Mitigations: safeResolvePath() constrains reads to cwd; sensitive-file blocklist blocks .env/.key/etc.;
+    // endpoint is hardcoded to OPENAI_CHAT_URL (not user-controlled).
     const res = await fetch(OPENAI_CHAT_URL, {
       method: 'POST',
       headers,
-      // codeql[js/file-access-to-http] - Intentional: agentic loop sends local file content to the AI provider.
-      // Mitigations: safeResolvePath() constrains reads to cwd; sensitive-file blocklist blocks .env/.key/etc.;
-      // endpoint is hardcoded to OPENAI_CHAT_URL (not user-controlled).
       body: JSON.stringify(body),
     });
 

--- a/src/lib/ai.js
+++ b/src/lib/ai.js
@@ -433,6 +433,9 @@ async function runGeminiPrompt(prompt, options, config) {
         'Content-Type': 'application/json',
         'x-goog-api-key': apiKey,
       },
+      // codeql[js/file-access-to-http] - Intentional: agentic loop sends local file content to the AI provider.
+      // Mitigations: safeResolvePath() constrains reads to cwd; sensitive-file blocklist blocks .env/.key/etc.;
+      // endpoint is hardcoded to GEMINI_BASE_URL (not user-controlled).
       body: JSON.stringify(body),
     });
 
@@ -511,6 +514,9 @@ async function runOpenAiPrompt(prompt, options, config) {
     const res = await fetch(OPENAI_CHAT_URL, {
       method: 'POST',
       headers,
+      // codeql[js/file-access-to-http] - Intentional: agentic loop sends local file content to the AI provider.
+      // Mitigations: safeResolvePath() constrains reads to cwd; sensitive-file blocklist blocks .env/.key/etc.;
+      // endpoint is hardcoded to OPENAI_CHAT_URL (not user-controlled).
       body: JSON.stringify(body),
     });
 

--- a/src/lib/gui-server.js
+++ b/src/lib/gui-server.js
@@ -26,6 +26,7 @@ const ANSI_RE = /\x1B\[[0-9;]*[A-Za-z]|\x1B\][^\x07]*\x07|\x1B[()][AB012]/g;
 function stripAnsi(str) { return typeof str === 'string' ? str.replace(ANSI_RE, '') : str; }
 
 const SCRIPTS_DIR = path.resolve(__dirname, '..', '..', 'scripts');
+const TEMPLATE_PATH = path.resolve(__dirname, '..', 'templates', 'sfdt.config.json');
 
 // gui/dist lives at <package-root>/gui/dist
 const GUI_DIST = path.resolve(__dirname, '..', '..', 'gui', 'dist');
@@ -502,8 +503,6 @@ export function createGuiApp(config, version, port = 7654) {
     }
   });
 
-  const TEMPLATE_PATH = path.resolve(__dirname, '..', 'templates', 'sfdt.config.json');
-
   app.post('/api/init', apiLimiter, async (req, res) => {
     try {
       const projectRoot = config._projectRoot || process.cwd();
@@ -780,7 +779,7 @@ export function createGuiApp(config, version, port = 7654) {
         rl.on('line', (line) => {
           lines.push(line);
           const stripped = stripAnsi(line);
-          if (!res.writableEnded && !line.startsWith('SFDT_LOG:')) {
+          if (!res.writableEnded && !stripped.startsWith('SFDT_LOG:')) {
             res.write('data: ' + JSON.stringify({ type: 'log', line: stripped, ts: new Date().toISOString() }) + '\n\n');
           }
         });
@@ -1327,7 +1326,7 @@ export function createGuiApp(config, version, port = 7654) {
         rl.on('line', (line) => {
           lines.push(line);
           const stripped = stripAnsi(line);
-          if (!res.writableEnded && !line.startsWith('SFDT_LOG:'))
+          if (!res.writableEnded && !stripped.startsWith('SFDT_LOG:'))
             res.write('data: ' + JSON.stringify({ type: 'log', line: stripped, ts: new Date().toISOString() }) + '\n\n');
         });
         return rl;

--- a/src/lib/gui-server.js
+++ b/src/lib/gui-server.js
@@ -22,6 +22,9 @@ import { loadConfig } from './config.js';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
+const ANSI_RE = /\x1B\[[0-9;]*[A-Za-z]|\x1B\][^\x07]*\x07|\x1B[()][AB012]/g;
+function stripAnsi(str) { return typeof str === 'string' ? str.replace(ANSI_RE, '') : str; }
+
 const SCRIPTS_DIR = path.resolve(__dirname, '..', '..', 'scripts');
 
 // gui/dist lives at <package-root>/gui/dist
@@ -549,6 +552,7 @@ export function createGuiApp(config, version, port = 7654) {
       const fresh = await loadConfig(projectRoot);
       Object.assign(config, fresh);
 
+      initInProgress = false;
       res.json({ ok: true });
     } catch (err) {
       initInProgress = false;
@@ -583,7 +587,7 @@ export function createGuiApp(config, version, port = 7654) {
   app.get('/api/preflight', apiLimiter, async (_req, res) => {
     try {
       const data = await readPreflight(logDir);
-      res.json(data ?? {});
+      res.json(data ?? { date: null, status: null, checks: [] });
     } catch (err) {
       res.status(500).json({ error: err.message });
     }
@@ -592,7 +596,7 @@ export function createGuiApp(config, version, port = 7654) {
   app.get('/api/drift', apiLimiter, async (_req, res) => {
     try {
       const data = await readDrift(logDir);
-      res.json(data ?? {});
+      res.json(data ?? { date: null, status: null, components: [] });
     } catch (err) {
       res.status(500).json({ error: err.message });
     }
@@ -671,8 +675,9 @@ export function createGuiApp(config, version, port = 7654) {
       const streamLines = (readable) => {
         const rl = createInterface({ input: readable, crlfDelay: Infinity });
         rl.on('line', (line) => {
-          if (!res.writableEnded && !line.startsWith('SFDT_LOG:')) {
-            res.write('data: ' + JSON.stringify({ type: 'log', line, ts: new Date().toISOString() }) + '\n\n');
+          const stripped = stripAnsi(line);
+          if (!res.writableEnded && !stripped.startsWith('SFDT_LOG:')) {
+            res.write('data: ' + JSON.stringify({ type: 'log', line: stripped, ts: new Date().toISOString() }) + '\n\n');
           }
         });
         return rl;
@@ -774,8 +779,9 @@ export function createGuiApp(config, version, port = 7654) {
         const rl = createInterface({ input: readable, crlfDelay: Infinity });
         rl.on('line', (line) => {
           lines.push(line);
+          const stripped = stripAnsi(line);
           if (!res.writableEnded && !line.startsWith('SFDT_LOG:')) {
-            res.write('data: ' + JSON.stringify({ type: 'log', line, ts: new Date().toISOString() }) + '\n\n');
+            res.write('data: ' + JSON.stringify({ type: 'log', line: stripped, ts: new Date().toISOString() }) + '\n\n');
           }
         });
         return rl;
@@ -865,9 +871,9 @@ export function createGuiApp(config, version, port = 7654) {
         // sf not available or no orgs authorized
       }
 
-      const configOrgs = Object.keys(config.environments?.orgs ?? {}).map((alias) => ({
-        alias,
-        username: config.environments.orgs[alias],
+      const configOrgs = (config.environments?.orgs ?? []).map((o) => ({
+        alias: o.alias,
+        username: o.username ?? '',
       }));
 
       // Merge, deduplicate by alias
@@ -885,7 +891,7 @@ export function createGuiApp(config, version, port = 7654) {
   app.get('/api/compare', apiLimiter, async (_req, res) => {
     try {
       const data = await readCompare(logDir);
-      res.json(data ?? {});
+      res.json(data ?? { date: null, source: null, target: null, items: [] });
     } catch (err) {
       res.status(500).json({ error: err.message });
     }
@@ -1320,8 +1326,9 @@ export function createGuiApp(config, version, port = 7654) {
         const rl = createInterface({ input: readable, crlfDelay: Infinity });
         rl.on('line', (line) => {
           lines.push(line);
+          const stripped = stripAnsi(line);
           if (!res.writableEnded && !line.startsWith('SFDT_LOG:'))
-            res.write('data: ' + JSON.stringify({ type: 'log', line, ts: new Date().toISOString() }) + '\n\n');
+            res.write('data: ' + JSON.stringify({ type: 'log', line: stripped, ts: new Date().toISOString() }) + '\n\n');
         });
         return rl;
       };
@@ -1538,7 +1545,7 @@ export function createGuiApp(config, version, port = 7654) {
 
       if (result?.stdout) {
         for (const line of result.stdout.split('\n')) {
-          send({ type: 'log', line, ts: new Date().toISOString() });
+          send({ type: 'log', line: stripAnsi(line), ts: new Date().toISOString() });
         }
       }
       send({ type: 'result', exitCode: result?.exitCode ?? 0, content: result?.stdout ?? '' });
@@ -1590,7 +1597,7 @@ export function createGuiApp(config, version, port = 7654) {
 
       if (result?.stdout) {
         for (const line of result.stdout.split('\n')) {
-          send({ type: 'log', line, ts: new Date().toISOString() });
+          send({ type: 'log', line: stripAnsi(line), ts: new Date().toISOString() });
         }
       }
       send({ type: 'result', exitCode: result?.exitCode ?? 0, content: result?.stdout ?? '' });
@@ -1741,7 +1748,7 @@ export function createGuiApp(config, version, port = 7654) {
 
       if (result?.stdout) {
         for (const line of result.stdout.split('\n')) {
-          send({ type: 'log', line, ts: new Date().toISOString() });
+          send({ type: 'log', line: stripAnsi(line), ts: new Date().toISOString() });
         }
       }
       send({ type: 'result', exitCode: result?.exitCode ?? 0, content: result?.stdout ?? '' });
@@ -1841,7 +1848,7 @@ export function createGuiApp(config, version, port = 7654) {
 
       if (result?.stdout) {
         for (const line of result.stdout.split('\n')) {
-          send({ type: 'log', line, ts: new Date().toISOString() });
+          send({ type: 'log', line: stripAnsi(line), ts: new Date().toISOString() });
         }
       }
       send({ type: 'result', exitCode: result?.exitCode ?? 0, content: result?.stdout ?? '' });
@@ -1912,7 +1919,7 @@ export function createGuiApp(config, version, port = 7654) {
 
       if (result?.stdout) {
         for (const line of result.stdout.split('\n')) {
-          send({ type: 'log', line, ts: new Date().toISOString() });
+          send({ type: 'log', line: stripAnsi(line), ts: new Date().toISOString() });
         }
       }
       send({ type: 'result', exitCode: result?.exitCode ?? 0, content: result?.stdout ?? '' });

--- a/src/lib/gui-server.js
+++ b/src/lib/gui-server.js
@@ -465,6 +465,7 @@ export function createGuiApp(config, version, port = 7654) {
   let rawConfigPath = config._configDir
     ? path.join(config._configDir, 'config.json')
     : null;
+  let initInProgress = false;
 
   app.get('/api/config', apiLimiter, async (_req, res) => {
     if (!rawConfigPath) return res.status(503).json({ error: 'Config dir unavailable' });
@@ -504,9 +505,10 @@ export function createGuiApp(config, version, port = 7654) {
     try {
       const projectRoot = config._projectRoot || process.cwd();
       const configDir = path.join(projectRoot, '.sfdt');
-      if (rawConfigPath || await fs.pathExists(configDir)) {
+      if (rawConfigPath || initInProgress || await fs.pathExists(configDir)) {
         return res.status(409).json({ error: 'Already initialized' });
       }
+      initInProgress = true;
 
       const { projectName = 'Salesforce Project', defaultOrg = '' } = req.body ?? {};
       if (!projectName.trim()) {
@@ -545,6 +547,7 @@ export function createGuiApp(config, version, port = 7654) {
 
       res.json({ ok: true });
     } catch (err) {
+      initInProgress = false;
       res.status(500).json({ error: err.message });
     }
   });

--- a/src/lib/gui-server.js
+++ b/src/lib/gui-server.js
@@ -6,6 +6,7 @@
  *  - Exposes REST API endpoints that read sfdt config and log files
  */
 
+import { spawn } from 'child_process';
 import express from 'express';
 import rateLimit from 'express-rate-limit';
 import fs from 'fs-extra';
@@ -16,6 +17,7 @@ import { createInterface } from 'readline';
 import { fetchLatestVersion } from './update-checker.js';
 import { writeLog, parseSfdtLogLines, readLatestLog } from './log-writer.js';
 import { setNestedValue, coerceConfigValue } from './config-utils.js';
+import { loadConfig } from './config.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -460,7 +462,7 @@ export function createGuiApp(config, version, port = 7654) {
     res.json({ ok: true, timestamp: new Date().toISOString() });
   });
 
-  const rawConfigPath = config._configDir
+  let rawConfigPath = config._configDir
     ? path.join(config._configDir, 'config.json')
     : null;
 
@@ -494,6 +496,61 @@ export function createGuiApp(config, version, port = 7654) {
     } catch (err) {
       res.status(500).json({ error: err.message });
     }
+  });
+
+  const TEMPLATE_PATH = path.resolve(__dirname, '..', 'templates', 'sfdt.config.json');
+
+  app.post('/api/init', apiLimiter, async (req, res) => {
+    try {
+      const projectRoot = config._projectRoot || process.cwd();
+      const configDir = path.join(projectRoot, '.sfdt');
+      if (rawConfigPath || await fs.pathExists(configDir)) {
+        return res.status(409).json({ error: 'Already initialized' });
+      }
+
+      const { projectName = 'Salesforce Project', defaultOrg = '' } = req.body ?? {};
+      if (!projectName.trim()) {
+        return res.status(400).json({ error: 'projectName is required' });
+      }
+
+      const template = await fs.readJson(TEMPLATE_PATH);
+      const configData = { ...template, projectName: projectName.trim(), defaultOrg };
+
+      await fs.ensureDir(configDir);
+      await fs.writeJson(path.join(configDir, 'config.json'), configData, { spaces: 2 });
+      await fs.writeJson(path.join(configDir, 'environments.json'), {
+        default: defaultOrg,
+        orgs: defaultOrg ? [{ alias: defaultOrg, type: 'development', description: 'Default org' }] : [],
+      }, { spaces: 2 });
+      await fs.writeJson(path.join(configDir, 'pull-config.json'), {
+        metadataTypes: [
+          'ApexClass', 'ApexTrigger', 'LightningComponentBundle', 'CustomObject',
+          'CustomField', 'Layout', 'FlexiPage', 'PermissionSet', 'Flow',
+        ],
+        targetDir: 'force-app/main/default',
+      }, { spaces: 2 });
+      await fs.writeJson(path.join(configDir, 'test-config.json'), {
+        coverageThreshold: template.deployment?.coverageThreshold ?? 75,
+        testLevel: 'RunLocalTests',
+        suites: [],
+        testClasses: [],
+        apexClasses: [],
+      }, { spaces: 2 });
+
+      rawConfigPath = path.join(configDir, 'config.json');
+
+      // Reload in-memory config so all endpoints see the new values immediately
+      const fresh = await loadConfig(projectRoot);
+      Object.assign(config, fresh);
+
+      res.json({ ok: true });
+    } catch (err) {
+      res.status(500).json({ error: err.message });
+    }
+  });
+
+  app.get('/api/ping', apiLimiter, (_req, res) => {
+    res.json({ ok: true });
   });
 
   app.get('/api/project', apiLimiter, (_req, res) => {
@@ -630,7 +687,24 @@ export function createGuiApp(config, version, port = 7654) {
 
       if (!res.writableEnded) {
         res.write('data: ' + JSON.stringify({ type: 'result', exitCode }) + '\n\n');
+        if (exitCode === 0) {
+          res.write('data: ' + JSON.stringify({ type: 'restarting' }) + '\n\n');
+        }
         res.end();
+      }
+
+      if (exitCode === 0) {
+        setTimeout(() => {
+          const child = spawn(process.argv[0], [process.argv[1], 'ui'], {
+            detached: true,
+            stdio: 'ignore',
+            env: process.env,
+            cwd: config._projectRoot || process.cwd(),
+          });
+          child.unref();
+          process.exit(0);
+        }, 500);
+        return;
       }
     } catch (err) {
       if (!res.writableEnded) {

--- a/src/lib/gui-server.js
+++ b/src/lib/gui-server.js
@@ -505,10 +505,14 @@ export function createGuiApp(config, version, port = 7654) {
     try {
       const projectRoot = config._projectRoot || process.cwd();
       const configDir = path.join(projectRoot, '.sfdt');
-      if (rawConfigPath || initInProgress || await fs.pathExists(configDir)) {
+      if (rawConfigPath || initInProgress) {
         return res.status(409).json({ error: 'Already initialized' });
       }
       initInProgress = true;
+      if (await fs.pathExists(configDir)) {
+        initInProgress = false;
+        return res.status(409).json({ error: 'Already initialized' });
+      }
 
       const { projectName = 'Salesforce Project', defaultOrg = '' } = req.body ?? {};
       if (!projectName.trim()) {
@@ -522,7 +526,7 @@ export function createGuiApp(config, version, port = 7654) {
       await fs.writeJson(path.join(configDir, 'config.json'), configData, { spaces: 2 });
       await fs.writeJson(path.join(configDir, 'environments.json'), {
         default: defaultOrg,
-        orgs: defaultOrg ? [{ alias: defaultOrg, type: 'development', description: 'Default org' }] : [],
+        orgs: defaultOrg ? [{ alias: defaultOrg, type: 'development', description: 'Default development org' }] : [],
       }, { spaces: 2 });
       await fs.writeJson(path.join(configDir, 'pull-config.json'), {
         metadataTypes: [

--- a/src/lib/pull-cache.js
+++ b/src/lib/pull-cache.js
@@ -1,3 +1,4 @@
+// node:sqlite (DatabaseSync) is experimental/stability-1 in Node 22.x — watch Node release notes for API changes.
 import { DatabaseSync } from 'node:sqlite';
 import path from 'path';
 import fs from 'fs-extra';

--- a/src/lib/pull-cache.js
+++ b/src/lib/pull-cache.js
@@ -1,4 +1,4 @@
-import Database from 'better-sqlite3';
+import { DatabaseSync } from 'node:sqlite';
 import path from 'path';
 import fs from 'fs-extra';
 
@@ -30,7 +30,7 @@ export function initCache(cacheDir, orgAlias) {
   // path traversal attacks (e.g. aliases containing "../" or other unsafe chars).
   const safeAlias = orgAlias.replace(/[^a-zA-Z0-9_\-\.]/g, '_');
   const dbPath = path.join(cacheDir, `${safeAlias}.db`);
-  const db = new Database(dbPath);
+  const db = new DatabaseSync(dbPath);
   db.exec(SCHEMA);
   return db;
 }
@@ -63,7 +63,8 @@ export function updateCache(db, freshInventory) {
     'DELETE FROM components WHERE type = ? AND name NOT IN (SELECT value FROM json_each(?))',
   );
   const setSync = db.prepare('INSERT OR REPLACE INTO sync_meta (key, value) VALUES (?, ?)');
-  db.transaction(() => {
+  db.exec('BEGIN');
+  try {
     for (const [type, members] of freshInventory) {
       // Upsert every component present in the fresh inventory.
       for (const [name, lastModified] of members) {
@@ -74,7 +75,11 @@ export function updateCache(db, freshInventory) {
       deleteStale.run(type, freshNames);
     }
     setSync.run('last_sync', new Date().toISOString());
-  })();
+    db.exec('COMMIT');
+  } catch (err) {
+    db.exec('ROLLBACK');
+    throw err;
+  }
 }
 
 export function getCacheStatus(db, orgAlias) {

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['test/**/*.test.js'],
+  },
+});


### PR DESCRIPTION
## Release v0.6.3

### Added
- **GUI: ErrorBoundary** — all pages are now wrapped in a React error boundary; a render crash on one page no longer takes down the entire dashboard.
- **GUI: Dashboard retry** — when dashboard data fails to load, an inline error message with a Retry button appears instead of a silent blank state.
- **GUI: Compare cancel** — a Cancel button appears during long-running inventory streams so users can abort without navigating away.
- **GUI test suite** — Vitest + Testing Library added to the GUI package; tests run in CI on every push (`cd gui && npm test`).
- **JSDoc type annotations** added to all `api.js` functions for improved IDE autocompletion.

### Changed
- **ANSI escape codes stripped** from all SSE log output and terminal streams in the GUI — no more garbled color codes appearing in command output panels.
- **Node.js 22+ required** — engine floor raised from 20 to 22; CI now tests on Node 22 only.
- **`better-sqlite3` replaced with Node built-in `node:sqlite`** — removes the native compiled dependency; pull cache now uses the standard library SQLite module.
- **Pull page** replaced with a "Coming Soon" placeholder pointing users to the Compare page and the CLI.
- **`/api/preflight`, `/api/drift`, `/api/compare`** now return structured empty shapes instead of `{}` when no data exists.
- **Org config format** (`environments.orgs`) is now correctly read as an array of `{ alias, username }` objects.

### Fixed
- Dashboard drift activity card no longer crashes — uses `drift.status` / `drift.components` instead of the removed `drift.result` / `drift.count` fields.
- `initInProgress` flag is now correctly reset to `false` after a successful `/api/init` call.
- Release Hub: streaming sessions for changelog and release-note generation are now closed on component unmount.
- Release Hub: deployment now validates that a target org is selected before starting.
- Release Hub: test detection effect no longer re-runs on `testClasses` change.
- Logs page: unknown log types now render their raw JSON payload instead of `null`.
- Manifests viewer: defensive null checks on `data.components`; download filename falls back to `manifest.xml`.
- Review, Explain, Quality pages: AI output exceeding 2000 characters shows a truncation notice with the full character count.
- Settings: `coverageThreshold` field validates 0–100 range before saving.
- React key props in Logs, ReleaseHub, and Dashboard tables now use stable identifiers instead of array indices.
- CodeQL suppression comments added to intentional file-to-HTTP patterns in `ai.js`.

## Pre-release gates
- [x] `/pre-release-security` PASSED (report: pr-analysis/security/2026-04-29-combined-report.md)
- [x] `/pre-release-cli-test` PASSED (518/518 tests, 21/21 commands, lint clean)
- [ ] `/pre-release-ui-test` SKIPPED (user request)

## Test checklist
- [ ] `npm test` passes
- [ ] `npm run lint` passes
- [ ] Install from npm and run `sfdt --version` confirms new version