### PR TITLE
chore: release v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-06-08
+
+Promotes a backlog of work that had accumulated on `main` since 0.10.1 but was never published — three new commands, Flow analysis, and an audit trail — and repairs two regressions that shipped alongside the inquirer 14 upgrade and the gui-server refactor in 0.10.0.
+
+### Added
+
+- **`sfdt mcp` command** — manage the built-in Model Context Protocol server so agents can drive sfdt as a tool:
+  - `sfdt mcp start` — start the MCP server in stdio mode.
+  - `sfdt mcp cleanup` — purge expired "parked" results from the cache directory.
+- **`sfdt plugin` command** — manage CLI plugins:
+  - `sfdt plugin create [name]` — scaffold a new sfdt CLI plugin project (`--description`, `--author`). Complements the existing auto-discovery of `sfdt-plugin-*` packages and `.sfdt/plugins/*.js`.
+- **`sfdt skills` command** — manage agent skills:
+  - `sfdt skills export [--json]` — export local agent skills to IDE/agent-specific configurations.
+- **Flow analysis** — a new Flow analyzer library powers Flow health/quality analysis, surfaced in the GUI as a **Flow Intelligence** page.
+- **Local audit trail** — privileged/local actions are now recorded to `logs/audit.json`, with OAuth session tokens and passwords automatically redacted.
+
+### Fixed
+
+- **`sfdt init` and `sfdt pull` no longer crash at their interactive prompts.** inquirer 14 (shipped in 0.10.0) removed the legacy `list` prompt type, so `sfdt init` aborted at the "AI provider" step and `sfdt pull` aborted at its action picker with `Prompt type "list" is not registered`. Both prompts now use inquirer 14's `select` type. This also unblocks first-time project setup — a fresh `.sfdt/config.json` could not be created while `init` was crashing.
+- **The `sfdt ui` dashboard loads again.** After the gui-server was split into `gui-server/index.js`, `startGuiServer()` returned the HTTP server without its launch token, so the browser opened with `?token=undefined`, every `/api/*` request returned `401 Unauthorized`, and every page showed *"Failed to load dashboard data: 401 Unauthorized"*. The per-launch token is now propagated onto the running server, restoring authenticated access to the dashboard.
+
+### Security
+
+- **The `plugins` config key can no longer be written through the GUI server's config API** — closes a path where a writable config value could be used to load arbitrary local JavaScript at startup.
+- **CodeQL hardening in the audit logger** — cleared a remote-property-injection finding by constructing redacted objects from a fixed key set rather than copying arbitrary input keys.
+- **Additional CodeQL findings resolved** carried over from the release-branch review, including incomplete URL sanitization in test fixtures and several critical/high/medium items flagged in PR review.
+
 ## [0.10.0] - 2026-06-02
 
 Adds a Flow Core panel to the `sfdt ui` dashboard, surfaces `@sfdt/flow-core` package details in the GUI, and rolls in a batch of dependency hygiene — including removing the extension's unused React dependencies and forcing patched transitive packages through the extension toolchain.

--- a/README.md
+++ b/README.md
@@ -110,6 +110,15 @@ sfdt deploy
 | `sfdt feature-flags clear` | Re-enable everything | `--remove`, `--json` |
 | `sfdt doctor --extension` | Diagnose the extension stack (bridge reachable, native host, kill-switch file, telemetry) | `--port <n>`, `--json` |
 
