### PR TITLE
chore: release v0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.1] - 2026-05-13
+
+### Fixed
+- **GUI: result pages didn't refresh after a non-zero exit run**. When `sf apex run test` exited 100 (tests ran but some failed), the server still wrote the full artifact — including `classCoverage` — to disk, but the `CommandRunner` callback only fired on `exitCode === 0`. The Coverage page was the most visible casualty: the per-class table stayed empty and the trend chart never updated, even though all 88% / 106-class data was present. The same bug affected Quality, Preflight, Drift, and Test Runs. `onComplete` now always fires and receives the exit code; Release Hub's preflight gate still correctly requires `exitCode === 0` before enabling "Continue to Deploy".
+
+### Security
+- **CodeQL: type confusion via parameter tampering** — addressed CodeQL alert on GUI API parameter handling.
+
+### Changed
+- Standardized `--json` output shapes across CLI commands and added test coverage for the JSON output mode.
+- Dependency updates.
+
 ## [0.8.0] - 2026-05-12
 
 ### Added

--- a/gui/src/components/CommandRunner.jsx
+++ b/gui/src/components/CommandRunner.jsx
@@ -53,7 +53,7 @@ export default function CommandRunner({ command, label, extraParams = {}, onComp
         setExitCode(msg.exitCode);
         es.close();
         esRef.current = null;
-        if (ok) onComplete();
+        onComplete(msg.exitCode);
       } else if (msg.type === 'error') {
         setStatus('error');
         es.close();

--- a/gui/src/pages/ReleaseHub/ValidateStep.jsx
+++ b/gui/src/pages/ReleaseHub/ValidateStep.jsx
@@ -15,7 +15,7 @@ export default function ValidateStep({ onMarkDone }) {
       <CommandRunner
         command="preflight"
         label="Preflight Checks"
-        onComplete={() => setIsValidated(true)}
+        onComplete={(code) => { if (code === 0) setIsValidated(true); }}
       />
 
       {isValidated && (

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sfdt/cli",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Salesforce DevTools — Production-grade CLI for Salesforce DX deployment, testing, quality analysis, and release management",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Release v0.8.1

### Fixed
- **GUI: result pages didn't refresh after a non-zero exit run**. When `sf apex run test` exited 100 (tests ran but some failed), the server still wrote the full artifact — including `classCoverage` — to disk, but the `CommandRunner` callback only fired on `exitCode === 0`. The Coverage page was the most visible casualty: the per-class table stayed empty and the trend chart never updated, even though all 88% / 106-class data was present. The same bug affected Quality, Preflight, Drift, and Test Runs. `onComplete` now always fires and receives the exit code; Release Hub's preflight gate still correctly requires `exitCode === 0` before enabling "Continue to Deploy".

### Security
- **CodeQL: type confusion via parameter tampering** — addressed CodeQL alert on GUI API parameter handling.

### Changed
- Standardized `--json` output shapes across CLI commands and added test coverage for the JSON output mode.
- Dependency updates.

## Test checklist
- [x] `npm test` passes (954/954 — one transient socket-hang-up flake on rerun confirmed passing)
- [x] `npm run lint` passes
- [ ] Install from npm and run `sfdt --version` confirms `0.8.1`