### PR TITLE
fix(deps): override vulnerable tmp/node-notifier/uuid via wxt chain (closes audit gate + alert #14)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,13 @@
       },
       "engines": {
         "node": ">=22.15.0"
+      },
+      "overrides": {
+        "tmp": "^0.2.6",
+        "uuid": "^11.1.1",
+        "node-notifier": {
+          "uuid": "^11.1.1"
+        }
       }
     },
     "extension": {
@@ -11159,9 +11166,9 @@
       "license": "MIT"
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11633,14 +11640,17 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/vary": {

--- a/package.json
+++ b/package.json
@@ -99,6 +99,13 @@
     "typescript-eslint": "^8.59.3",
     "vitest": "^4.1.4"
   },
+  "overrides": {
+    "tmp": "^0.2.6",
+    "uuid": "^11.1.1",
+    "node-notifier": {
+      "uuid": "^11.1.1"
+    }
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/scoobydrew83/sfdt.git"


### PR DESCRIPTION
## Summary

The CI `test (22)` job runs `npm audit --audit-level=high` and was failing (exit 1) on `develop` and every PR branch. This also corresponds to open Dependabot security alert **#14**. All advisories are **dev-only transitive dependencies** introduced by the extension's WXT tooling.

### The transitive chain

```
extension/  (devDependency: wxt ^0.20.6, installed 0.20.26)
  └─ wxt
       └─ web-ext-run
            ├─ tmp           <0.2.6   → GHSA-ph9p-34f9-6g65 / CVE-2026-44705 (HIGH, path traversal)
            └─ node-notifier >=7.0.0
                 └─ uuid     <11.1.1  → GHSA-w5hq-g745-h8pq (MODERATE, buffer bounds check)
```

The entire chain is **hoisted to the root `node_modules`** (verified — nothing under `extension/node_modules`), so per npm workspaces rules the `overrides` block must live in the **root `package.json`**, which is where it was added.

### Fix

Added an `overrides` block forcing patched versions:

```json
"overrides": {
  "tmp": "^0.2.6",
  "uuid": "^11.1.1",
  "node-notifier": { "uuid": "^11.1.1" }
}
```

- **tmp** `0.2.5 → 0.2.7` — patches the path-traversal advisory (HIGH).
- **uuid** `8.3.2 → 11.1.1` — patches the buffer-bounds advisory (MODERATE). `node-notifier@10.0.1` is the latest published version and still pins `uuid@^8.3.2`, so a forward bump of `node-notifier` cannot resolve this; the nested `node-notifier > uuid` override pulls it onto the patched uuid. `node-notifier` only calls `uuid.v4()`, which is API-compatible across v8→v11, so this is safe.

### Why not `npm audit fix --force`?

It would install `wxt@0.3.2` — a **downgrade** from the current `wxt@0.20.26` and a breaking change (wrong direction). The override approach keeps WXT current.

### Verification (local, mirrors CI's `npm ci`)

- `npm audit --audit-level=high` → **exit 0, found 0 vulnerabilities** (0 at all severity levels, clearing both the high gate and the moderate uuid advisory / alert #14).
- `npm run lint` → pass.
- `npm test` → **114 files / 1623 tests passed**.
- `npm test --workspace=gui` (the `gui-build` job) → **4 files / 18 tests passed**.

The lockfile change is intentionally surgical: only the `overrides` field plus the `tmp` and `uuid` package entries changed (18 insertions / 8 deletions). React hoisting and all other resolutions are preserved to keep the GUI test suite green — a full `npm install` re-resolve would otherwise re-hoist React 18 to the root and break the GUI tests, which is unrelated to this security fix.

Closes the `npm audit` CI gate and Dependabot alert #14.