+### Agent & extensibility
+
+| Command | Description | Key Options |
+|---|---|---|
+| `sfdt mcp start` | Start the built-in Model Context Protocol server (stdio) so agents can drive sfdt as a tool | — |
+| `sfdt mcp cleanup` | Purge expired parked results from the MCP cache directory | — |
+| `sfdt plugin create [name]` | Scaffold a new sfdt CLI plugin project | `--description <desc>`, `--author <author>` |
+| `sfdt skills export` | Export local agent skills to IDE/agent-specific configurations | `--json` |
+
 ## Configuration
 
 Running `sfdt init` creates a `.sfdt/` directory in your project root:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sfdt/cli",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "description": "Salesforce DevTools — Production-grade CLI for Salesforce DX deployment, testing, quality analysis, and release management",
   "type": "module",
   "bin": {

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -143,7 +143,7 @@ export function registerInitCommand(program) {
             default: true,
           },
           {
-            type: 'list',
+            type: 'select',
             name: 'aiProvider',
             message: 'AI provider:',
             choices: [

--- a/src/commands/pull.js
+++ b/src/commands/pull.js
@@ -90,7 +90,7 @@ async function runPull(options) {
     ...groupChoices,
   ];
 
-  const { action } = await inquirer.prompt([{ type: 'list', name: 'action', message: 'Select pull action:', choices }]);
+  const { action } = await inquirer.prompt([{ type: 'select', name: 'action', message: 'Select pull action:', choices }]);
 
   switch (action) {
     case 'smart':

--- a/src/lib/gui-server/index.js
+++ b/src/lib/gui-server/index.js
@@ -3050,6 +3050,7 @@ export async function startGuiServer(port, config, version) {
   return new Promise((resolve, reject) => {
     const server = app.listen(port, '127.0.0.1', () => {
       server.cleanup = app.cleanup;
+      server.launchToken = app.launchToken;
       resolve(server);
     });
     server.once('error', reject);


### PR DESCRIPTION
## Release v0.11.0

Promotes a backlog that accumulated on `develop`/`main` since 0.10.1 but was never published — three new commands, Flow analysis, and an audit trail — and ships two critical regression fixes from this cycle.

### Added
- **`sfdt mcp`** — manage the built-in MCP server: `mcp start` (stdio) and `mcp cleanup` (purge expired parked results).
- **`sfdt plugin create [name]`** — scaffold a new CLI plugin project (`--description`, `--author`).
- **`sfdt skills export [--json]`** — export local agent skills to IDE/agent-specific configs.
- **Flow analysis** — Flow analyzer library + **Flow Intelligence** GUI page.
- **Local audit trail** — privileged/local actions recorded to `logs/audit.json` (OAuth tokens & passwords redacted).

### Fixed
- **`sfdt init` / `sfdt pull` crash** — inquirer 14 removed the `list` prompt type; both now use `select`. (Also unblocks first-time `.sfdt/` setup.)
- **`sfdt ui` dashboard 401** — `startGuiServer()` didn't propagate the launch token, so the dashboard opened with `?token=undefined` and every API call returned 401. Token is now propagated.

### Security
- Block the `plugins` config key from the GUI config API (prevents loading arbitrary local JS).
- CodeQL hardening: cleared remote-property-injection in the audit logger; resolved incomplete URL sanitization + PR-review findings.

## Pre-release gates
- [x] `/pre-release-security` PASSED (report: pr-analysis/security/2026-06-08-combined-report.md) — Claude + Codex adversarial, 0 high-confidence findings (Gemini skipped, non-interactive)
- [x] `/pre-release-cli-test` PASSED (report: pr-analysis/cli-test/2026-06-08-cli-test.md) — 1752/1752 tests, lint clean, coverage 75.26%, 29/29 commands `--help` OK
- [x] `/pre-release-ui-test` PASSED with caveats (report: pr-analysis/ui-test/2026-06-08-ui-test.md) — gate caught the launchToken regression; Dashboard verified post-fix; full 13-page sweep deferred

## Test checklist
- [x] `npm test` passes (1752/1752)
- [x] `npm run lint` passes
- [x] `/validate-npm-paths` — no violations
- [ ] After merge: install from npm and run `sfdt --version` confirms 0.11.0

## Doc follow-up
- USAGE.md per-command sections for `mcp`/`plugin`/`skills` and a dedicated `skills` doc are TODO (MCP.md & PLUGINS.md already cover mcp/plugin). The CI `document` flow can also handle this post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)