### PR TITLE
fix: inquirer 14 prompt crash + ui dashboard launch token (release blockers)

### DIFF
--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -143,7 +143,7 @@ export function registerInitCommand(program) {
             default: true,
           },
           {
-            type: 'list',
+            type: 'select',
             name: 'aiProvider',
             message: 'AI provider:',
             choices: [

--- a/src/commands/pull.js
+++ b/src/commands/pull.js
@@ -90,7 +90,7 @@ async function runPull(options) {
     ...groupChoices,
   ];
 
-  const { action } = await inquirer.prompt([{ type: 'list', name: 'action', message: 'Select pull action:', choices }]);
+  const { action } = await inquirer.prompt([{ type: 'select', name: 'action', message: 'Select pull action:', choices }]);
 
   switch (action) {
     case 'smart':

--- a/src/lib/gui-server/index.js
+++ b/src/lib/gui-server/index.js
@@ -3050,6 +3050,7 @@ export async function startGuiServer(port, config, version) {
   return new Promise((resolve, reject) => {
     const server = app.listen(port, '127.0.0.1', () => {
       server.cleanup = app.cleanup;
+      server.launchToken = app.launchToken;
       resolve(server);
     });
     server.once('error', reject);


### PR DESCRIPTION
## Summary

Two release-blocking bugs found during pre-release gating (UI test gate + a user-reported `sfdt init` crash). Both fixed and verified.

## Bug 1 — `sfdt init` / `sfdt pull` crash on inquirer 14

`inquirer` was bumped `13.4.3 → 14.0.2` in this release. v14 removed the legacy `list` prompt type (now `select`), so:
- `sfdt init` crashed at the **AI provider** prompt
- `sfdt pull` crashed at the interactive **action picker**

with: `Prompt type "list" is not registered. Available prompt types: ... select`

**Fix:** `type: 'list'` → `type: 'select'` in `src/commands/init.js` and `src/commands/pull.js`.
**Verified:** directly against the installed inquirer 14 — `list` throws the exact error, `select` registers cleanly.

## Bug 2 — `sfdt ui` dashboard 401s for all users

The gui-server refactor (`gui-server.js` → `gui-server/index.js`) set `app.launchToken`, but `startGuiServer()` returned the http server without copying it. `ui.js` builds the browser URL from `server.launchToken`, so it became `?token=undefined` → every API call returned **401 Unauthorized** → the dashboard showed *"Failed to load dashboard data: 401 Unauthorized"* on every page.

**Fix:** copy `app.launchToken` onto the returned server alongside `app.cleanup` in `startGuiServer()`.
**Verified:** end-to-end with browser automation — dashboard now loads stat cards, recent test runs, and the activity feed with no 401 and no console errors.

## Test checklist
- [x] `npm test` — 1752/1752 pass
- [x] `npm run lint` — clean
- [x] Bug 1 reproduced + fix verified against inquirer 14
- [x] Bug 2 reproduced + dashboard load verified in browser

## Notes
Targets `develop` (the release integration branch). These fixes should be included in the upcoming `@sfdt/cli` release.