### PR TITLE
fix(flow-core): add repository field for npm provenance

### DIFF
--- a/packages/flow-core/package.json
+++ b/packages/flow-core/package.json
@@ -3,6 +3,11 @@
   "version": "0.9.1",
   "description": "Pure-TypeScript core for Salesforce Flow analysis: normalization, health rules, scoring, scheduled-flow math, AI prompt library, API name expansion. No DOM, no chrome.*, no Node-specific APIs.",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/scoobydrew83/sfdt.git",
+    "directory": "packages/flow-core"
+  },
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"


### PR DESCRIPTION
## Problem

Publishing `@sfdt/flow-core@0.9.1` with `--provenance` failed at the registry:

```
npm error code E422
Error verifying sigstore provenance bundle: Failed to validate repository information:
package.json: "repository.url" is "", expected to match "https://github.com/scoobydrew83/sfdt"
```

The workspace package `packages/flow-core/package.json` had **no `repository` field**, so npm read it as `""` and could not match it against the GitHub source recorded in the signed provenance bundle.

## Fix

Add a `repository` field with:
- `url` = `git+https://github.com/scoobydrew83/sfdt.git` (matches the root package + provenance host)
- `directory` = `packages/flow-core` (monorepo subfolder location)

Metadata-only change — no source/build impact.

## After merge

Re-run the publish workflow. Version is still `0.9.1`; the prior run never landed the tarball on the registry so it should publish. If npm reports it as taken, bump to `0.9.2`.