### PR TITLE
chore(deps): bump qs from 6.15.1 to 6.15.2 (security)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9993,9 +9993,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -12495,6 +12495,7 @@
     "packages/flow-core": {
       "name": "@sfdt/flow-core",
       "version": "0.9.0",
+      "license": "MIT",
       "devDependencies": {
         "typescript": "^5.6.3",
         "vitest": "^4.1.4"


### PR DESCRIPTION
## Summary

Closes Dependabot alert [#13](https://github.com/scoobydrew83/sfdt/security/dependabot/13) — qs DoS vulnerability (CVE-2026-8723, GHSA-q8mj-m7cp-5q26, CVSS 5.3).

`qs.stringify` throws `TypeError` when called with `arrayFormat: 'comma'` + `encodeValuesOnly: true` on an array containing `null` or `undefined`. Fixed in 6.15.2 by skipping null/undefined entries instead of crashing.

## Why this is a manual PR

Dependabot's auto-PR (#86) targeted `main` (config bug, since fixed). We closed it to retarget to `develop`, but Dependabot dedup prevents auto-recreating the security PR. This is a manual mirror of what Dependabot would have produced — lockfile-only bump of the transitive.

## Test plan

- [x] Lockfile-only change; no source code modified
- [x] No drift between package.json and lockfile (`npm install --package-lock-only --dry-run` clean)
- [x] CI: standard test/build matrix should pass identically