### PR TITLE
chore: bump @sfdt/cli to 0.10.1 (re-trigger stuck publish)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sfdt/cli",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sfdt/cli",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sfdt/cli",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Salesforce DevTools — Production-grade CLI for Salesforce DX deployment, testing, quality analysis, and release management",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Minimal version bump to recover the failed v0.10.0 release.

## Background
The v0.10.0 publish job aborted at the `@sfdt/flow-core` provenance step (empty `repository` field, fixed in #108). Neither package landed on npm:
- `@sfdt/cli` latest stuck at 0.9.1 (repo was 0.10.0)
- `@sfdt/flow-core` latest stuck at 0.9.0 (repo is 0.9.1)

The production `publish` job only fires on a CLI version change, and 0.10.0 is already on main (spent). Bumping to **0.10.1** re-triggers it.

## Effect once on main
`publish` job runs → publishes `@sfdt/flow-core@0.9.1` first (now passes provenance), then `@sfdt/cli@0.10.1`. CLI skips the dead 0.10.0 number.

## Scope
CLI root `package.json` + lockfile only. flow-core untouched (stays 0.9.1).