### PR TITLE
fix(ci): trigger docs-verify via dispatch instead of push

### DIFF
--- a/.github/workflows/docs-verify-dispatch.yml
+++ b/.github/workflows/docs-verify-dispatch.yml
@@ -1,0 +1,27 @@
+name: Documentation Verification Dispatcher
+
+# Watches every push to main and triggers docs-verify.yml via workflow_dispatch,
+# because claude-code-action does not support push events.
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  actions: write
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Trigger docs verification
+        uses: actions/github-script@v9
+        with:
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'docs-verify.yml',
+              ref: context.ref,
+            });

--- a/.github/workflows/docs-verify.yml
+++ b/.github/workflows/docs-verify.yml
@@ -2,10 +2,12 @@ name: Documentation Verification
 
 # Runs after every merge to main. Audits documentation accuracy against the
 # current codebase and opens a GitHub issue if anything is stale or wrong.
+#
+# Triggered by docs-verify-dispatch.yml after every push to main.
+# claude-code-action does not support the push event, so dispatch is used instead.
 
 on:
-  push:
-    branches: [main]
+  workflow_dispatch:
 
 concurrency:
   group: docs-verify


### PR DESCRIPTION
## Problem

The **Documentation Verification** workflow fails on every merge to `main` (~21s, exit 1) and has never actually run an audit. Root cause from the run logs:

```
##[error]Action failed with error: Unsupported event type: push
```

`docs-verify.yml` invoked `anthropics/claude-code-action@v1` directly on a `push` trigger, but that action does not support the `push` event.

## Fix

Mirrors the pattern this repo already uses for `docs-update.yml`:

- **`docs-verify.yml`** — trigger changed from `push: [main]` → `workflow_dispatch`
- **`docs-verify-dispatch.yml`** (new) — catches push-to-main and fires `docs-verify.yml` via `createWorkflowDispatch`

No SHA inputs are passed (unlike docs-update) because the verification audits current repo state, not a diff.

## Note

`workflow_dispatch` only resolves once `docs-verify.yml` exists on the default branch, so the **first** push after this merges won't trigger it; every push after that will. Same behavior as the existing docs-update flow.