### PR TITLE
Release: @sfdt/cli 0.10.1 + @sfdt/flow-core 0.9.1 to npm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sfdt/cli",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sfdt/cli",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sfdt/cli",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Salesforce DevTools — Production-grade CLI for Salesforce DX deployment, testing, quality analysis, and release management",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Sync `develop` → `main` to publish the recovered release.

Carries the CLI bump to **0.10.1** (#110). On push to main the production `publish` job fires (0.10.0 → 0.10.1) and publishes, in order:
1. `@sfdt/flow-core@0.9.1` — now passes provenance (repository field added in #108)
2. `@sfdt/cli@0.10.1`

Recovers the failed v0.10.0 release where the flow-core provenance step aborted the whole job.