### PR TITLE
MCP 2026-07-28 RC alignment + improvement-review remediation

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -116,6 +116,7 @@ Before any release PR is merged:
 - [ ] If anything in `packages/flow-core/src/bridge-contract.ts` changed, the `/pre-release-cli-test` skill has been run (verifies all 21 CLI commands' `--help` smoke).
 - [ ] If anything in `gui/` changed, the `/pre-release-ui-test` skill has been run.
 - [ ] If anything outside docs/tests changed, the `/pre-release-security` skill has been run.
+- [ ] If `@modelcontextprotocol/sdk` was bumped past 1.29.x, a manual smoke test has been run against both `sf mcp start` (client side, `src/lib/mcp-client.js`) and `sfdt mcp start` (server side) — at minimum a `tools/list` plus one `tools/call` round-trip. The server relies on verified-but-undocumented SDK behaviors (handler results passed through verbatim, loose `_meta` parsing), so SDK bumps must not land silently.
 - [ ] `CHANGELOG.md` updated.
 
 The user invokes those skills (`/pre-release-cli-test`, `/pre-release-ui-test`, `/pre-release-security`) — they are not auto-runnable from CI.

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -27,7 +27,8 @@ Configure the MCP server in your `.sfdt/config.json` under the `mcp` key:
     "parking": {
       "enabled": true,
       "thresholdBytes": 50000,
-      "ttlSeconds": 86400
+      "ttlSeconds": 86400,
+      "cacheScope": "session"
     }
   }
 }
@@ -36,7 +37,8 @@ Configure the MCP server in your `.sfdt/config.json` under the `mcp` key:
 * **`mcp.enabled`:** Toggle MCP integration.
 * **`mcp.parking.enabled`:** Enables context budget governance.
 * **`mcp.parking.thresholdBytes`:** Size limit above which response payloads are parked (default: 50 KB).
-* **`mcp.parking.ttlSeconds`:** Time-to-live before parked cache files are deleted (default: 24 hours).
+* **`mcp.parking.ttlSeconds`:** Time-to-live before parked cache files are deleted (default: 24 hours). The `ttlMs` field in parked envelopes is derived from this value.
+* **`mcp.parking.cacheScope`:** SEP-2549 cache scope advertised on parked envelopes — `"global"`, `"user"`, or `"session"` (default: `"session"`).
 
 ---
 
@@ -116,10 +118,40 @@ Reads the latest deployment, preflight, quality, or drift logs.
 
 ### 4. Context Budget Governance & Parking
 
+When a tool result exceeds `mcp.parking.thresholdBytes`, the server writes the full payload to `.sfdt/cache/parked/<uuid>.json` and returns a lightweight envelope instead:
+
+```json
+{
+  "_parked": true,
+  "ref": "parked://<uuid>",
+  "byteSize": 123456,
+  "rowCount": 42,
+  "preview": "...",
+  "ttlMs": 86400000,
+  "cacheScope": "session"
+}
+```
+
+> [!NOTE]
+> **Breaking envelope change:** the `expiresAt` ISO timestamp field was replaced by `ttlMs` + `cacheScope` to match the SEP-2549 cache metadata shape in the MCP 2026-07-28 release candidate. Consumers should treat `ttlMs` as relative to when the envelope was received.
+
 #### `sfdt_get_parked_result`
 Retrieves the full content of an oversized payload cached under `.sfdt/cache/parked/`.
 * **Arguments:**
   * `ref` (string, required): The reference URI (e.g. `parked://<uuid>`).
+
+---
+
+## MCP RC Alignment (2026-07-28)
+
+The server is aligned with the MCP 2026-07-28 release candidate at the application level. The pinned SDK (`~1.29.0`) predates the RC, so protocol-level negotiation is unchanged; the items below are sfdt's own surface:
+
+* **No deprecated primitives.** The server advertises a tools-only capability — `Roots`, `Sampling`, and `Logging` (deprecated in the RC with a 12-month removal runway) are not exposed and must not be added.
+* **Stateless per-request design.** Every tool call shells out to the sfdt CLI; no session state exists beyond the parked-file cache, matching the RC's stateless posture (SEP-2567).
+* **SEP-2549 cache metadata.** `tools/list` responses include `ttlMs: 86400000, cacheScope: "global"` (the catalog is static per process). Parked envelopes carry `ttlMs`/`cacheScope` instead of `expiresAt`. If a strict non-SDK client ever rejects the top-level fields on `tools/list`, relocating them into `_meta` is a one-line change.
+* **W3C Trace Context (SEP-414).** `traceparent`/`tracestate` are read from `params._meta` on `tools/call`, validated, included in stderr audit logs for correlation, and echoed back in the result `_meta`.
+* **Redacted audit logging.** Tool-call logs record the tool name, argument keys, payload size, and traceparent — never argument values.
+* **Deferred until an RC-aware SDK ships:** consuming server-advertised `ttlMs` in `src/lib/mcp-client.js` (which currently uses a local 30s cache), and any Streamable HTTP transport (which would require `Mcp-Method`/`Mcp-Name` header enforcement plus an OAuth/OIDC story).
 
 ---
 

--- a/extension/entrypoints/background.ts
+++ b/extension/entrypoints/background.ts
@@ -88,20 +88,29 @@ export default defineBackground(() => {
             // content scripts even with host_permissions set.
             const port = clampBridgePort(message.port);
             const url = `http://127.0.0.1:${port}/api/bridge/ping`;
-            const controller = new AbortController();
-            const timer = setTimeout(() => controller.abort(), 1500);
-            try {
-              const res = await fetch(url, { method: 'GET', signal: controller.signal });
-              const body = (await res.json().catch(() => null)) as unknown;
-              return { ok: true, body };
-            } catch (err) {
-              return {
-                ok: false,
-                error: err instanceof Error ? err.message : String(err),
-              };
-            } finally {
-              clearTimeout(timer);
-            }
+            const attempt = async (): Promise<{ ok: boolean; body?: unknown; error?: string }> => {
+              const controller = new AbortController();
+              const timer = setTimeout(() => controller.abort(), 1500);
+              try {
+                const res = await fetch(url, { method: 'GET', signal: controller.signal });
+                const body = (await res.json().catch(() => null)) as unknown;
+                return { ok: true, body };
+              } catch (err) {
+                return {
+                  ok: false,
+                  error: err instanceof Error ? err.message : String(err),
+                };
+              } finally {
+                clearTimeout(timer);
+              }
+            };
+            // The ping result feeds the feature kill-switch — retry once so a
+            // single slow/failed ping doesn't flip feature state. Ping is
+            // idempotent (GET), so the retry is safe.
+            const first = await attempt();
+            if (first.ok) return first;
+            await new Promise((resolve) => setTimeout(resolve, 300));
+            return attempt();
           }
 
           default:

--- a/extension/entrypoints/content.ts
+++ b/extension/entrypoints/content.ts
@@ -8,7 +8,7 @@ import { createFeatureRegistry } from '../lib/feature-registry.js';
 import { createSpaRouter } from '../lib/spa-router.js';
 import { isFeatureEnabled, loadSettings, onSettingsChange } from '../lib/settings.js';
 import { createBridgeClient } from '../lib/sfdt-bridge.js';
-import { createTelemetry } from '../lib/telemetry.js';
+import { createTelemetry, type BridgeFailureCategory } from '../lib/telemetry.js';
 import { readKillSwitchCache, writeKillSwitchCache } from '../lib/killswitch-cache.js';
 import { mountSideButton, type MenuItem } from '../ui/side-button.js';
 import { createAiAssistantFeature } from '../features/ai-assistant.js';
@@ -90,13 +90,22 @@ export default defineContentScript({
 
     // Boot awaits one ping with a 1.5s timeout; on miss, fall back to the
     // last-known cache so the side button still renders something useful.
+    // Cache entries older than 24h are ignored (treated as no cache) so a
+    // long-dead bridge can't pin stale kill-switch state forever.
     // Subsequent route changes refresh in the background.
     let disabledRemote: ReadonlySet<string> = new Set(await readKillSwitchCache());
+
+    // Fire-and-forget by design — the bridge never awaits this hook, and the
+    // bridge layer already skips telemetry.* kinds to avoid feedback loops.
+    const onBridgeFailure = (failure: { category: BridgeFailureCategory }): void => {
+      void telemetry.trackBridgeFailure(failure.category);
+    };
 
     let bridge = createBridgeClient({
       token: settings.bridge.token,
       preferredTransport: settings.bridge.preferredTransport,
       localhostPort: settings.bridge.localhostPort,
+      onBridgeFailure,
     });
 
     async function refreshKillSwitch(): Promise<void> {
@@ -186,6 +195,7 @@ export default defineContentScript({
           token: next.bridge.token,
           preferredTransport: next.bridge.preferredTransport,
           localhostPort: next.bridge.localhostPort,
+          onBridgeFailure,
         });
         void refreshKillSwitch();
       }

--- a/extension/entrypoints/options/main.ts
+++ b/extension/entrypoints/options/main.ts
@@ -5,7 +5,7 @@ import {
   patchSettings,
   type Settings,
 } from '../../lib/settings.js';
-import { createBridgeClient } from '../../lib/sfdt-bridge.js';
+import { createBridgeClient, getBridgeData } from '../../lib/sfdt-bridge.js';
 import { createFeatureRegistry } from '../../lib/feature-registry.js';
 import { buildField } from '../../lib/zod-to-dom.js';
 import { createTelemetry } from '../../lib/telemetry.js';
@@ -267,7 +267,7 @@ async function render(): Promise<void> {
     });
     const response = await client.call({ kind: 'ping' });
     if (response.ok) {
-      const data = response.data as { serverVersion?: string; transport?: string };
+      const data = getBridgeData<{ serverVersion: string; transport: string }>(response);
       testStatus.className = 'status show ok';
       testStatus.textContent = `OK — sfdt v${data.serverVersion ?? '?'} via ${data.transport ?? '?'}`;
     } else {

--- a/extension/features/event-monitor.ts
+++ b/extension/features/event-monitor.ts
@@ -3,6 +3,7 @@ import { CONTEXTS } from '../lib/context-detector.js';
 import type { Feature } from '../lib/feature-registry.js';
 import {
   getSalesforceApi,
+  type QueryEnvelope,
   type SalesforceApiClient,
 } from '../lib/salesforce-api.js';
 import { registerSettingsShape } from '../lib/settings.js';
@@ -14,7 +15,14 @@ const EVENT_MONITOR_SETTINGS_SCHEMA = z.object({
 
 registerSettingsShape('event-monitor', EVENT_MONITOR_SETTINGS_SCHEMA);
 
-interface BayeuxMessage {
+// Bayeux/CometD `ext` field — this client only uses the Salesforce replay
+// extension (replayId per channel), but servers may echo arbitrary keys.
+interface BayeuxExt {
+  replay?: Record<string, number>;
+  [key: string]: unknown;
+}
+
+export interface BayeuxMessage {
   channel: string;
   clientId?: string;
   version?: string;
@@ -22,9 +30,11 @@ interface BayeuxMessage {
   supportedConnectionTypes?: string[];
   connectionType?: string;
   subscription?: string;
-  ext?: any;
+  ext?: BayeuxExt;
   id?: string;
-  data?: any;
+  // Event payload shape depends entirely on the subscribed channel; consumers
+  // must narrow before use.
+  data?: unknown;
   successful?: boolean;
   error?: string;
 }
@@ -33,7 +43,7 @@ export class SalesforceBayeuxClient {
   private clientId = '';
   private isConnected = false;
   private abortController: AbortController | null = null;
-  private messageListener: ((message: any) => void) | null = null;
+  private messageListener: ((message: unknown) => void) | null = null;
   private statusListener: ((status: string, isError: boolean) => void) | null = null;
   private connectAttempts = 0;
 
@@ -44,7 +54,7 @@ export class SalesforceBayeuxClient {
     private readonly fetchImpl: typeof fetch = fetch,
   ) {}
 
-  onMessage(callback: (message: any) => void): void {
+  onMessage(callback: (message: unknown) => void): void {
     this.messageListener = callback;
   }
 
@@ -69,7 +79,7 @@ export class SalesforceBayeuxClient {
       const endpoint = `${this.baseUrl}/cometd/${this.apiVersion.replace(/^v/, '')}`;
 
       // 1. Handshake
-      const handshakePayload = [
+      const handshakePayload: BayeuxMessage[] = [
         {
           version: '1.0',
           minimumVersion: '0.9',
@@ -88,7 +98,7 @@ export class SalesforceBayeuxClient {
       this.logStatus('Handshake successful. Subscribing...');
 
       // 2. Subscribe
-      const subscribePayload = [
+      const subscribePayload: BayeuxMessage[] = [
         {
           channel: '/meta/subscribe',
           clientId: this.clientId,
@@ -112,16 +122,17 @@ export class SalesforceBayeuxClient {
       // 3. Connect Loop
       void this.connectLoop(endpoint, channelPath);
 
-    } catch (err: any) {
+    } catch (err) {
       this.isConnected = false;
-      this.logStatus(`Connection failed: ${err.message}`, true);
+      const message = err instanceof Error ? err.message : String(err);
+      this.logStatus(`Connection failed: ${message}`, true);
     }
   }
 
   private async connectLoop(endpoint: string, channelPath: string): Promise<void> {
     while (this.isConnected) {
       try {
-        const connectPayload = [
+        const connectPayload: BayeuxMessage[] = [
           {
             channel: '/meta/connect',
             clientId: this.clientId,
@@ -144,12 +155,13 @@ export class SalesforceBayeuxClient {
             return;
           }
         }
-      } catch (err: any) {
-        if (err.name === 'AbortError' || !this.isConnected) {
+      } catch (err) {
+        if ((err instanceof Error && err.name === 'AbortError') || !this.isConnected) {
           break;
         }
         this.connectAttempts++;
-        this.logStatus(`Connection error (attempt ${this.connectAttempts}): ${err.message}`, true);
+        const message = err instanceof Error ? err.message : String(err);
+        this.logStatus(`Connection error (attempt ${this.connectAttempts}): ${message}`, true);
         
         // Exponential backoff up to 30 seconds
         const delay = Math.min(30000, 1000 * Math.pow(2, this.connectAttempts));
@@ -165,19 +177,19 @@ export class SalesforceBayeuxClient {
 
     try {
       const endpoint = `${this.baseUrl}/cometd/${this.apiVersion.replace(/^v/, '')}`;
-      const disconnectPayload = [
+      const disconnectPayload: BayeuxMessage[] = [
         {
           channel: '/meta/disconnect',
           clientId: this.clientId,
         },
       ];
-      await this.post<any>(endpoint, disconnectPayload).catch(() => {});
+      await this.post<BayeuxMessage[]>(endpoint, disconnectPayload).catch(() => {});
     } finally {
       this.logStatus('Disconnected');
     }
   }
 
-  private async post<T>(url: string, body: any): Promise<T> {
+  private async post<T>(url: string, body: BayeuxMessage[]): Promise<T> {
     const response = await this.fetchImpl(url, {
       method: 'POST',
       headers: {
@@ -220,8 +232,8 @@ export function createEventMonitorFeature(options: {
   let replayId = -1;
   let eventFilter = '';
   let showMetrics = false;
-  const events: any[] = [];
-  let selectedEvent: any = null;
+  const events: unknown[] = [];
+  let selectedEvent: unknown = null;
 
   // Cached lists
   const channelsCache: Record<string, ChannelOption[]> = {
@@ -245,48 +257,55 @@ export function createEventMonitorFeature(options: {
       return channelsCache[type];
     }
 
-    const apiVersion = (api as any).apiVersion ?? 'v62.0';
+    const apiVersion = api.apiVersion;
     let query = '';
     const list: ChannelOption[] = [];
 
     try {
       if (type === 'standardPlatformEvent') {
         query = "SELECT Label, QualifiedApiName FROM EntityDefinition WHERE IsCustomizable = FALSE AND IsEverCreatable = TRUE AND QualifiedApiName LIKE '%Event' AND (NOT QualifiedApiName LIKE '%ChangeEvent') ORDER BY Label ASC LIMIT 200";
-        const res = await api.apiGet<any>(`/services/data/${apiVersion}/query`, { q: query });
+        const res = await api.apiGet<QueryEnvelope<{ Label: string; QualifiedApiName: string }>>(
+          `/services/data/${apiVersion}/query`,
+          { q: query },
+        );
         if (res && res.records) {
-          res.records.forEach((r: any) => {
+          res.records.forEach((r) => {
             list.push({ name: r.QualifiedApiName, label: `${r.Label} (${r.QualifiedApiName})` });
           });
         }
       } else if (type === 'platformEvent') {
         query = "SELECT QualifiedApiName, Label FROM EntityDefinition WHERE isCustomizable = TRUE AND KeyPrefix LIKE 'e%' ORDER BY Label ASC";
-        const res = await api.apiGet<any>(`/services/data/${apiVersion}/query`, { q: query });
+        const res = await api.apiGet<QueryEnvelope<{ Label: string; QualifiedApiName: string }>>(
+          `/services/data/${apiVersion}/query`,
+          { q: query },
+        );
         if (res && res.records) {
-          res.records.forEach((r: any) => {
+          res.records.forEach((r) => {
             list.push({ name: r.QualifiedApiName, label: `${r.Label} (${r.QualifiedApiName})` });
           });
         }
       } else if (type === 'customChannel') {
         query = 'SELECT FullName, MasterLabel FROM PlatformEventChannel ORDER BY DeveloperName';
-        const res = await api.toolingQuery<any>(query);
+        const res = await api.toolingQuery<{ FullName: string; MasterLabel: string }>(query);
         if (res && res.records) {
-          res.records.forEach((r: any) => {
+          res.records.forEach((r) => {
             list.push({ name: r.FullName, label: `${r.MasterLabel} (${r.FullName})` });
           });
         }
       } else if (type === 'changeEvent') {
         list.push({ name: 'ChangeEvents', label: 'All Change Events (ChangeEvents)' });
         query = "SELECT MasterLabel, SelectedEntity FROM PlatformEventChannelMember WHERE EventChannel = 'ChangeEvents' ORDER BY MasterLabel";
-        const res = await api.toolingQuery<any>(query);
+        const res = await api.toolingQuery<{ MasterLabel: string; SelectedEntity?: string }>(query);
         if (res && res.records) {
-          res.records.forEach((r: any) => {
+          res.records.forEach((r) => {
             const label = r.SelectedEntity ? r.SelectedEntity.replace(/([A-Z])/g, ' $1').trim() : r.MasterLabel;
             list.push({ name: `${r.SelectedEntity}ChangeEvent`, label: `${label} Change Event` });
           });
         }
       }
-    } catch (err: any) {
-      console.warn(`[SFUT] Failed to fetch channels for ${type}: ${err.message}`);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.warn(`[SFUT] Failed to fetch channels for ${type}: ${message}`);
     }
 
     if (list.length === 0) {
@@ -385,8 +404,9 @@ export function createEventMonitorFeature(options: {
           p.textContent = `${k}: Remaining ${limit.Remaining} out of ${limit.Max} (${percentage}% consumed)`;
           limitsContainer!.appendChild(p);
         });
-      } catch (err: any) {
-        limitsContainer.textContent = `Failed to load limits: ${err.message}`;
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        limitsContainer.textContent = `Failed to load limits: ${message}`;
       }
     }
   }
@@ -578,8 +598,7 @@ export function createEventMonitorFeature(options: {
         return;
       }
 
-      const apiVersion = (api as any).apiVersion ?? 'v62.0';
-      client = new SalesforceBayeuxClient(details.baseUrl, details.sid, apiVersion);
+      client = new SalesforceBayeuxClient(details.baseUrl, details.sid, api.apiVersion);
       
       client.onStatus((status, isErr) => {
         updateStatus(status, isErr);

--- a/extension/features/event-monitor.ts
+++ b/extension/features/event-monitor.ts
@@ -300,7 +300,7 @@ export function createEventMonitorFeature(options: {
   let channelSelect: HTMLSelectElement | null = null;
   async function updateChannelDropdown(): Promise<void> {
     if (!channelSelect) return;
-    channelSelect.innerHTML = '';
+    channelSelect.replaceChildren();
     const list = await fetchChannels(selectedChannelType);
     list.forEach(c => {
       const opt = doc.createElement('option');
@@ -316,7 +316,7 @@ export function createEventMonitorFeature(options: {
   let eventListContainer: HTMLDivElement | null = null;
   function renderEvents(): void {
     if (!eventListContainer) return;
-    eventListContainer.innerHTML = '';
+    eventListContainer.replaceChildren();
 
     const filtered = events.filter(e => {
       if (!eventFilter) return true;
@@ -371,7 +371,7 @@ export function createEventMonitorFeature(options: {
       limitsContainer.textContent = 'Loading limits...';
       try {
         const res = await api.limits();
-        limitsContainer.innerHTML = '';
+        limitsContainer.replaceChildren();
         const keys = Object.keys(res).filter(k => k.includes('PlatformEvent') || k.includes('Streaming'));
         if (keys.length === 0) {
           limitsContainer.textContent = 'No Platform Event limits returned by org.';

--- a/extension/features/flow-deploy.ts
+++ b/extension/features/flow-deploy.ts
@@ -3,7 +3,7 @@ import { detectContext, CONTEXTS } from '../lib/context-detector.js';
 import type { Feature } from '../lib/feature-registry.js';
 import { getSalesforceApi, type SalesforceApiClient } from '../lib/salesforce-api.js';
 import { loadSettings } from '../lib/settings.js';
-import { createBridgeClient } from '../lib/sfdt-bridge.js';
+import { createBridgeClient, LONG_RUNNING_TIMEOUT_MS } from '../lib/sfdt-bridge.js';
 import { showToast } from '../ui/toast.js';
 
 async function dispatchBridge(
@@ -17,7 +17,9 @@ async function dispatchBridge(
     localhostPort: settings.bridge.localhostPort,
     connectNativeImpl: chrome.runtime?.connectNative?.bind(chrome.runtime),
   });
-  return bridge.call({ kind, ...payload } as never);
+  // Deploys and rollbacks run real `sf` CLI work server-side — give them far
+  // longer than the default request timeout.
+  return bridge.call({ kind, ...payload } as never, { timeoutMs: LONG_RUNNING_TIMEOUT_MS });
 }
 
 function describeBridgeError(response: SfdtResponse): string {

--- a/extension/features/flow-deploy.ts
+++ b/extension/features/flow-deploy.ts
@@ -3,7 +3,7 @@ import { detectContext, CONTEXTS } from '../lib/context-detector.js';
 import type { Feature } from '../lib/feature-registry.js';
 import { getSalesforceApi, type SalesforceApiClient } from '../lib/salesforce-api.js';
 import { loadSettings } from '../lib/settings.js';
-import { createBridgeClient, LONG_RUNNING_TIMEOUT_MS } from '../lib/sfdt-bridge.js';
+import { createBridgeClient, getBridgeData, LONG_RUNNING_TIMEOUT_MS } from '../lib/sfdt-bridge.js';
 import { showToast } from '../ui/toast.js';
 
 async function dispatchBridge(
@@ -112,9 +112,9 @@ export function createFlowDeployFeature(options: FlowDeployFeatureOptions = {}):
         showToast(`Deploying ${flowApiName}…`, { doc });
         const response = await dispatchBridge('deploy', { flowApiName, flowId });
         if (response.ok) {
-          const data = response.data as { status?: string; summary?: string };
-          showToast(data?.summary ?? `Deploy ${data?.status ?? 'completed'}`, {
-            kind: data?.status === 'Succeeded' ? 'success' : 'warning',
+          const data = getBridgeData<{ status: string; summary: string }>(response);
+          showToast(data.summary ?? `Deploy ${data.status ?? 'completed'}`, {
+            kind: data.status === 'Succeeded' ? 'success' : 'warning',
             doc,
           });
         } else {

--- a/extension/features/metadata-retrieve.ts
+++ b/extension/features/metadata-retrieve.ts
@@ -86,7 +86,7 @@ export function createMetadataRetrieveFeature(options: {
   let logsContainer: HTMLDivElement | null = null;
   function renderLogs(): void {
     if (!logsContainer) return;
-    logsContainer.innerHTML = '';
+    logsContainer.replaceChildren();
     for (const msg of logMessages) {
       const item = doc.createElement('div');
       item.style.cssText = 'padding: 2px 0; font-family: monospace; font-size: 11px; border-bottom: 1px solid #f3f3f3;';
@@ -502,7 +502,7 @@ export function createMetadataRetrieveFeature(options: {
   let treeContainer: HTMLDivElement | null = null;
   function renderTree(): void {
     if (!treeContainer) return;
-    treeContainer.innerHTML = '';
+    treeContainer.replaceChildren();
 
     const list = doc.createElement('ul');
     list.style.cssText = 'list-style: none; padding-left: 0; margin: 0;';

--- a/extension/features/soap-explore.ts
+++ b/extension/features/soap-explore.ts
@@ -185,7 +185,7 @@ export function createSoapExploreFeature(options: {
 
     function syncOperations(): void {
       const wsdl = wsdlSelect.value;
-      opSelect.innerHTML = '';
+      opSelect.replaceChildren();
       const ops = Object.keys(TEMPLATES[wsdl] || {});
       ops.forEach(op => {
         const opt = doc.createElement('option');
@@ -307,7 +307,7 @@ export function createSoapExploreFeature(options: {
 
     async function renderHistoryMenu(): Promise<void> {
       if (!historyMenu) return;
-      historyMenu.innerHTML = '';
+      historyMenu.replaceChildren();
       const entries = await readSoapHistory();
       if (entries.length === 0) {
         const empty = doc.createElement('div');

--- a/extension/features/soql-runner.ts
+++ b/extension/features/soql-runner.ts
@@ -139,7 +139,7 @@ export class DescribeCache {
     if (cached) return cached;
 
     this.globalCache.set(mode, { status: 'loading' });
-    const apiVersion = (this.api as any).apiVersion ?? 'v62.0';
+    const apiVersion = this.api.apiVersion;
     const endpoint = mode === 'tooling'
       ? `/services/data/${apiVersion}/tooling/sobjects/`
       : `/services/data/${apiVersion}/sobjects/`;
@@ -165,7 +165,7 @@ export class DescribeCache {
     if (cached) return cached;
 
     this.sobjectCache.set(key, { status: 'loading' });
-    const apiVersion = (this.api as any).apiVersion ?? 'v62.0';
+    const apiVersion = this.api.apiVersion;
     const endpoint = mode === 'tooling'
       ? `/services/data/${apiVersion}/tooling/sobjects/${name}/describe`
       : `/services/data/${apiVersion}/sobjects/${name}/describe`;
@@ -186,6 +186,17 @@ export class DescribeCache {
   }
 }
 
+
+// Shape shared by every autocomplete chip (objects, fields, values, retry).
+// `rank`/`dataType` are optional because sentinel entries (e.g. Retry) omit them.
+interface AutocompleteSuggestion {
+  value: string;
+  title: string;
+  suffix: string;
+  autocompleteType: string;
+  rank?: number;
+  dataType?: string;
+}
 
 export function columnsFromRecords(records: ReadonlyArray<Record<string, unknown>>): string[] {
   const seen = new Set<string>();
@@ -244,7 +255,7 @@ async function runQuery(
   mode: ApiMode,
 ): Promise<QueryEnvelope<Record<string, unknown>>> {
   const trimmed = soql.trim();
-  const apiVersion = (api as any).apiVersion ?? 'v62.0';
+  const apiVersion = api.apiVersion;
 
   // SOSL search mode
   if (trimmed.toLowerCase().startsWith('find')) {
@@ -257,7 +268,7 @@ async function runQuery(
 
   // GraphQL query mode
   if (trimmed.startsWith('{') || trimmed.toLowerCase().startsWith('query')) {
-    const response = await api.apiRequest<{ data: any; errors?: Array<{ message?: string }> }>(
+    const response = await api.apiRequest<{ data: unknown; errors?: Array<{ message?: string }> }>(
       'POST',
       `/services/data/${apiVersion}/graphql`,
       { query: soql }
@@ -269,26 +280,28 @@ async function runQuery(
         .filter((m): m is string => typeof m === 'string' && m.length > 0);
       throw new Error(messages.length > 0 ? messages.join('\n') : 'GraphQL query failed.');
     }
-    const records: any[] = [];
+    const isRecord = (v: unknown): v is Record<string, unknown> =>
+      typeof v === 'object' && v !== null && !Array.isArray(v);
+    const records: Record<string, unknown>[] = [];
     if (response?.data) {
-      const findNodes = (obj: any) => {
-        if (!obj || typeof obj !== 'object') return;
+      const findNodes = (obj: unknown): void => {
         if (Array.isArray(obj)) {
           for (const item of obj) {
-            if (item && item.node) {
+            if (isRecord(item) && isRecord(item.node)) {
               records.push(item.node);
             } else {
               findNodes(item);
             }
           }
-        } else {
+        } else if (isRecord(obj)) {
           for (const key of Object.keys(obj)) {
-            if (key === 'edges' && Array.isArray(obj[key])) {
-              for (const edge of obj[key]) {
-                if (edge && edge.node) records.push(edge.node);
+            const value = obj[key];
+            if (key === 'edges' && Array.isArray(value)) {
+              for (const edge of value) {
+                if (isRecord(edge) && isRecord(edge.node)) records.push(edge.node);
               }
             } else {
-              findNodes(obj[key]);
+              findNodes(value);
             }
           }
         }
@@ -296,7 +309,7 @@ async function runQuery(
       findNodes(response.data);
     }
     return {
-      records: records.length > 0 ? records : [response as any],
+      records: records.length > 0 ? records : [(response ?? {}) as Record<string, unknown>],
       done: true,
     };
   }
@@ -912,8 +925,8 @@ export function createSoqlRunnerFeature(options: SoqlRunnerOptions = {}): Featur
         return i;
       }
       
-      function resultsSort(a: any, b: any) {
-        return sortRank(a.value, a.title) - sortRank(b.value, b.title) || a.rank - b.rank || a.value.localeCompare(b.value);
+      function resultsSort(a: AutocompleteSuggestion, b: AutocompleteSuggestion) {
+        return sortRank(a.value, a.title) - sortRank(b.value, b.title) || (a.rank ?? 0) - (b.rank ?? 0) || a.value.localeCompare(b.value);
       }
 
       const textBefore = query.substring(0, replaceStart);
@@ -1156,7 +1169,7 @@ export function createSoqlRunnerFeature(options: SoqlRunnerOptions = {}): Featur
           return;
         }
 
-        const suggestions: any[] = [];
+        const suggestions: AutocompleteSuggestion[] = [];
         for (const { field } of contextValueFields) {
           for (const pv of field.picklistValues) {
             if (!inValuesUtilized.includes(pv.value.toLowerCase())) {
@@ -1276,7 +1289,7 @@ export function createSoqlRunnerFeature(options: SoqlRunnerOptions = {}): Featur
         return;
       }
 
-      const fieldSuggestions: any[] = [];
+      const fieldSuggestions: AutocompleteSuggestion[] = [];
       for (const desc of contextSobjectDescribes) {
         const fields = desc.fields.filter(
           field => field.name.toLowerCase().includes(searchTerm.toLowerCase()) || field.label.toLowerCase().includes(searchTerm.toLowerCase())
@@ -1332,7 +1345,7 @@ export function createSoqlRunnerFeature(options: SoqlRunnerOptions = {}): Featur
       });
     }
 
-    function getIconForSuggestion(type: string, dataType: string): string {
+    function getIconForSuggestion(type: string, dataType: string | undefined): string {
       if (type === 'object') return '📦';
       if (type === 'relationshipName') return '🔗';
       if (type === 'variable') return '⚙️';
@@ -1366,7 +1379,7 @@ export function createSoqlRunnerFeature(options: SoqlRunnerOptions = {}): Featur
       return '🔹';
     }
 
-    function renderAutocompleteUI(data: { sobjectName: string; title: string; results: any[] }) {
+    function renderAutocompleteUI(data: { sobjectName: string; title: string; results: AutocompleteSuggestion[] }) {
       autocompleteTitle.textContent = data.title || '\u00A0';
       
       while (autocompleteResults.firstChild) {
@@ -1410,7 +1423,7 @@ export function createSoqlRunnerFeature(options: SoqlRunnerOptions = {}): Featur
       }
     }
 
-    function onAutocompleteClick(item: any) {
+    function onAutocompleteClick(item: AutocompleteSuggestion) {
       if (item.value === 'Retry') {
         describeCache.clear();
         void runAutocomplete();

--- a/extension/features/trigger-conflicts.ts
+++ b/extension/features/trigger-conflicts.ts
@@ -9,7 +9,7 @@ import { CONTEXTS } from '../lib/context-detector.js';
 import { escapeSoql } from '../lib/escape.js';
 import { getSalesforceApi, type SalesforceApiClient } from '../lib/salesforce-api.js';
 import { loadSettings } from '../lib/settings.js';
-import { createBridgeClient } from '../lib/sfdt-bridge.js';
+import { createBridgeClient, LONG_RUNNING_TIMEOUT_MS } from '../lib/sfdt-bridge.js';
 import { showToast } from '../ui/toast.js';
 
 interface FlowDefinitionRecord {
@@ -322,7 +322,9 @@ async function dispatchRollback(
     localhostPort: settings.bridge.localhostPort,
     connectNativeImpl: chrome.runtime?.connectNative?.bind(chrome.runtime),
   });
-  return bridge.call({ kind: 'rollback', flowApiName, toVersion });
+  // Rollback runs real `sf` CLI work server-side — give it far longer than
+  // the default request timeout.
+  return bridge.call({ kind: 'rollback', flowApiName, toVersion }, { timeoutMs: LONG_RUNNING_TIMEOUT_MS });
 }
 
 function describeBridgeError(response: SfdtResponse): string {

--- a/extension/lib/feature-registry.ts
+++ b/extension/lib/feature-registry.ts
@@ -2,6 +2,7 @@
 // without double-initialising on the same URL.
 
 import type { Context } from './context-detector.js';
+import { showToast } from '../ui/toast.js';
 
 export type FeatureId = string;
 
@@ -75,6 +76,8 @@ export function createFeatureRegistry(options: {
   /** Defaults to chrome.runtime.getManifest().permissions; empty in non-extension surfaces (treats everything as missing). */
   manifestPermissions?: readonly chrome.runtime.ManifestPermissions[];
   track?: TrackFn;
+  /** Shown when a feature fails to initialise. Defaults to a toast; no-op without a DOM. */
+  notify?: (message: string) => void;
 } = {}): FeatureRegistry {
   const logger: RegistryLogger = options.logger ?? {
     log: (msg, ...rest) => console.log(`[SFUT] ${msg}`, ...rest),
@@ -83,6 +86,21 @@ export function createFeatureRegistry(options: {
   const log = (msg: string, ...rest: unknown[]): void => logger.log(msg, ...rest);
   const warn = (msg: string, ...rest: unknown[]): void => logger.warn(msg, ...rest);
   const track: TrackFn = options.track ?? (() => {});
+  const notify: (message: string) => void =
+    options.notify ??
+    ((message) => {
+      // The registry also runs in tests and the options page; only toast when
+      // a document is available, and never let the toast break init flow.
+      if (typeof document === 'undefined' || !document.body) return;
+      try {
+        showToast(message, { kind: 'warning' });
+      } catch {
+        // ignore — the console log above is the source of truth
+      }
+    });
+  // One toast per feature per page load — init retries on every SPA route
+  // change, and a persistently broken feature must not spam the user.
+  const initFailureNotified = new Set<FeatureId>();
 
   const manifestPermissions: ReadonlySet<string> = new Set(
     options.manifestPermissions ?? readManifestPermissions(),
@@ -169,6 +187,12 @@ export function createFeatureRegistry(options: {
         } catch (err) {
           log(`Error initialising feature '${id}': ${(err as Error).message}`, err);
           void track('feature.errored', { featureId: id });
+          if (!initFailureNotified.has(id)) {
+            initFailureNotified.add(id);
+            notify(
+              `sfdt: feature '${feature.manifest.name}' failed to start — see console for details`,
+            );
+          }
         }
       }
     },

--- a/extension/lib/killswitch-cache.ts
+++ b/extension/lib/killswitch-cache.ts
@@ -1,19 +1,31 @@
-// Cache is honoured indefinitely — better to keep a known-broken feature
-// disabled than have it reappear when the bridge is offline. ts is stored
-// for a future age-out pass.
+// The cache is a fallback for when the bridge ping fails. Entries are
+// stamped with a storedAt timestamp (`ts`) at write time; reads treat
+// anything older than 24h as stale and ignore it, falling back to the same
+// safe default as "no cache" (nothing remotely disabled). This stops a
+// bridge that has been offline since install — or a long-abandoned cache —
+// from pinning features off (or on) forever. Records without a valid `ts`
+// (pre-stamping writes, manual tampering) are treated as stale too: their
+// age is unknowable, and the next successful ping rewrites a stamped record.
 
 const STORAGE_KEY = 'sfut.killswitch.cache';
+
+/** Cache entries older than this are ignored on read. */
+export const KILL_SWITCH_CACHE_MAX_AGE_MS = 24 * 60 * 60 * 1000;
 
 interface CacheRecord {
   disabled: string[];
   ts: number;
 }
 
-export async function readKillSwitchCache(): Promise<readonly string[]> {
+export async function readKillSwitchCache(now: number = Date.now()): Promise<readonly string[]> {
   return new Promise((resolve) => {
     chrome.storage.local.get(STORAGE_KEY, (result) => {
       const raw = result?.[STORAGE_KEY] as CacheRecord | undefined;
       if (!raw || !Array.isArray(raw.disabled)) return resolve([]);
+      // Stale or un-stamped → behave exactly as if no cache existed.
+      if (typeof raw.ts !== 'number' || now - raw.ts > KILL_SWITCH_CACHE_MAX_AGE_MS) {
+        return resolve([]);
+      }
       resolve(raw.disabled.filter((v) => typeof v === 'string' && v.length > 0));
     });
   });

--- a/extension/lib/salesforce-api.ts
+++ b/extension/lib/salesforce-api.ts
@@ -47,6 +47,60 @@ interface Session {
   candidates: SessionCandidate[];
 }
 
+interface RequestFailure {
+  baseUrl: string;
+  status: number;
+  errorText: string;
+}
+
+// Salesforce REST error bodies are usually JSON like
+// [{"message":"...","errorCode":"..."}]; pull out the human-readable message
+// so user-facing errors stay short instead of dumping raw JSON.
+function extractErrorDetail(errorText: string): string {
+  if (!errorText) return '';
+  try {
+    const parsed = JSON.parse(errorText) as unknown;
+    const first = Array.isArray(parsed) ? (parsed[0] as unknown) : parsed;
+    if (
+      first &&
+      typeof first === 'object' &&
+      'message' in first &&
+      typeof (first as { message: unknown }).message === 'string'
+    ) {
+      return (first as { message: string }).message;
+    }
+  } catch {
+    // not JSON — fall through to the raw text
+  }
+  return errorText.length > 200 ? `${errorText.slice(0, 200)}…` : errorText;
+}
+
+// Multi-host failures log the full per-host breakdown to the console for
+// debugging; the thrown Error stays short because callers surface
+// err.message directly in user-facing toasts and error panels.
+function buildRequestError(operation: string, endpoint: string, errors: RequestFailure[]): Error {
+  const primary = errors.find((e) => e.status >= 400 && e.status !== 401) ?? errors[0]!;
+  console.error(
+    `[SFDT] Salesforce ${operation} ${endpoint} failed:`,
+    errors
+      .map((e) => `${e.baseUrl} -> ${e.status || 'network error'}${e.errorText ? ` (${e.errorText})` : ''}`)
+      .join('; '),
+  );
+  const detail = extractErrorDetail(primary.errorText);
+  const summary = primary.status > 0 ? `HTTP ${primary.status}` : 'network error';
+  return new Error(`Salesforce ${operation} failed (${summary})${detail ? `: ${detail}` : ''}`);
+}
+
+// SOAP responses may namespace-prefix every element (<soapenv:Envelope>
+// wrapping <ns:queryResponse xmlns:ns="...">). CSS selectors cannot express
+// namespace prefixes, so match on localName instead of querySelector().
+function findElementByLocalName(doc: Document, localName: string): Element | null {
+  for (const el of Array.from(doc.getElementsByTagName('*'))) {
+    if (el.localName === localName) return el;
+  }
+  return null;
+}
+
 function defaultMessageBus(): MessageBus {
   return {
     sendMessage(message, timeoutMs = SEND_MESSAGE_TIMEOUT_MS) {
@@ -84,7 +138,7 @@ function maybeDecodeSid(sid: string): string {
 }
 
 export class SalesforceApiClient {
-  private readonly apiVersion: string;
+  readonly apiVersion: string;
   private readonly win: Window;
   private readonly bus: MessageBus;
   private readonly fetchImpl: typeof fetch;
@@ -155,7 +209,7 @@ export class SalesforceApiClient {
 
     const queryString =
       Object.keys(params).length > 0 ? `?${new URLSearchParams(params).toString()}` : '';
-    const errors: Array<{ baseUrl: string; status: number; errorText: string }> = [];
+    const errors: RequestFailure[] = [];
 
     for (const { baseUrl, sid } of session.candidates) {
       try {
@@ -181,13 +235,7 @@ export class SalesforceApiClient {
       return this.apiGet<T>(endpoint, params, { retryOn401: false });
     }
 
-    const primary = errors.find((e) => e.status >= 400 && e.status !== 401) ?? errors[0]!;
-    throw new Error(
-      `Salesforce API error: ${primary.baseUrl} -> ${primary.status}. ` +
-        `Details: ${primary.errorText}. All results: ${errors
-          .map((e) => `${e.baseUrl} -> ${e.status}`)
-          .join(', ')}`,
-    );
+    throw buildRequestError('GET request', endpoint, errors);
   }
 
   async apiRequest<T = unknown>(
@@ -203,7 +251,7 @@ export class SalesforceApiClient {
     const session = await this.getSession();
     if (!session) throw new Error('No Salesforce session available');
 
-    const errors: Array<{ baseUrl: string; status: number; errorText: string }> = [];
+    const errors: RequestFailure[] = [];
 
     for (const { baseUrl, sid } of session.candidates) {
       try {
@@ -238,13 +286,7 @@ export class SalesforceApiClient {
       return this.apiRequest<T>(method, endpoint, body, { retryOn401: false });
     }
 
-    const primary = errors.find((e) => e.status >= 400 && e.status !== 401) ?? errors[0]!;
-    throw new Error(
-      `Salesforce API error: ${primary.baseUrl} -> ${primary.status}. ` +
-        `Details: ${primary.errorText}. All results: ${errors
-          .map((e) => `${e.baseUrl} -> ${e.status}`)
-          .join(', ')}`,
-    );
+    throw buildRequestError(`${method} request`, endpoint, errors);
   }
 
   apiPatch<T = unknown>(endpoint: string, body: unknown): Promise<T | null> {
@@ -254,8 +296,8 @@ export class SalesforceApiClient {
   async apiSoap<T = unknown>(
     apiName: 'Partner' | 'Metadata' | 'Tooling' | 'Enterprise' | 'Apex',
     method: string,
-    args: any,
-    options: { retryOn401?: boolean; headers?: Record<string, any> } = {},
+    args: unknown,
+    options: { retryOn401?: boolean; headers?: Record<string, unknown> } = {},
   ): Promise<T> {
     const retryOn401 = options.retryOn401 ?? true;
     const session = await this.getSession();
@@ -290,7 +332,7 @@ export class SalesforceApiClient {
     };
 
     const wsdl = wsdls[apiName];
-    const errors: Array<{ baseUrl: string; status: number; errorText: string }> = [];
+    const errors: RequestFailure[] = [];
 
     for (const { baseUrl, sid } of session.candidates) {
       try {
@@ -328,7 +370,7 @@ export class SalesforceApiClient {
         if (res.ok) {
           const text = await res.text();
           const doc = new DOMParser().parseFromString(text, "text/xml");
-          const responseBody = doc.querySelector(method + "Response");
+          const responseBody = findElementByLocalName(doc, method + "Response");
           if (!responseBody) {
             throw new Error(`Response body missing ${method}Response`);
           }
@@ -340,7 +382,7 @@ export class SalesforceApiClient {
         let faultString = '';
         try {
           const doc = new DOMParser().parseFromString(errorText, "text/xml");
-          faultString = doc.querySelector("faultstring")?.textContent ?? '';
+          faultString = findElementByLocalName(doc, "faultstring")?.textContent ?? '';
         } catch {}
         errors.push({ baseUrl, status: res.status, errorText: faultString || errorText });
       } catch (err) {
@@ -360,10 +402,13 @@ export class SalesforceApiClient {
     }
 
     const primary = errors.find((e) => e.status >= 400 && e.status !== 401) ?? errors[0]!;
-    const err = new Error(primary.errorText || `SOAP error ${primary.status}`);
+    const err = new Error(primary.errorText || `SOAP error ${primary.status}`) as Error & {
+      status?: number;
+      detail?: string;
+    };
     err.name = "SalesforceSoapError";
-    (err as any).status = primary.status;
-    (err as any).detail = primary.errorText;
+    err.status = primary.status;
+    err.detail = primary.errorText;
     throw err;
   }
 

--- a/extension/lib/sfdt-bridge.ts
+++ b/extension/lib/sfdt-bridge.ts
@@ -13,6 +13,7 @@ import type {
   ProtocolNegotiation,
 } from '@sfdt/flow-core/bridge-contract';
 import { negotiateProtocolVersion } from '@sfdt/flow-core/bridge-contract';
+import type { BridgeFailureCategory } from './telemetry.js';
 
 const DEFAULT_TIMEOUT_MS = 8000;
 const DISCOVERY_TIMEOUT_MS = 1000;
@@ -38,6 +39,12 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+/** Emitted once per failed logical bridge call (after any retry), never per attempt. */
+export interface BridgeFailureEvent {
+  kind: string;
+  category: BridgeFailureCategory;
+}
+
 export interface BridgeOptions {
   token: string;
   preferredTransport?: 'auto' | 'localhost' | 'native';
@@ -47,6 +54,14 @@ export interface BridgeOptions {
   connectNativeImpl?: typeof chrome.runtime.connectNative;
   sendMessageImpl?: (message: unknown) => Promise<unknown>;
   timeoutMs?: number;
+  /**
+   * Fire-and-forget transport-health hook (typically telemetry). Invoked
+   * synchronously but never awaited; exceptions are swallowed so it can
+   * never alter a bridge call's result. NOT invoked for `telemetry.*`
+   * request kinds — telemetry ships through this same bridge, and counting
+   * its own failures would feed back on itself.
+   */
+  onBridgeFailure?: (failure: BridgeFailureEvent) => void;
 }
 
 type Transport = 'localhost' | 'native' | 'unknown';
@@ -126,6 +141,20 @@ export interface BridgeClient {
   ): Promise<SfdtResponse>;
 }
 
+/**
+ * Narrow runtime guard for success-response payloads. The contract types
+ * `data` as required on `ok: true`, but the wire gives no such guarantee —
+ * older or buggy servers can answer `{ ok: true }` with no data. Returns the
+ * payload as a Partial so every property access stays optional, or {} when
+ * the response failed or `data` is not an object.
+ */
+export function getBridgeData<T extends object>(response: SfdtResponse): Partial<T> {
+  if (!response.ok) return {};
+  const data: unknown = (response as { data?: unknown }).data;
+  if (data === null || typeof data !== 'object') return {};
+  return data as Partial<T>;
+}
+
 export function createBridgeClient(options: BridgeOptions): BridgeClient {
   const token = options.token;
   const preferredTransport = options.preferredTransport ?? 'auto';
@@ -140,6 +169,30 @@ export function createBridgeClient(options: BridgeOptions): BridgeClient {
   // send() short-circuits non-ping/version traffic when the bridge is on
   // an incompatible major version; ping/version stay open for diagnostics.
   let cachedNegotiation: ProtocolNegotiation | null = null;
+
+  function categorizeFailure(response: SfdtErrorResponse): BridgeFailureCategory {
+    switch (response.code) {
+      case 'BRIDGE_OFFLINE':
+        return /timed out|abort/i.test(response.error) ? 'timeout' : 'offline';
+      case 'BRIDGE_UNAUTHORIZED':
+      case 'BRIDGE_FORBIDDEN':
+        return 'unauthorized';
+      default:
+        return 'other';
+    }
+  }
+
+  // Fire-and-forget: never awaited, never throws into the caller, and never
+  // fires for telemetry's own bridge traffic (recursion guard).
+  function emitFailure(kind: string, category: BridgeFailureCategory): void {
+    if (!options.onBridgeFailure) return;
+    if (kind.startsWith('telemetry')) return;
+    try {
+      options.onBridgeFailure({ kind, category });
+    } catch {
+      // The hook must never affect bridge call results.
+    }
+  }
 
   async function sendOverLocalhost(
     request: SfdtRequest,
@@ -312,6 +365,7 @@ export function createBridgeClient(options: BridgeOptions): BridgeClient {
       request.kind !== 'ping' &&
       request.kind !== 'version'
     ) {
+      emitFailure(request.kind, 'protocol');
       return {
         ok: false,
         requestId: request.requestId,
@@ -321,6 +375,17 @@ export function createBridgeClient(options: BridgeOptions): BridgeClient {
     }
 
     const requestTimeoutMs = callOptions?.timeoutMs ?? timeoutMs;
+    const final = await sendWithRetry(request, requestTimeoutMs);
+    // One failure event per logical send(), emitted after the retry (if any)
+    // resolved — never one per attempt.
+    if (!final.ok) emitFailure(request.kind, categorizeFailure(final as SfdtErrorResponse));
+    return final;
+  }
+
+  async function sendWithRetry(
+    request: SfdtRequest,
+    requestTimeoutMs: number,
+  ): Promise<SfdtResponse> {
     const first = await sendOnce(request, requestTimeoutMs);
     if (first.ok) return first;
     // One retry, idempotent kinds only, and only for transport-level failures
@@ -371,7 +436,10 @@ export function createBridgeClient(options: BridgeOptions): BridgeClient {
     } catch {
       // fall through to native or null
     }
-    if (!connectNativeImpl) return null;
+    if (!connectNativeImpl) {
+      emitFailure('ping', 'offline');
+      return null;
+    }
     const native = await sendOverNative({ requestId: makeRequestId(), kind: 'ping' } as SfdtRequest);
     if (native.ok) {
       const data = (native as { data?: PingResponseData }).data;
@@ -387,6 +455,7 @@ export function createBridgeClient(options: BridgeOptions): BridgeClient {
         };
       }
     }
+    emitFailure('ping', 'offline');
     return null;
   }
 

--- a/extension/lib/sfdt-bridge.ts
+++ b/extension/lib/sfdt-bridge.ts
@@ -16,6 +16,27 @@ import { negotiateProtocolVersion } from '@sfdt/flow-core/bridge-contract';
 
 const DEFAULT_TIMEOUT_MS = 8000;
 const DISCOVERY_TIMEOUT_MS = 1000;
+const RETRY_DELAY_MS = 300;
+
+/** Per-call timeout for bridge operations that run real sf CLI work. */
+export const LONG_RUNNING_TIMEOUT_MS = 60000;
+
+// Read-only request kinds per the bridge contract — safe to retry once on a
+// transport failure. Mutating kinds (deploy, rollback), cost-incurring kinds
+// (ai), and write-on-server kinds (telemetry.snapshot) are deliberately
+// excluded: a retry there could double-apply the operation.
+const IDEMPOTENT_KINDS: ReadonlySet<string> = new Set([
+  'ping',
+  'version',
+  'quality',
+  'drift',
+  'scan',
+  'compare',
+]);
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
 export interface BridgeOptions {
   token: string;
@@ -69,6 +90,11 @@ async function chromeRuntimeSendMessage<T>(message: unknown): Promise<T | null> 
   });
 }
 
+export interface BridgeCallOptions {
+  /** Overrides the client-level timeout for this call only. */
+  timeoutMs?: number;
+}
+
 export interface BridgeClient {
   discover(): Promise<Transport>;
 
@@ -87,12 +113,17 @@ export interface BridgeClient {
   /**
    * Returns BRIDGE_OFFLINE with the negotiation message when a prior
    * getServerInfo detected a major protocol mismatch — ping/version are
-   * exempt so diagnostics still flow.
+   * exempt so diagnostics still flow. Idempotent (read-only) kinds are
+   * retried once after a short delay on a transport failure; mutating
+   * kinds are never retried.
    */
-  send<R extends SfdtRequest>(request: R): Promise<SfdtResponse>;
+  send<R extends SfdtRequest>(request: R, options?: BridgeCallOptions): Promise<SfdtResponse>;
 
   /** Stamps the requestId for the caller. */
-  call<R extends Omit<SfdtRequest, 'requestId'>>(request: R): Promise<SfdtResponse>;
+  call<R extends Omit<SfdtRequest, 'requestId'>>(
+    request: R,
+    options?: BridgeCallOptions,
+  ): Promise<SfdtResponse>;
 }
 
 export function createBridgeClient(options: BridgeOptions): BridgeClient {
@@ -110,7 +141,10 @@ export function createBridgeClient(options: BridgeOptions): BridgeClient {
   // an incompatible major version; ping/version stay open for diagnostics.
   let cachedNegotiation: ProtocolNegotiation | null = null;
 
-  async function sendOverLocalhost(request: SfdtRequest): Promise<SfdtResponse> {
+  async function sendOverLocalhost(
+    request: SfdtRequest,
+    requestTimeoutMs: number = timeoutMs,
+  ): Promise<SfdtResponse> {
     if (!token) {
       return {
         ok: false,
@@ -121,7 +155,7 @@ export function createBridgeClient(options: BridgeOptions): BridgeClient {
     }
     const url = `http://127.0.0.1:${port}/api/bridge/exchange`;
     const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    const timer = setTimeout(() => controller.abort(), requestTimeoutMs);
     try {
       const res = await fetchImpl(url, {
         method: 'POST',
@@ -146,7 +180,10 @@ export function createBridgeClient(options: BridgeOptions): BridgeClient {
     }
   }
 
-  async function sendOverNative(request: SfdtRequest): Promise<SfdtResponse> {
+  async function sendOverNative(
+    request: SfdtRequest,
+    requestTimeoutMs: number = timeoutMs,
+  ): Promise<SfdtResponse> {
     if (!connectNativeImpl) {
       // Tests and non-extension surfaces lack chrome.runtime.connectNative.
       return offlineResponse(request.requestId, 'Native messaging host is not available in this context.');
@@ -170,8 +207,10 @@ export function createBridgeClient(options: BridgeOptions): BridgeClient {
         } catch {
           // ignore
         }
-        resolve(offlineResponse(request.requestId, `Native host timed out after ${timeoutMs}ms.`));
-      }, timeoutMs);
+        resolve(
+          offlineResponse(request.requestId, `Native host timed out after ${requestTimeoutMs}ms.`),
+        );
+      }, requestTimeoutMs);
 
       port.onMessage.addListener((msg: SfdtResponse) => {
         clearTimeout(timer);
@@ -248,7 +287,24 @@ export function createBridgeClient(options: BridgeOptions): BridgeClient {
     }
   }
 
-  async function send(request: SfdtRequest): Promise<SfdtResponse> {
+  async function sendOnce(request: SfdtRequest, requestTimeoutMs: number): Promise<SfdtResponse> {
+    if (preferredTransport === 'localhost') return sendOverLocalhost(request, requestTimeoutMs);
+    if (preferredTransport === 'native') return sendOverNative(request, requestTimeoutMs);
+
+    const local = await sendOverLocalhost(request, requestTimeoutMs);
+    if (local.ok) return local;
+    const localCode = (local as SfdtErrorResponse).code;
+    // Any non-offline error means sfdt ui IS reachable — surface that error
+    // rather than shadowing it with a native-host attempt.
+    if (localCode && localCode !== 'BRIDGE_OFFLINE') return local;
+    if (!connectNativeImpl) return local;
+    return sendOverNative(request, requestTimeoutMs);
+  }
+
+  async function send(
+    request: SfdtRequest,
+    callOptions?: BridgeCallOptions,
+  ): Promise<SfdtResponse> {
     // Major protocol mismatch → refuse non-diagnostic traffic.
     if (
       cachedNegotiation &&
@@ -264,21 +320,22 @@ export function createBridgeClient(options: BridgeOptions): BridgeClient {
       };
     }
 
-    if (preferredTransport === 'localhost') return sendOverLocalhost(request);
-    if (preferredTransport === 'native') return sendOverNative(request);
-
-    const local = await sendOverLocalhost(request);
-    if (local.ok) return local;
-    const localCode = (local as SfdtErrorResponse).code;
-    // Any non-offline error means sfdt ui IS reachable — surface that error
-    // rather than shadowing it with a native-host attempt.
-    if (localCode && localCode !== 'BRIDGE_OFFLINE') return local;
-    if (!connectNativeImpl) return local;
-    return sendOverNative(request);
+    const requestTimeoutMs = callOptions?.timeoutMs ?? timeoutMs;
+    const first = await sendOnce(request, requestTimeoutMs);
+    if (first.ok) return first;
+    // One retry, idempotent kinds only, and only for transport-level failures
+    // (timeout / network) — BRIDGE_UNAUTHORIZED etc. won't fix themselves.
+    if (!IDEMPOTENT_KINDS.has(request.kind)) return first;
+    if ((first as SfdtErrorResponse).code !== 'BRIDGE_OFFLINE') return first;
+    await sleep(RETRY_DELAY_MS);
+    return sendOnce(request, requestTimeoutMs);
   }
 
-  async function call<R extends Omit<SfdtRequest, 'requestId'>>(req: R): Promise<SfdtResponse> {
-    return send({ ...(req as object), requestId: makeRequestId() } as SfdtRequest);
+  async function call<R extends Omit<SfdtRequest, 'requestId'>>(
+    req: R,
+    callOptions?: BridgeCallOptions,
+  ): Promise<SfdtResponse> {
+    return send({ ...(req as object), requestId: makeRequestId() } as SfdtRequest, callOptions);
   }
 
   async function getServerInfo(): Promise<{

--- a/extension/lib/telemetry.ts
+++ b/extension/lib/telemetry.ts
@@ -9,6 +9,21 @@ export type TelemetryEvent =
   | 'feature.errored'
   | 'feature.disabled.remote';
 
+/**
+ * Coarse transport-health buckets for bridge call failures.
+ *   offline      — bridge endpoint unreachable (BRIDGE_OFFLINE)
+ *   timeout      — request aborted / native host timed out
+ *   unauthorized — bearer token missing/invalid or origin rejected
+ *   protocol     — refused locally after a major protocol-version mismatch
+ *   other        — any other bridge error code
+ */
+export type BridgeFailureCategory =
+  | 'offline'
+  | 'timeout'
+  | 'unauthorized'
+  | 'protocol'
+  | 'other';
+
 export interface FeatureCounter {
   activated: number;
   errored: number;
@@ -18,10 +33,19 @@ export interface FeatureCounter {
 export interface TelemetrySnapshot {
   monthKey: string;
   counters: Record<string, FeatureCounter>;
+  /** Bridge failure counts by category. Absent on snapshots written before
+   * bridge tracking existed — readers treat undefined as all-zero. */
+  bridge?: Partial<Record<BridgeFailureCategory, number>>;
 }
 
 export interface Telemetry {
   track(event: TelemetryEvent, data: { featureId: string }): Promise<void>;
+  /**
+   * Counts a bridge transport failure. MUST never be fed by telemetry's own
+   * bridge traffic (the bridge layer filters `telemetry.*` kinds before
+   * emitting) — otherwise a dead bridge would count its own push failures.
+   */
+  trackBridgeFailure(category: BridgeFailureCategory): Promise<void>;
   snapshot(): Promise<TelemetrySnapshot>;
   /**
    * No-op when telemetry is opt-out. Returns true when the bridge accepted
@@ -88,6 +112,20 @@ export function createTelemetry(opts: {
       if (event === 'feature.activated') counter.activated += 1;
       else if (event === 'feature.errored') counter.errored += 1;
       else if (event === 'feature.disabled.remote') counter.disabled_remote += 1;
+      await write(snapshot);
+    },
+
+    async trackBridgeFailure(category) {
+      if (!opts.isEnabled()) return;
+      const today = monthKeyOf(now());
+      const existing = await read();
+      const snapshot: TelemetrySnapshot =
+        existing && existing.monthKey === today
+          ? existing
+          : { monthKey: today, counters: {} };
+      const bridge = snapshot.bridge ?? {};
+      bridge[category] = (bridge[category] ?? 0) + 1;
+      snapshot.bridge = bridge;
       await write(snapshot);
     },
 

--- a/extension/test/event-monitor.test.ts
+++ b/extension/test/event-monitor.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { createEventMonitorFeature, SalesforceBayeuxClient } from '../features/event-monitor.js';
+import { createEventMonitorFeature, SalesforceBayeuxClient, type BayeuxMessage } from '../features/event-monitor.js';
 import type { SalesforceApiClient } from '../lib/salesforce-api.js';
 
 function fakeApi(overrides: Partial<SalesforceApiClient> = {}): SalesforceApiClient {
   return {
+    apiVersion: 'v62.0',
     apiGet: vi.fn(async () => ({ records: [] })),
     toolingQuery: vi.fn(async () => ({ records: [] })),
     limits: vi.fn(async () => ({})),
@@ -95,6 +96,62 @@ describe('SalesforceBayeuxClient', () => {
     expect(statusChanges).toContain('Handshake successful. Subscribing...');
     expect(statusChanges).toContain('Listening on /event/My_Event__e...');
     expect(statusChanges).toContain('Disconnected');
+  });
+
+  it('sends a typed replay extension and delivers typed message data', async () => {
+    // Typed fixture — compiles against the exported BayeuxMessage shape,
+    // including the replay `ext` and channel-specific `data` payload.
+    const connectMessages: BayeuxMessage[] = [
+      {
+        channel: '/event/My_Event__e',
+        data: { payload: { Message__c: 'typed' }, event: { replayId: 7 } },
+        ext: { replay: { '/event/My_Event__e': 7 } },
+      },
+    ];
+
+    const sentBodies: BayeuxMessage[][] = [];
+    const fetchSpy = vi.fn(async (url, options: any) => {
+      const body = JSON.parse(options.body) as BayeuxMessage[];
+      sentBodies.push(body);
+      const channel = body[0]?.channel;
+
+      if (channel === '/meta/handshake') {
+        return {
+          ok: true,
+          json: async () => [{ channel: '/meta/handshake', clientId: 'client-123', successful: true }],
+        } as Response;
+      }
+      if (channel === '/meta/subscribe') {
+        return {
+          ok: true,
+          json: async () => [{ channel: '/meta/subscribe', successful: true }],
+        } as Response;
+      }
+      if (channel === '/meta/connect') {
+        return { ok: true, json: async () => connectMessages } as Response;
+      }
+      return { ok: true, json: async () => [{ channel: '/meta/disconnect', successful: true }] } as Response;
+    });
+
+    const client = new SalesforceBayeuxClient(
+      'https://test.salesforce.com',
+      'session-id',
+      'v62.0',
+      fetchSpy as any,
+    );
+
+    const received: unknown[] = [];
+    client.onMessage((msg) => {
+      received.push(msg);
+      void client.stop();
+    });
+
+    await client.start('/event/My_Event__e', -5);
+    await new Promise((r) => setTimeout(r, 10));
+
+    const subscribeBody = sentBodies.find((b) => b[0]?.channel === '/meta/subscribe');
+    expect(subscribeBody?.[0]?.ext?.replay).toEqual({ '/event/My_Event__e': -5 });
+    expect(received).toEqual([{ payload: { Message__c: 'typed' }, event: { replayId: 7 } }]);
   });
 
   it('stops if handshake fails', async () => {

--- a/extension/test/feature-registry.test.ts
+++ b/extension/test/feature-registry.test.ts
@@ -295,6 +295,68 @@ describe('extension/lib/feature-registry', () => {
     expect(track).toHaveBeenCalledWith('feature.errored', { featureId: 'alpha' });
   });
 
+  it('notifies once per feature per page load when init throws (no spam on route changes)', async () => {
+    const notify = vi.fn();
+    const reg = createFeatureRegistry({ logger: makeLogger(), notify });
+    reg.register({
+      manifest: { id: 'alpha', name: 'Alpha Feature', contexts: [] },
+      init: () => {
+        throw new Error('boom');
+      },
+    });
+    await reg.initForCurrentRoute(['alpha'], {
+      disabledRemote: new Set(),
+      isUserEnabled: () => true,
+    });
+    reg.resetForRouteChange('r2');
+    await reg.initForCurrentRoute(['alpha'], {
+      disabledRemote: new Set(),
+      isUserEnabled: () => true,
+    });
+    expect(notify).toHaveBeenCalledOnce();
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining('Alpha Feature'));
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining('failed to start'));
+  });
+
+  it('does not notify for teardown errors (console-only)', async () => {
+    const notify = vi.fn();
+    const reg = createFeatureRegistry({ logger: makeLogger(), notify });
+    reg.register({
+      manifest: { id: 'alpha', name: 'alpha', contexts: [] },
+      init: () => {},
+      teardown: () => {
+        throw new Error('teardown boom');
+      },
+    });
+    await reg.initForCurrentRoute(['alpha'], {
+      disabledRemote: new Set(),
+      isUserEnabled: () => true,
+    });
+    reg.resetForRouteChange('r2');
+    await reg.initForCurrentRoute(['alpha'], {
+      disabledRemote: new Set(['alpha']),
+      isUserEnabled: () => true,
+    });
+    expect(notify).not.toHaveBeenCalled();
+  });
+
+  it('default notify renders a toast into the document on init failure', async () => {
+    const reg = createFeatureRegistry({ logger: makeLogger() });
+    reg.register({
+      manifest: { id: 'alpha', name: 'Alpha Feature', contexts: [] },
+      init: () => {
+        throw new Error('boom');
+      },
+    });
+    await reg.initForCurrentRoute(['alpha'], {
+      disabledRemote: new Set(),
+      isUserEnabled: () => true,
+    });
+    const container = document.getElementById('sfut-toast-container');
+    expect(container?.textContent).toContain('Alpha Feature');
+    container?.remove();
+  });
+
   it('tracks feature.disabled.remote when a running feature is newly kill-switched', async () => {
     const track = vi.fn();
     const reg = createFeatureRegistry({ logger: makeLogger(), track });

--- a/extension/test/killswitch-cache.test.ts
+++ b/extension/test/killswitch-cache.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { readKillSwitchCache, writeKillSwitchCache } from '../lib/killswitch-cache.js';
+import {
+  readKillSwitchCache,
+  writeKillSwitchCache,
+  KILL_SWITCH_CACHE_MAX_AGE_MS,
+} from '../lib/killswitch-cache.js';
 
 describe('killswitch-cache', () => {
   beforeEach(() => {
@@ -23,8 +27,37 @@ describe('killswitch-cache', () => {
 
   it('filters non-string entries on read (defensive)', async () => {
     chrome.storage.local.set({
-      'sfut.killswitch.cache': { disabled: ['canvas-search', 42, null], ts: 0 },
+      'sfut.killswitch.cache': { disabled: ['canvas-search', 42, null], ts: Date.now() },
     } as any);
     expect(await readKillSwitchCache()).toEqual(['canvas-search']);
+  });
+
+  it('honours a fresh cache (younger than 24h)', async () => {
+    const now = Date.now();
+    chrome.storage.local.set({
+      'sfut.killswitch.cache': {
+        disabled: ['canvas-search'],
+        ts: now - (KILL_SWITCH_CACHE_MAX_AGE_MS - 60_000), // 23h59m old
+      },
+    } as any);
+    expect(await readKillSwitchCache(now)).toEqual(['canvas-search']);
+  });
+
+  it('treats a cache older than 24h as stale and falls back to the default ([])', async () => {
+    const now = Date.now();
+    chrome.storage.local.set({
+      'sfut.killswitch.cache': {
+        disabled: ['canvas-search'],
+        ts: now - (KILL_SWITCH_CACHE_MAX_AGE_MS + 60_000), // 24h01m old
+      },
+    } as any);
+    expect(await readKillSwitchCache(now)).toEqual([]);
+  });
+
+  it('treats an un-stamped legacy record (missing ts) as stale', async () => {
+    chrome.storage.local.set({
+      'sfut.killswitch.cache': { disabled: ['canvas-search'] },
+    } as any);
+    expect(await readKillSwitchCache()).toEqual([]);
   });
 });

--- a/extension/test/salesforce-api.test.ts
+++ b/extension/test/salesforce-api.test.ts
@@ -348,4 +348,135 @@ describe('extension/lib/salesforce-api', () => {
       expect(result).toBeNull();
     });
   });
+
+  describe('multi-host failure error messages', () => {
+    it('throws a short user-facing message with no candidate URL list', async () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const win = fakeWin('https://x.lightning.force.com/anything');
+      const bus = makeBus({
+        'https://x.my.salesforce.com': 'sid-mysf',
+        'https://x.lightning.force.com': 'sid-light',
+      });
+      const fetchSpy = vi.fn(
+        fetchResponder({
+          'https://x.my.salesforce.com/services/data': {
+            status: 400,
+            body: '[{"message":"unexpected token: FRM","errorCode":"MALFORMED_QUERY"}]',
+          },
+          'https://x.lightning.force.com/services/data': {
+            status: 400,
+            body: '[{"message":"unexpected token: FRM","errorCode":"MALFORMED_QUERY"}]',
+          },
+        }),
+      );
+      const client = new SalesforceApiClient({ win, messageBus: bus, fetchImpl: fetchSpy });
+      const err: Error = await client.query('SELECT Id FRM Account').then(
+        () => {
+          throw new Error('expected query to reject');
+        },
+        (e: Error) => e,
+      );
+
+      // Short, user-appropriate: operation + status + Salesforce message.
+      expect(err.message).toContain('GET request failed');
+      expect(err.message).toContain('HTTP 400');
+      expect(err.message).toContain('unexpected token: FRM');
+      // No host/URL dump in the toast-facing message.
+      expect(err.message).not.toContain('https://');
+      expect(err.message).not.toContain('All results');
+
+      // Full multi-host diagnostics still reach the console.
+      expect(consoleSpy).toHaveBeenCalled();
+      const logged = consoleSpy.mock.calls[0]!.map(String).join(' ');
+      expect(logged).toContain('https://x.my.salesforce.com');
+      expect(logged).toContain('https://x.lightning.force.com');
+      consoleSpy.mockRestore();
+    });
+
+    it('reports a network error without a fake HTTP status', async () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const win = fakeWin('https://x.lightning.force.com/anything');
+      const bus = makeBus({ 'https://x.my.salesforce.com': 'sid' });
+      const fetchSpy = vi.fn(async () => {
+        throw new Error('Failed to fetch');
+      });
+      const client = new SalesforceApiClient({ win, messageBus: bus, fetchImpl: fetchSpy as unknown as typeof fetch });
+      await expect(client.apiRequest('POST', '/services/data/v62.0/sobjects/Account', {})).rejects.toThrow(
+        /POST request failed \(network error\)/,
+      );
+      expect(consoleSpy).toHaveBeenCalled();
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('apiSoap SOAP parsing', () => {
+    function xmlFetch(status: number, xml: string): typeof fetch {
+      return (async () => ({
+        ok: status >= 200 && status < 300,
+        status,
+        async text() {
+          return xml;
+        },
+        async json() {
+          return null;
+        },
+      })) as unknown as typeof fetch;
+    }
+
+    it('parses a namespace-prefixed SOAP response body', async () => {
+      const win = fakeWin('https://x.lightning.force.com/anything');
+      const bus = makeBus({ 'https://x.my.salesforce.com': 'sid' });
+      const xml = [
+        '<?xml version="1.0" encoding="UTF-8"?>',
+        '<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">',
+        '<soapenv:Body>',
+        '<ns:getUserInfoResponse xmlns:ns="urn:partner.soap.sforce.com">',
+        '<ns:result><ns:userName>admin@example.com</ns:userName></ns:result>',
+        '</ns:getUserInfoResponse>',
+        '</soapenv:Body>',
+        '</soapenv:Envelope>',
+      ].join('');
+      const client = new SalesforceApiClient({ win, messageBus: bus, fetchImpl: xmlFetch(200, xml) });
+      const result = await client.apiSoap<{ userName: string }>('Partner', 'getUserInfo', {});
+      expect(result).toMatchObject({ userName: 'admin@example.com' });
+    });
+
+    it('parses an unprefixed (default-namespace) SOAP response body', async () => {
+      const win = fakeWin('https://x.lightning.force.com/anything');
+      const bus = makeBus({ 'https://x.my.salesforce.com': 'sid' });
+      const xml = [
+        '<?xml version="1.0" encoding="UTF-8"?>',
+        '<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">',
+        '<soapenv:Body>',
+        '<getUserInfoResponse xmlns="urn:partner.soap.sforce.com">',
+        '<result><userName>admin@example.com</userName></result>',
+        '</getUserInfoResponse>',
+        '</soapenv:Body>',
+        '</soapenv:Envelope>',
+      ].join('');
+      const client = new SalesforceApiClient({ win, messageBus: bus, fetchImpl: xmlFetch(200, xml) });
+      const result = await client.apiSoap<{ userName: string }>('Partner', 'getUserInfo', {});
+      expect(result).toMatchObject({ userName: 'admin@example.com' });
+    });
+
+    it('extracts the faultstring from a namespace-prefixed SOAP fault', async () => {
+      const win = fakeWin('https://x.lightning.force.com/anything');
+      const bus = makeBus({ 'https://x.my.salesforce.com': 'sid' });
+      const faultXml = [
+        '<?xml version="1.0" encoding="UTF-8"?>',
+        '<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">',
+        '<soapenv:Body>',
+        '<soapenv:Fault>',
+        '<soapenv:faultcode>sf:INVALID_TYPE</soapenv:faultcode>',
+        '<soapenv:faultstring>INVALID_TYPE: sObject type Bogus is not supported</soapenv:faultstring>',
+        '</soapenv:Fault>',
+        '</soapenv:Body>',
+        '</soapenv:Envelope>',
+      ].join('');
+      const client = new SalesforceApiClient({ win, messageBus: bus, fetchImpl: xmlFetch(500, faultXml) });
+      await expect(client.apiSoap('Partner', 'describeSObject', { sObjectType: 'Bogus' })).rejects.toThrow(
+        'INVALID_TYPE: sObject type Bogus is not supported',
+      );
+    });
+  });
 });

--- a/extension/test/sfdt-bridge.test.ts
+++ b/extension/test/sfdt-bridge.test.ts
@@ -214,3 +214,97 @@ describe('createBridgeClient — protocol negotiation', () => {
     expect(client.getNegotiation()).toBeNull();
   });
 });
+
+describe('createBridgeClient — retries and per-call timeout', () => {
+  function okResponse(requestId: string, data: unknown = { version: '0.9.0' }) {
+    return new Response(JSON.stringify({ ok: true, requestId, data }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  }
+
+  it('retries an idempotent kind once after a transport failure', async () => {
+    const fetchSpy = vi.fn(async () => {
+      if (fetchSpy.mock.calls.length === 1) throw new Error('network down');
+      return okResponse('r1');
+    });
+    const client = createBridgeClient({
+      token: 'token-x',
+      preferredTransport: 'localhost',
+      fetchImpl: fetchSpy as unknown as typeof fetch,
+    });
+    const res = await client.send({ requestId: 'r1', kind: 'version' });
+    expect(res.ok).toBe(true);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('gives up after the single retry when the transport keeps failing', async () => {
+    const fetchSpy = vi.fn(async () => {
+      throw new Error('network down');
+    });
+    const client = createBridgeClient({
+      token: 'token-x',
+      preferredTransport: 'localhost',
+      fetchImpl: fetchSpy as unknown as typeof fetch,
+    });
+    const res = await client.send({ requestId: 'r1', kind: 'ping' });
+    expect(res.ok).toBe(false);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('does NOT retry a mutating kind on transport failure', async () => {
+    const fetchSpy = vi.fn(async () => {
+      throw new Error('network down');
+    });
+    const client = createBridgeClient({
+      token: 'token-x',
+      preferredTransport: 'localhost',
+      fetchImpl: fetchSpy as unknown as typeof fetch,
+    });
+    const res = await client.send({
+      requestId: 'r2',
+      kind: 'deploy',
+      flowApiName: 'My_Flow',
+    });
+    expect(res.ok).toBe(false);
+    expect(fetchSpy).toHaveBeenCalledOnce();
+  });
+
+  it('does NOT retry non-transport errors (missing token short-circuits once)', async () => {
+    const fetchSpy = vi.fn(async () => okResponse('r3'));
+    const client = createBridgeClient({
+      token: '', // → BRIDGE_UNAUTHORIZED before any fetch
+      preferredTransport: 'localhost',
+      fetchImpl: fetchSpy as unknown as typeof fetch,
+    });
+    const res = await client.send({ requestId: 'r3', kind: 'ping' });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.code).toBe('BRIDGE_UNAUTHORIZED');
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('honours a per-call timeoutMs override over the 8s default', async () => {
+    // Never resolves except via abort — only the per-call 50ms timeout can
+    // bring this test home before the suite timeout.
+    const fetchSpy = vi.fn(
+      (_url: string, init: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init.signal?.addEventListener('abort', () => reject(new Error('aborted')));
+        }),
+    );
+    const client = createBridgeClient({
+      token: 'token-x',
+      preferredTransport: 'localhost',
+      fetchImpl: fetchSpy as unknown as typeof fetch,
+    });
+    const started = Date.now();
+    const res = await client.send(
+      { requestId: 'r4', kind: 'deploy', flowApiName: 'My_Flow' },
+      { timeoutMs: 50 },
+    );
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.code).toBe('BRIDGE_OFFLINE');
+    expect(Date.now() - started).toBeLessThan(4000);
+    expect(fetchSpy).toHaveBeenCalledOnce();
+  });
+});

--- a/extension/test/sfdt-bridge.test.ts
+++ b/extension/test/sfdt-bridge.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { createBridgeClient } from '../lib/sfdt-bridge.js';
+import { createBridgeClient, getBridgeData, type BridgeFailureEvent } from '../lib/sfdt-bridge.js';
 
 /**
  * Build a sendMessage stub that returns the given bridgePing response shape.
@@ -306,5 +306,158 @@ describe('createBridgeClient — retries and per-call timeout', () => {
     if (!res.ok) expect(res.code).toBe('BRIDGE_OFFLINE');
     expect(Date.now() - started).toBeLessThan(4000);
     expect(fetchSpy).toHaveBeenCalledOnce();
+  });
+});
+
+describe('createBridgeClient — bridge failure telemetry hook', () => {
+  it('emits ONE offline event per logical call even when the idempotent retry also fails', async () => {
+    const onBridgeFailure = vi.fn((_f: BridgeFailureEvent) => {});
+    const fetchSpy = vi.fn(async () => {
+      throw new Error('network down');
+    });
+    const client = createBridgeClient({
+      token: 'token-x',
+      preferredTransport: 'localhost',
+      fetchImpl: fetchSpy as unknown as typeof fetch,
+      onBridgeFailure,
+    });
+    const res = await client.send({ requestId: 'r1', kind: 'version' });
+    expect(res.ok).toBe(false);
+    expect(fetchSpy).toHaveBeenCalledTimes(2); // two attempts…
+    expect(onBridgeFailure).toHaveBeenCalledOnce(); // …one event
+    expect(onBridgeFailure).toHaveBeenCalledWith({ kind: 'version', category: 'offline' });
+  });
+
+  it('emits unauthorized when the bearer token is missing', async () => {
+    const onBridgeFailure = vi.fn((_f: BridgeFailureEvent) => {});
+    const client = createBridgeClient({
+      token: '',
+      preferredTransport: 'localhost',
+      fetchImpl: vi.fn() as unknown as typeof fetch,
+      onBridgeFailure,
+    });
+    const res = await client.send({ requestId: 'r2', kind: 'ping' });
+    expect(res.ok).toBe(false);
+    expect(onBridgeFailure).toHaveBeenCalledOnce();
+    expect(onBridgeFailure).toHaveBeenCalledWith({ kind: 'ping', category: 'unauthorized' });
+  });
+
+  it('emits protocol when a major version mismatch blocks the call locally', async () => {
+    const onBridgeFailure = vi.fn((_f: BridgeFailureEvent) => {});
+    const client = createBridgeClient({
+      token: 'token-x',
+      preferredTransport: 'localhost',
+      sendMessageImpl: async () => ({
+        ok: true,
+        body: {
+          ok: true,
+          data: {
+            pong: true,
+            serverVersion: '2.0.0',
+            protocolVersion: '2.0',
+            transport: 'localhost',
+            disabledFeatures: [],
+          },
+        },
+      }),
+      onBridgeFailure,
+    });
+    await client.getServerInfo();
+    onBridgeFailure.mockClear(); // only interested in the send() below
+    const res = await client.send({ requestId: 'r3', kind: 'quality', flowXml: '{}' });
+    expect(res.ok).toBe(false);
+    expect(onBridgeFailure).toHaveBeenCalledOnce();
+    expect(onBridgeFailure).toHaveBeenCalledWith({ kind: 'quality', category: 'protocol' });
+  });
+
+  it('never emits for telemetry.* kinds (no recursion when telemetry ships over the bridge)', async () => {
+    const onBridgeFailure = vi.fn((_f: BridgeFailureEvent) => {});
+    const fetchSpy = vi.fn(async () => {
+      throw new Error('network down');
+    });
+    const client = createBridgeClient({
+      token: 'token-x',
+      preferredTransport: 'localhost',
+      fetchImpl: fetchSpy as unknown as typeof fetch,
+      onBridgeFailure,
+    });
+    const res = await client.send({
+      requestId: 'r4',
+      kind: 'telemetry.snapshot',
+      monthKey: '2026-06',
+      counters: {},
+    });
+    expect(res.ok).toBe(false);
+    expect(onBridgeFailure).not.toHaveBeenCalled();
+  });
+
+  it('does not emit on a successful call', async () => {
+    const onBridgeFailure = vi.fn((_f: BridgeFailureEvent) => {});
+    const fetchSpy = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ ok: true, requestId: 'r5', data: { version: '0.9.0' } }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+    );
+    const client = createBridgeClient({
+      token: 'token-x',
+      preferredTransport: 'localhost',
+      fetchImpl: fetchSpy as unknown as typeof fetch,
+      onBridgeFailure,
+    });
+    const res = await client.send({ requestId: 'r5', kind: 'version' });
+    expect(res.ok).toBe(true);
+    expect(onBridgeFailure).not.toHaveBeenCalled();
+  });
+
+  it('a throwing hook never affects the bridge call result', async () => {
+    const onBridgeFailure = vi.fn(() => {
+      throw new Error('hook exploded');
+    });
+    const fetchSpy = vi.fn(async () => {
+      throw new Error('network down');
+    });
+    const client = createBridgeClient({
+      token: 'token-x',
+      preferredTransport: 'localhost',
+      fetchImpl: fetchSpy as unknown as typeof fetch,
+      onBridgeFailure,
+    });
+    const res = await client.send({ requestId: 'r6', kind: 'ping' });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.code).toBe('BRIDGE_OFFLINE');
+  });
+});
+
+describe('getBridgeData', () => {
+  it('returns the payload when ok and data is an object', () => {
+    const data = getBridgeData<{ serverVersion: string }>({
+      ok: true,
+      requestId: 'r1',
+      data: { serverVersion: '0.9.0' },
+    });
+    expect(data.serverVersion).toBe('0.9.0');
+  });
+
+  it('returns {} when the response is ok but data is missing (contract violation)', () => {
+    const response = { ok: true, requestId: 'r2' } as never;
+    expect(getBridgeData<{ serverVersion: string }>(response)).toEqual({});
+  });
+
+  it('returns {} when data is not an object', () => {
+    const response = { ok: true, requestId: 'r3', data: 'oops' } as never;
+    expect(getBridgeData<{ serverVersion: string }>(response)).toEqual({});
+  });
+
+  it('returns {} for error responses', () => {
+    expect(
+      getBridgeData<{ serverVersion: string }>({
+        ok: false,
+        requestId: 'r4',
+        error: 'down',
+        code: 'BRIDGE_OFFLINE',
+      }),
+    ).toEqual({});
   });
 });

--- a/extension/test/soql-runner.test.ts
+++ b/extension/test/soql-runner.test.ts
@@ -25,6 +25,7 @@ const {
 
 function fakeApi(overrides: Partial<SalesforceApiClient> = {}): SalesforceApiClient {
   return {
+    apiVersion: 'v62.0',
     query: vi.fn(async (_soql: string) => ({
       totalSize: 0,
       done: true,

--- a/extension/test/telemetry.test.ts
+++ b/extension/test/telemetry.test.ts
@@ -57,6 +57,33 @@ describe('telemetry', () => {
     expect(counters['canvas-search']!.disabled_remote).toBe(1);
   });
 
+  describe('trackBridgeFailure', () => {
+    it('records nothing when opt-in is false', async () => {
+      const t = createTelemetry({ isEnabled: () => false });
+      await t.trackBridgeFailure('offline');
+      const snapshot = await t.snapshot();
+      expect(snapshot.bridge).toBeUndefined();
+    });
+
+    it('increments per-category bridge counters when opted in', async () => {
+      const t = createTelemetry({ isEnabled: () => true });
+      await t.trackBridgeFailure('offline');
+      await t.trackBridgeFailure('offline');
+      await t.trackBridgeFailure('unauthorized');
+      const snapshot = await t.snapshot();
+      expect(snapshot.bridge).toEqual({ offline: 2, unauthorized: 1 });
+    });
+
+    it('keeps feature counters and bridge counters in the same monthly snapshot', async () => {
+      const t = createTelemetry({ isEnabled: () => true });
+      await t.track('feature.activated', { featureId: 'canvas-search' });
+      await t.trackBridgeFailure('timeout');
+      const snapshot = await t.snapshot();
+      expect(snapshot.counters['canvas-search']?.activated).toBe(1);
+      expect(snapshot.bridge?.timeout).toBe(1);
+    });
+  });
+
   describe('pushSnapshot', () => {
     it('is a no-op (returns false) when telemetry is opted out', async () => {
       const t = createTelemetry({ isEnabled: () => false });

--- a/host/package.json
+++ b/host/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sfdt/host",
-  "version": "0.0.1",
+  "version": "0.11.0",
   "description": "Native messaging host that bridges the @sfdt/extension Chrome extension to the sfdt CLI when the sfdt ui localhost server is unavailable.",
   "private": true,
   "type": "module",

--- a/host/src/index.js
+++ b/host/src/index.js
@@ -207,7 +207,9 @@ async function dispatch(request) {
     case 'compare':
       return makeErrorResponse(
         request.requestId,
-        `Request kind "${request.kind}" is not yet implemented on the native host.`,
+        `Request kind "${request.kind}" is not available via the native messaging host, ` +
+          'which is a limited fallback transport. This operation requires the HTTP bridge: ' +
+          'run `sfdt ui` in your Salesforce project to start it, then retry.',
         'NOT_IMPLEMENTED',
       );
     default:

--- a/package-lock.json
+++ b/package-lock.json
@@ -94,7 +94,7 @@
     },
     "host": {
       "name": "@sfdt/host",
-      "version": "0.0.1",
+      "version": "0.11.0",
       "dependencies": {
         "@sfdt/flow-core": "^0.9.0"
       },
@@ -10536,11 +10536,17 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz",
-      "integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/shellwords": {
       "version": "0.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sfdt/cli",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sfdt/cli",
-      "version": "0.10.1",
+      "version": "0.11.0",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -16,7 +16,7 @@
         "packages/*"
       ],
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.29.0",
+        "@modelcontextprotocol/sdk": "~1.29.0",
         "@sfdt/flow-core": "^0.9.0",
         "ajv": "^8.20.0",
         "ajv-formats": "^3.0.1",
@@ -49,7 +49,7 @@
     },
     "extension": {
       "name": "@sfdt/extension",
-      "version": "0.0.2",
+      "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {
         "@sfdt/flow-core": "^0.9.0",
@@ -877,6 +877,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -894,6 +895,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -911,6 +913,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -928,6 +931,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -945,6 +949,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -962,6 +967,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -979,6 +985,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -996,6 +1003,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1013,6 +1021,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1030,6 +1039,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1047,6 +1057,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1064,6 +1075,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1081,6 +1093,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1098,6 +1111,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1115,6 +1129,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1132,6 +1147,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1149,6 +1165,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1166,6 +1183,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1183,6 +1201,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1200,6 +1219,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1217,6 +1237,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1234,6 +1255,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1251,6 +1273,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1268,6 +1291,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1285,6 +1309,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1302,6 +1327,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "node": ">=22.15.0"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.29.0",
+    "@modelcontextprotocol/sdk": "~1.29.0",
     "@sfdt/flow-core": "^0.9.0",
     "ajv": "^8.20.0",
     "ajv-formats": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
   "overrides": {
     "tmp": "^0.2.6",
     "uuid": "^11.1.1",
+    "shell-quote": "^1.8.4",
     "node-notifier": {
       "uuid": "^11.1.1"
     }

--- a/src/commands/manifest.js
+++ b/src/commands/manifest.js
@@ -1,7 +1,7 @@
 import fs from 'fs-extra';
 import path from 'path';
-import { execa } from 'execa';
 import { loadConfig } from '../lib/config.js';
+import { isSafeGitRef, resolveBaseRef, diffNameStatus } from '../lib/git-utils.js';
 import { isAiAvailable, runAiPrompt } from '../lib/ai.js';
 import { getPrompt } from '../lib/prompts.js';
 import { print } from '../lib/output.js';
@@ -36,13 +36,21 @@ export function registerManifestCommand(program) {
         const apiVersion = config.sourceApiVersion || '63.0';
         const manifestDir = config.manifestDir || 'manifest/release';
 
+        if (!isSafeGitRef(options.base) || !isSafeGitRef(options.head)) {
+          print.error('Invalid git ref — refs must not start with "-" or contain shell metacharacters');
+          process.exitCode = 1;
+          return;
+        }
+
         // Resolve release name
         let releaseName = options.name || options.version || null;
         if (releaseName === 'today') {
           releaseName = new Date().toISOString().slice(0, 10);
         }
-        if (releaseName && !/^[A-Za-z0-9._-]+$/.test(releaseName)) {
-          print.error('--name must contain only alphanumeric characters, dots, underscores, or hyphens');
+        // Must start alphanumeric so labels like "..." or "-x" can't produce
+        // confusing or path-traversing filenames (matches the GUI validation).
+        if (releaseName && !/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(releaseName)) {
+          print.error('--name must start with an alphanumeric character and contain only alphanumerics, dots, underscores, or hyphens');
           process.exitCode = 1;
           return;
         }
@@ -82,11 +90,7 @@ export function registerManifestCommand(program) {
           print.info(`Using merge-base ${baseRef.slice(0, 7)} as diff base`);
         }
 
-        const diffResult = await execa(
-          'git',
-          ['diff', '--name-status', baseRef, options.head, '--', ...diffPaths],
-          { cwd: projectRoot, reject: false },
-        );
+        const diffResult = await diffNameStatus(baseRef, options.head, diffPaths, projectRoot);
 
         if (diffResult.exitCode !== 0) {
           print.error(`git diff failed: ${diffResult.stderr || 'unknown error'}`);
@@ -186,20 +190,4 @@ export function registerManifestCommand(program) {
         process.exitCode = resolveExitCode(err);
       }
     });
-}
-
-/**
- * Try to resolve a base ref. If the user passed a branch name and we're on
- * a feature branch, fall back to the merge-base to avoid pulling in changes
- * that are already on main.
- */
-async function resolveBaseRef(base, head, cwd) {
-  // If the caller passed a specific commit SHA we trust it as-is.
-  if (/^[0-9a-f]{7,40}$/i.test(base)) return base;
-
-  const mergeBase = await execa('git', ['merge-base', base, head], { cwd, reject: false });
-  if (mergeBase.exitCode === 0 && mergeBase.stdout.trim()) {
-    return mergeBase.stdout.trim();
-  }
-  return base;
 }

--- a/src/commands/prDescription.js
+++ b/src/commands/prDescription.js
@@ -7,6 +7,7 @@ import { getPrompt } from '../lib/prompts.js';
 import { print } from '../lib/output.js';
 import { resolveExitCode } from '../lib/exit-codes.js';
 import { safeResolvePath } from '../lib/project-detect.js';
+import { isSafeGitRef, diffNameStatus } from '../lib/git-utils.js';
 import { parseDiffToMetadata, countMembers } from '../lib/metadata-mapper.js';
 
 const VALID_FORMATS = ['github', 'slack', 'markdown'];
@@ -28,6 +29,12 @@ export function registerPrDescriptionCommand(program) {
           print.error(
             `Unknown format "${options.format}". Valid: ${VALID_FORMATS.join(', ')}`,
           );
+          process.exitCode = 1;
+          return;
+        }
+
+        if (!isSafeGitRef(options.base) || !isSafeGitRef(options.head)) {
+          print.error('Invalid git ref — refs must not start with "-" or contain shell metacharacters');
           process.exitCode = 1;
           return;
         }
@@ -118,17 +125,11 @@ async function collectDiffContext(cwd, sourcePath, options) {
   );
 
   // Name-status diff scoped to the source root (force-app/, etc.)
-  const diff = await execa(
-    'git',
-    [
-      'diff',
-      '--name-status',
-      options.base,
-      options.head,
-      '--',
-      `${sourcePath.split('/')[0]}/`,
-    ],
-    execOpts,
+  const diff = await diffNameStatus(
+    options.base,
+    options.head,
+    [`${sourcePath.split('/')[0]}/`],
+    cwd,
   );
 
   const commits = (log.stdout || '').split('\n').filter(Boolean);

--- a/src/commands/pull.js
+++ b/src/commands/pull.js
@@ -7,6 +7,7 @@ import { loadConfig } from '../lib/config.js';
 import { fetchOrgInventory } from '../lib/org-inventory.js';
 import { initCache, getDelta, updateCache, getCacheStatus } from '../lib/pull-cache.js';
 import { parallelRetrieve } from '../lib/parallel-retrieve.js';
+import { buildSourceDirArgs } from '../lib/source-dirs.js';
 import { print } from '../lib/output.js';
 import { resolveExitCode } from '../lib/exit-codes.js';
 
@@ -50,10 +51,7 @@ async function runPull(options) {
   if (config.pullCache?.enabled === false) {
     const spinner = ora('Retrieving all metadata...').start();
     try {
-      const sourceDirArgs = (config.packageDirectories?.length
-        ? config.packageDirectories.map((d) => d.path)
-        : [config.defaultSourcePath ?? 'force-app/main/default']
-      ).flatMap((d) => ['--source-dir', d]);
+      const sourceDirArgs = buildSourceDirArgs(config);
       await execa('sf', ['project', 'retrieve', 'start', ...sourceDirArgs, '--target-org', orgAlias], { stdio: 'inherit', cwd: projectRoot });
       spinner.succeed('Retrieve complete (cache disabled)');
     } catch (err) {
@@ -99,22 +97,12 @@ async function runPull(options) {
     case 'full':
       await smartPull(config, { projectRoot, cacheDir, orgAlias, full: true, dryRun: options.dryRun });
       break;
-    case 'preview': {
-      const sourceDirArgs = (config.packageDirectories?.length
-        ? config.packageDirectories.map((d) => d.path)
-        : [config.defaultSourcePath ?? 'force-app/main/default']
-      ).flatMap((d) => ['--source-dir', d]);
-      await execa('sf', ['project', 'retrieve', 'preview', ...sourceDirArgs, '--target-org', orgAlias], { stdio: 'inherit', cwd: projectRoot });
+    case 'preview':
+      await execa('sf', ['project', 'retrieve', 'preview', ...buildSourceDirArgs(config), '--target-org', orgAlias], { stdio: 'inherit', cwd: projectRoot });
       break;
-    }
-    case 'conflict': {
-      const sourceDirArgs = (config.packageDirectories?.length
-        ? config.packageDirectories.map((d) => d.path)
-        : [config.defaultSourcePath ?? 'force-app/main/default']
-      ).flatMap((d) => ['--source-dir', d]);
-      await execa('sf', ['project', 'retrieve', 'start', '--verbose', ...sourceDirArgs, '--target-org', orgAlias], { stdio: 'inherit', cwd: projectRoot });
+    case 'conflict':
+      await execa('sf', ['project', 'retrieve', 'start', '--verbose', ...buildSourceDirArgs(config), '--target-org', orgAlias], { stdio: 'inherit', cwd: projectRoot });
       break;
-    }
     case 'reset':
       await execa('sf', ['project', 'reset', 'tracking', '--no-prompt', '--target-org', orgAlias], { stdio: 'inherit', cwd: projectRoot });
       break;

--- a/src/commands/update.js
+++ b/src/commands/update.js
@@ -55,7 +55,13 @@ export function registerUpdateCommand(program) {
 
         print.success(`sfdt updated to v${latestVersion}`);
       } catch (err) {
-        print.error(err.message);
+        print.error(`Update failed: ${err.message}`);
+        if (err.exitCode !== undefined) {
+          print.info(
+            'Common causes: no network access, or missing permission to write global npm packages. ' +
+            'Retry manually with: npm install --global @sfdt/cli@latest',
+          );
+        }
         process.exitCode = 1;
       }
     });

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -171,6 +171,18 @@ export async function loadConfig(startDir) {
         absolutePath: path.join(merged._projectRoot, d.path),
         name: d.name ?? d.path.split('/').at(-1),
       }));
+
+      // Surface missing package directories at load time rather than letting
+      // deploy/manifest/pull fail later with an opaque sf CLI error.
+      const missing = merged.packageDirectories.filter(
+        (d) => !fs.pathExistsSync(d.absolutePath),
+      );
+      if (missing.length > 0) {
+        console.warn(
+          `Warning: packageDirectories path(s) in ${SFDX_PROJECT_FILE} not found on disk: ` +
+            missing.map((d) => d.path).join(', '),
+        );
+      }
     }
   }
   merged.manifestLayout = merged.manifestLayout || 'flat';

--- a/src/lib/git-utils.js
+++ b/src/lib/git-utils.js
@@ -1,0 +1,49 @@
+import { execa } from 'execa';
+
+// Refs that start with '-' would be parsed by git as option flags rather
+// than refs; the rest of the class covers branch names, tags, SHAs, and
+// rev syntax (~, ^, @{...}, refs/heads/...).
+export const SAFE_GIT_REF_PATTERN = /^[A-Za-z0-9._/~^@:{}][A-Za-z0-9._/~^@:{}-]*$/;
+
+export function isSafeGitRef(ref) {
+  return typeof ref === 'string' && SAFE_GIT_REF_PATTERN.test(ref);
+}
+
+/**
+ * Resolve a diff base ref. If the caller passed a branch name, prefer the
+ * merge-base with head so the diff excludes changes already on the base
+ * branch. Commit SHAs are trusted as-is.
+ *
+ * @param {string} base - Base ref (branch name or SHA)
+ * @param {string} head - Head ref
+ * @param {string} cwd - Repository root
+ * @returns {Promise<string>} merge-base SHA, or `base` unchanged
+ */
+export async function resolveBaseRef(base, head, cwd) {
+  // If the caller passed a specific commit SHA we trust it as-is.
+  if (/^[0-9a-f]{7,40}$/i.test(base)) return base;
+
+  const mergeBase = await execa('git', ['merge-base', base, head], { cwd, reject: false });
+  if (mergeBase.exitCode === 0 && mergeBase.stdout.trim()) {
+    return mergeBase.stdout.trim();
+  }
+  return base;
+}
+
+/**
+ * Run `git diff --name-status <base> <head> -- <paths...>`.
+ * Does not throw on non-zero exit; callers inspect exitCode/stderr.
+ *
+ * @param {string} base
+ * @param {string} head
+ * @param {string[]} paths - Path prefixes to scope the diff
+ * @param {string} cwd - Repository root
+ * @returns {Promise<import('execa').Result>}
+ */
+export async function diffNameStatus(base, head, paths, cwd) {
+  return execa(
+    'git',
+    ['diff', '--name-status', base, head, '--', ...paths],
+    { cwd, reject: false },
+  );
+}

--- a/src/lib/gui-server/index.js
+++ b/src/lib/gui-server/index.js
@@ -807,7 +807,10 @@ export function createGuiApp(config, version, port = 7654) {
 
       const streamLines = (readable) => {
         const rl = createInterface({ input: readable, crlfDelay: Infinity });
-        rl.on('line', (line) => {
+        rl.on('line', (rawLine) => {
+          // Redact at ingest so secrets never sit in the in-memory buffer or
+          // reach the browser via the SSE stream.
+          const line = redactSensitiveData(rawLine);
           lines.push(line);
           const stripped = stripAnsi(line);
           if (!res.writableEnded && !stripped.startsWith('SFDT_LOG:')) {
@@ -863,12 +866,13 @@ export function createGuiApp(config, version, port = 7654) {
           retention: config.logRetention ?? 50,
         });
       } else {
-        // Non-structured commands (deploy, rollback) keep raw format
+        // Non-structured commands (deploy, rollback) keep raw format.
+        // Lines were already redacted at ingest in streamLines.
         const logPayload = {
           date: new Date().toISOString(),
           command,
           exitCode,
-          lines: redactSensitiveData(lines)
+          lines
         };
         const logFilePath = path.join(projectRoot, cmd.logFile);
         await fs.outputJson(logFilePath, logPayload, { spaces: 2 });
@@ -1796,7 +1800,9 @@ export function createGuiApp(config, version, port = 7654) {
       const JOB_ID_PATTERN = /Validation Job ID:\s*([A-Za-z0-9]{15,18})/;
       const streamLines = (readable) => {
         const rl = createInterface({ input: readable, crlfDelay: Infinity });
-        rl.on('line', (line) => {
+        rl.on('line', (rawLine) => {
+          // Redact at ingest so secrets never reach the buffer or the SSE stream.
+          const line = redactSensitiveData(rawLine);
           lines.push(line);
           const stripped = stripAnsi(line);
           if (!capturedValidationJobId) {

--- a/src/lib/gui-server/index.js
+++ b/src/lib/gui-server/index.js
@@ -21,6 +21,8 @@ import { loadConfig } from '../config.js';
 import { getPrompt, getAllPrompts, setPromptOverride, resetPromptOverride, interpolate } from '../prompts.js';
 import { buildScriptEnv } from '../script-runner.js';
 import { fetchOrgInventory, fetchInventory } from '../org-inventory.js';
+import { isSafeGitRef, resolveBaseRef } from '../git-utils.js';
+import { buildSourceDirArgs } from '../source-dirs.js';
 import { initCache, getDelta, updateCache } from '../pull-cache.js';
 import { parallelRetrieve } from '../parallel-retrieve.js';
 import { createCsrfToken, createOriginGuard, createRateLimiter, requireCsrfToken, requireCsrfTokenFromQueryOrHeader } from './security.js';
@@ -988,10 +990,7 @@ export function createGuiApp(config, version, port = 7654) {
           db.close();
         }
       } else if (mode === 'full') {
-        const sourceDirArgs = (config.packageDirectories?.length
-          ? config.packageDirectories.map((d) => d.path)
-          : [config.defaultSourcePath ?? 'force-app/main/default']
-        ).flatMap((d) => ['--source-dir', d]);
+        const sourceDirArgs = buildSourceDirArgs(config);
         const exitCode = await streamChild(spawn('sf', ['project', 'retrieve', 'start', ...sourceDirArgs, '--target-org', org], {
           cwd: projectRoot,
           stdio: ['ignore', 'pipe', 'pipe'],
@@ -999,10 +998,7 @@ export function createGuiApp(config, version, port = 7654) {
         const elapsed = Math.round((Date.now() - startTime) / 1000);
         emit({ type: 'result', exitCode, retrieved: 0, elapsed });
       } else if (mode === 'preview') {
-        const sourceDirArgs = (config.packageDirectories?.length
-          ? config.packageDirectories.map((d) => d.path)
-          : [config.defaultSourcePath ?? 'force-app/main/default']
-        ).flatMap((d) => ['--source-dir', d]);
+        const sourceDirArgs = buildSourceDirArgs(config);
         const exitCode = await streamChild(spawn('sf', ['project', 'retrieve', 'preview', ...sourceDirArgs, '--target-org', org], {
           cwd: projectRoot,
           stdio: ['ignore', 'pipe', 'pipe'],
@@ -1587,9 +1583,7 @@ export function createGuiApp(config, version, port = 7654) {
     if (!requireCsrfToken(req, res, csrfToken)) return;
     try {
       const { base = 'main', head = 'HEAD', package: pkg = 'all', name: releaseName } = req.body ?? {};
-      // Refs that start with '-' are git option flags (e.g. --output, -c), not refs.
-      const safeRefPattern = /^[A-Za-z0-9._/~^@:{}][A-Za-z0-9._/~^@:{}-]*$/;
-      if (!safeRefPattern.test(String(base)) || !safeRefPattern.test(String(head))) {
+      if (!isSafeGitRef(String(base)) || !isSafeGitRef(String(head))) {
         return res.status(400).json({ error: 'Invalid git ref' });
       }
       const packages = config.packageDirectories ?? [];
@@ -1599,8 +1593,7 @@ export function createGuiApp(config, version, port = 7654) {
 
       const { parseDiffToMetadata, renderPackageXml: renderXml, countMembers } = await import('../metadata-mapper.js');
 
-      const mergeBase = await execa('git', ['merge-base', base, head], { cwd: projectRoot, reject: false });
-      const baseRef = (mergeBase.exitCode === 0 && mergeBase.stdout.trim()) ? mergeBase.stdout.trim() : base;
+      const baseRef = await resolveBaseRef(base, head, projectRoot);
 
       let diffPaths;
       let diffSourcePath = sourcePath;
@@ -2339,7 +2332,7 @@ export function createGuiApp(config, version, port = 7654) {
   app.post('/api/review', apiLimiter, async (req, res) => {
     if (!requireCsrfToken(req, res, csrfToken)) return;
     const { base = 'main' } = req.body ?? {};
-    if (!/^[A-Za-z0-9._/~^@:{}][A-Za-z0-9._/~^@:{}-]*$/.test(base)) {
+    if (!isSafeGitRef(base)) {
       return res.status(400).json({ error: 'Invalid base ref' });
     }
 

--- a/src/lib/mcp-parking.js
+++ b/src/lib/mcp-parking.js
@@ -69,8 +69,9 @@ export async function parkIfNeeded(payload, config) {
     preview = preview.slice(0, 1000) + '\n... (truncated preview)';
   }
 
+  // SEP-2549 cache metadata shape (ttlMs/cacheScope) so the envelope matches
+  // the MCP 2026-07-28 RC fields rather than a parallel expiresAt timestamp.
   const ttl = parkingConfig.ttlSeconds ?? DEFAULT_TTL_SECONDS;
-  const expiresAt = new Date(Date.now() + ttl * 1000).toISOString();
 
   return {
     _parked: true,
@@ -78,7 +79,8 @@ export async function parkIfNeeded(payload, config) {
     byteSize,
     rowCount,
     preview,
-    expiresAt,
+    ttlMs: ttl * 1000,
+    cacheScope: parkingConfig.cacheScope ?? 'session',
   };
 }
 

--- a/src/lib/mcp-server.js
+++ b/src/lib/mcp-server.js
@@ -147,6 +147,40 @@ const TOOLS = [
   }
 ];
 
+// SEP-2549 cache metadata for tools/list: the catalog is a static module
+// constant that cannot change within a process, so clients may cache it
+// long-lived and share it across users.
+const TOOLS_LIST_CACHE = { ttlMs: 86_400_000, cacheScope: 'global' };
+
+// W3C Trace Context traceparent: version-traceid-parentid-flags, all lowercase hex.
+const TRACEPARENT_RE = /^[0-9a-f]{2}-[0-9a-f]{32}-[0-9a-f]{16}-[0-9a-f]{2}$/;
+const TRACESTATE_MAX_LENGTH = 512;
+
+/**
+ * Extracts W3C Trace Context from a request's `_meta`, validating shape so
+ * attacker-controlled values can't inject into audit logs. Invalid values are
+ * treated as absent.
+ *
+ * @param {object|undefined} meta - `request.params._meta`
+ * @returns {{ traceparent: string, tracestate?: string } | null}
+ */
+function extractTraceContext(meta) {
+  const traceparent = meta?.traceparent;
+  if (typeof traceparent !== 'string' || !TRACEPARENT_RE.test(traceparent)) {
+    return null;
+  }
+  const tracestate = meta.tracestate;
+  if (
+    typeof tracestate === 'string' &&
+    tracestate.length > 0 &&
+    tracestate.length <= TRACESTATE_MAX_LENGTH &&
+    !/[\r\n]/.test(tracestate)
+  ) {
+    return { traceparent, tracestate };
+  }
+  return { traceparent };
+}
+
 export class SfdtMcpServer {
   #server;
   #config;
@@ -174,11 +208,20 @@ export class SfdtMcpServer {
   #setupHandlers() {
     this.#server.setRequestHandler(ListToolsRequestSchema, async () => ({
       tools: TOOLS,
+      ttlMs: TOOLS_LIST_CACHE.ttlMs,
+      cacheScope: TOOLS_LIST_CACHE.cacheScope,
     }));
 
     this.#server.setRequestHandler(CallToolRequestSchema, async (request) => {
       const { name, arguments: args } = request.params;
-      console.error(`MCP Call: ${name} with args:`, JSON.stringify(args));
+      const trace = extractTraceContext(request.params._meta);
+      const traceSuffix = trace ? ` traceparent=${trace.traceparent}` : '';
+
+      // Log arg keys and size only — values can carry org aliases, file
+      // paths, and job IDs that must not land in audit logs.
+      const argKeys = Object.keys(args ?? {});
+      const argBytes = Buffer.byteLength(JSON.stringify(args ?? {}), 'utf8');
+      console.error(`MCP Call: ${name} argKeys=[${argKeys.join(',')}] argBytes=${argBytes}${traceSuffix}`);
 
       try {
         const result = await this.#executeTool(name, args ?? {});
@@ -186,6 +229,7 @@ export class SfdtMcpServer {
         const processed = await parkIfNeeded(result, this.#config);
 
         return {
+          ...(trace && { _meta: trace }),
           content: [
             {
               type: 'text',
@@ -194,8 +238,9 @@ export class SfdtMcpServer {
           ],
         };
       } catch (err) {
-        console.error(`Tool execution failed (${name}):`, err.stack || err.message);
+        console.error(`Tool execution failed (${name})${traceSuffix}:`, err.stack || err.message);
         return {
+          ...(trace && { _meta: trace }),
           isError: true,
           content: [
             {

--- a/src/lib/org-inventory.js
+++ b/src/lib/org-inventory.js
@@ -37,12 +37,17 @@ export async function fetchOrgInventory(
     ? metadataTypes
     : await listMetadataTypes(orgAlias);
   const inventory = new Map();
+  const failedTypes = [];
 
   for (let i = 0; i < types.length; i += BATCH_SIZE) {
     const batch = types.slice(i, i + BATCH_SIZE);
     await Promise.all(
       batch.map(async (type) => {
         const members = await listMetadataMembers(orgAlias, type);
+        if (members === null) {
+          failedTypes.push(type);
+          return;
+        }
         if (members.length > 0) {
           if (withDates) {
             inventory.set(type, new Map(members.map((m) => [m.name, m.lastModifiedDate])));
@@ -51,6 +56,15 @@ export async function fetchOrgInventory(
           }
         }
       }),
+    );
+  }
+
+  if (failedTypes.length > 0) {
+    const shown = failedTypes.slice(0, 10).join(', ');
+    const more = failedTypes.length > 10 ? ` (+${failedTypes.length - 10} more)` : '';
+    console.warn(
+      `Warning: could not list ${failedTypes.length} metadata type(s) from ${orgAlias}: ${shown}${more}. ` +
+      'Inventory may be incomplete.',
     );
   }
 
@@ -115,7 +129,8 @@ async function listMetadataMembers(orgAlias, metadataType) {
       lastModifiedDate: item.lastModifiedDate ?? '',
     }));
   } catch {
-    // Some metadata types are not retrievable; skip silently
-    return [];
+    // Some metadata types are not listable; null lets the caller distinguish
+    // "failed to list" from "type has no members" and report the gap.
+    return null;
   }
 }

--- a/src/lib/source-dirs.js
+++ b/src/lib/source-dirs.js
@@ -1,0 +1,14 @@
+/**
+ * Build repeated `--source-dir <path>` argument pairs for `sf project
+ * retrieve` commands from configured packageDirectories, falling back to
+ * the default source path.
+ *
+ * @param {object} config - Loaded sfdt config
+ * @returns {string[]} e.g. ['--source-dir', 'force-app/main/default']
+ */
+export function buildSourceDirArgs(config) {
+  const dirs = config.packageDirectories?.length
+    ? config.packageDirectories.map((d) => d.path)
+    : [config.defaultSourcePath ?? 'force-app/main/default'];
+  return dirs.flatMap((d) => ['--source-dir', d]);
+}

--- a/src/templates/sfdt.config.json
+++ b/src/templates/sfdt.config.json
@@ -34,6 +34,12 @@
       "transport": "stdio",
       "command": "sf",
       "args": ["mcp", "start"]
+    },
+    "parking": {
+      "enabled": true,
+      "thresholdBytes": 51200,
+      "ttlSeconds": 86400,
+      "cacheScope": "session"
     }
   },
   "pullCache": {

--- a/test/lib/config.test.js
+++ b/test/lib/config.test.js
@@ -1,0 +1,199 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('fs-extra', () => ({
+  default: {
+    pathExists: vi.fn(),
+    pathExistsSync: vi.fn(),
+    readJson: vi.fn(),
+  },
+}));
+
+import fs from 'fs-extra';
+import { loadConfig, validateConfig, ConfigError, getConfigDir } from '../../src/lib/config.js';
+
+const PROJECT = '/proj';
+const CONFIG_PATH = `${PROJECT}/.sfdt/config.json`;
+const SFDX_PATH = `${PROJECT}/sfdx-project.json`;
+
+const VALID_CONFIG = { defaultOrg: 'dev-org', features: { ai: false } };
+
+/**
+ * Configure the mocked filesystem. `existing` is the set of paths that exist
+ * (both sync and async checks); `json` maps path → parsed content or Error.
+ */
+function setupFs({ existing = [], json = {} } = {}) {
+  const exists = new Set(existing);
+  fs.pathExistsSync.mockImplementation((p) => exists.has(p));
+  fs.pathExists.mockImplementation(async (p) => exists.has(p));
+  fs.readJson.mockImplementation(async (p) => {
+    const value = json[p];
+    if (value === undefined) {
+      if (exists.has(p)) return {};
+      throw new Error(`ENOENT: ${p}`);
+    }
+    if (value instanceof Error) throw value;
+    return value;
+  });
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('loadConfig', () => {
+  it('loads a valid config and applies defaults', async () => {
+    setupFs({
+      existing: [SFDX_PATH, `${PROJECT}/.sfdt`, CONFIG_PATH],
+      json: { [CONFIG_PATH]: VALID_CONFIG },
+    });
+
+    const config = await loadConfig(PROJECT);
+    expect(config.defaultOrg).toBe('dev-org');
+    expect(config._configDir).toBe(`${PROJECT}/.sfdt`);
+    expect(config._projectRoot).toBe(PROJECT);
+    expect(config.manifestLayout).toBe('flat');
+    expect(config.changelogDir).toBe('changelogs');
+  });
+
+  it('walks up from a nested directory to find the project root', async () => {
+    setupFs({
+      existing: [SFDX_PATH, `${PROJECT}/.sfdt`, CONFIG_PATH],
+      json: { [CONFIG_PATH]: VALID_CONFIG },
+    });
+
+    const config = await loadConfig(`${PROJECT}/force-app/main/default`);
+    expect(config._projectRoot).toBe(PROJECT);
+  });
+
+  it('merges sibling config files like environments.json', async () => {
+    const envPath = `${PROJECT}/.sfdt/environments.json`;
+    setupFs({
+      existing: [SFDX_PATH, `${PROJECT}/.sfdt`, CONFIG_PATH, envPath],
+      json: {
+        [CONFIG_PATH]: VALID_CONFIG,
+        [envPath]: { default: 'qa', orgs: [] },
+      },
+    });
+
+    const config = await loadConfig(PROJECT);
+    expect(config.environments).toEqual({ default: 'qa', orgs: [] });
+  });
+
+  it('enriches config from sfdx-project.json', async () => {
+    setupFs({
+      existing: [
+        SFDX_PATH, `${PROJECT}/.sfdt`, CONFIG_PATH,
+        `${PROJECT}/force-app`, `${PROJECT}/force-app/marketing`,
+      ],
+      json: {
+        [CONFIG_PATH]: VALID_CONFIG,
+        [SFDX_PATH]: {
+          sourceApiVersion: '63.0',
+          packageDirectories: [
+            { path: 'force-app', default: true },
+            { path: 'force-app/marketing', name: 'mkt' },
+          ],
+        },
+      },
+    });
+
+    const config = await loadConfig(PROJECT);
+    expect(config.sourceApiVersion).toBe('63.0');
+    expect(config.defaultSourcePath).toBe('force-app/main/default');
+    expect(config.packageDirectories).toEqual([
+      { path: 'force-app', default: true, absolutePath: `${PROJECT}/force-app`, name: 'force-app' },
+      { path: 'force-app/marketing', default: false, absolutePath: `${PROJECT}/force-app/marketing`, name: 'mkt' },
+    ]);
+  });
+
+  it('warns when a packageDirectories path does not exist on disk', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    setupFs({
+      // force-app exists, ghost-pkg does not
+      existing: [SFDX_PATH, `${PROJECT}/.sfdt`, CONFIG_PATH, `${PROJECT}/force-app`],
+      json: {
+        [CONFIG_PATH]: VALID_CONFIG,
+        [SFDX_PATH]: {
+          packageDirectories: [
+            { path: 'force-app', default: true },
+            { path: 'ghost-pkg' },
+          ],
+        },
+      },
+    });
+
+    await loadConfig(PROJECT);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain('ghost-pkg');
+    expect(warnSpy.mock.calls[0][0]).not.toContain('force-app,');
+  });
+
+  it('does not warn when all packageDirectories exist', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    setupFs({
+      existing: [SFDX_PATH, `${PROJECT}/.sfdt`, CONFIG_PATH, `${PROJECT}/force-app`],
+      json: {
+        [CONFIG_PATH]: VALID_CONFIG,
+        [SFDX_PATH]: { packageDirectories: [{ path: 'force-app', default: true }] },
+      },
+    });
+
+    await loadConfig(PROJECT);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('throws ConfigError pointing at sfdt init when config.json is missing', async () => {
+    setupFs({ existing: [SFDX_PATH, `${PROJECT}/.sfdt`] });
+    await expect(loadConfig(PROJECT)).rejects.toThrow(ConfigError);
+    await expect(loadConfig(PROJECT)).rejects.toThrow(/sfdt init/);
+  });
+
+  it('throws ConfigError when config.json contains invalid JSON', async () => {
+    setupFs({
+      existing: [SFDX_PATH, `${PROJECT}/.sfdt`, CONFIG_PATH],
+      json: { [CONFIG_PATH]: new SyntaxError('Unexpected token x') },
+    });
+    await expect(loadConfig(PROJECT)).rejects.toThrow(/valid JSON/);
+  });
+
+  it('throws ConfigError when an SFDX project has no .sfdt directory', async () => {
+    setupFs({ existing: [SFDX_PATH] });
+    await expect(loadConfig(PROJECT)).rejects.toThrow(/no \.sfdt\/ directory/);
+  });
+
+  it('throws ConfigError when no project is found walking up', async () => {
+    setupFs({ existing: [] });
+    await expect(loadConfig('/elsewhere/deep/dir')).rejects.toThrow(/Could not find a Salesforce DX project/);
+  });
+});
+
+describe('validateConfig', () => {
+  it('accepts a minimal valid config', () => {
+    expect(() => validateConfig(VALID_CONFIG)).not.toThrow();
+  });
+
+  it('rejects non-object configs', () => {
+    expect(() => validateConfig(null)).toThrow(ConfigError);
+    expect(() => validateConfig('nope')).toThrow(ConfigError);
+  });
+
+  it('reports missing required keys with a sfdt init hint', () => {
+    expect(() => validateConfig({ features: {} })).toThrow(/missing required keys: defaultOrg/);
+  });
+
+  it('rejects wrong-typed fields', () => {
+    expect(() => validateConfig({ defaultOrg: 'dev', features: {}, logRetention: 'lots' }))
+      .toThrow(ConfigError);
+  });
+});
+
+describe('getConfigDir', () => {
+  it('returns the .sfdt path for a valid project', () => {
+    setupFs({ existing: [SFDX_PATH, `${PROJECT}/.sfdt`] });
+    expect(getConfigDir(PROJECT)).toBe(`${PROJECT}/.sfdt`);
+  });
+});

--- a/test/lib/git-utils.test.js
+++ b/test/lib/git-utils.test.js
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('execa', () => ({
+  execa: vi.fn(),
+}));
+
+import { execa } from 'execa';
+import { isSafeGitRef, resolveBaseRef, diffNameStatus } from '../../src/lib/git-utils.js';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe('isSafeGitRef', () => {
+  it('accepts branch names, SHAs, and rev syntax', () => {
+    expect(isSafeGitRef('main')).toBe(true);
+    expect(isSafeGitRef('feature/my-branch')).toBe(true);
+    expect(isSafeGitRef('v1.2.3')).toBe(true);
+    expect(isSafeGitRef('abc1234')).toBe(true);
+    expect(isSafeGitRef('HEAD~2')).toBe(true);
+    expect(isSafeGitRef('main@{upstream}')).toBe(true);
+  });
+
+  it('rejects refs starting with "-" (git option flags)', () => {
+    expect(isSafeGitRef('--output=/tmp/x')).toBe(false);
+    expect(isSafeGitRef('-c')).toBe(false);
+  });
+
+  it('rejects shell metacharacters, whitespace, and non-strings', () => {
+    expect(isSafeGitRef('main; rm -rf /')).toBe(false);
+    expect(isSafeGitRef('$(whoami)')).toBe(false);
+    expect(isSafeGitRef('main head')).toBe(false);
+    expect(isSafeGitRef('')).toBe(false);
+    expect(isSafeGitRef(undefined)).toBe(false);
+    expect(isSafeGitRef(null)).toBe(false);
+  });
+});
+
+describe('resolveBaseRef', () => {
+  it('returns commit SHAs as-is without invoking git', async () => {
+    const sha = 'a'.repeat(40);
+    expect(await resolveBaseRef(sha, 'HEAD', '/repo')).toBe(sha);
+    expect(await resolveBaseRef('abc1234', 'HEAD', '/repo')).toBe('abc1234');
+    expect(execa).not.toHaveBeenCalled();
+  });
+
+  it('returns the merge-base when git resolves one', async () => {
+    execa.mockResolvedValueOnce({ exitCode: 0, stdout: 'deadbee\n' });
+    const result = await resolveBaseRef('main', 'HEAD', '/repo');
+    expect(execa).toHaveBeenCalledWith(
+      'git',
+      ['merge-base', 'main', 'HEAD'],
+      { cwd: '/repo', reject: false },
+    );
+    expect(result).toBe('deadbee');
+  });
+
+  it('falls back to the base ref when merge-base fails', async () => {
+    execa.mockResolvedValueOnce({ exitCode: 1, stdout: '' });
+    expect(await resolveBaseRef('main', 'HEAD', '/repo')).toBe('main');
+  });
+});
+
+describe('diffNameStatus', () => {
+  it('runs git diff --name-status scoped to the given paths', async () => {
+    execa.mockResolvedValueOnce({ exitCode: 0, stdout: 'M\tforce-app/x', stderr: '' });
+    const result = await diffNameStatus('main', 'HEAD', ['force-app/'], '/repo');
+    expect(execa).toHaveBeenCalledWith(
+      'git',
+      ['diff', '--name-status', 'main', 'HEAD', '--', 'force-app/'],
+      { cwd: '/repo', reject: false },
+    );
+    expect(result.stdout).toContain('force-app/x');
+  });
+});

--- a/test/lib/mcp-client.test.js
+++ b/test/lib/mcp-client.test.js
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockClient = vi.hoisted(() => ({
+  connect: vi.fn(),
+  close: vi.fn(),
+  listTools: vi.fn(),
+  callTool: vi.fn(),
+}));
+
+// Function expression (not arrow) so the mock is `new`-constructible;
+// returning an object from a constructor yields that object.
+const MockClientCtor = vi.hoisted(() => vi.fn(function MockClient() { return mockClient; }));
+const MockTransportCtor = vi.hoisted(() => vi.fn());
+
+vi.mock('@modelcontextprotocol/sdk/client/index.js', () => ({
+  Client: MockClientCtor,
+}));
+
+vi.mock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
+  StdioClientTransport: MockTransportCtor,
+}));
+
+import { SalesforceMcpClient, isMcpAvailable } from '../../src/lib/mcp-client.js';
+
+const baseConfig = {
+  defaultOrg: 'dev-org',
+  mcp: { enabled: true, salesforce: { command: 'sf', args: ['mcp', 'start'] } },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockClient.connect.mockResolvedValue(undefined);
+  mockClient.close.mockResolvedValue(undefined);
+  mockClient.listTools.mockResolvedValue({ tools: [] });
+  mockClient.callTool.mockResolvedValue({ content: [] });
+});
+
+describe('isMcpAvailable', () => {
+  it('reflects config.mcp.enabled', () => {
+    expect(isMcpAvailable({ mcp: { enabled: true } })).toBe(true);
+    expect(isMcpAvailable({ mcp: { enabled: false } })).toBe(false);
+    expect(isMcpAvailable({})).toBe(false);
+  });
+});
+
+describe('SalesforceMcpClient', () => {
+  it('connects with the configured command and args', async () => {
+    const client = new SalesforceMcpClient({
+      ...baseConfig,
+      mcp: { salesforce: { command: 'custom-sf', args: ['serve'] } },
+    });
+    await client.connect();
+    expect(MockTransportCtor).toHaveBeenCalledWith({ command: 'custom-sf', args: ['serve'] });
+    expect(client.isConnected()).toBe(true);
+  });
+
+  it('defaults to `sf mcp start` when no transport config is present', async () => {
+    const client = new SalesforceMcpClient({ defaultOrg: 'dev-org' });
+    await client.connect();
+    expect(MockTransportCtor).toHaveBeenCalledWith({ command: 'sf', args: ['mcp', 'start'] });
+  });
+
+  it('does not reconnect when already connected', async () => {
+    const client = new SalesforceMcpClient(baseConfig);
+    await client.connect();
+    await client.connect();
+    expect(mockClient.connect).toHaveBeenCalledTimes(1);
+  });
+
+  it('disconnect closes the client and ignores close errors', async () => {
+    const client = new SalesforceMcpClient(baseConfig);
+    await client.connect();
+    mockClient.close.mockRejectedValueOnce(new Error('boom'));
+    await client.disconnect();
+    expect(client.isConnected()).toBe(false);
+  });
+
+  it('calls pattern-matching tools with the default org and keys results by tool name', async () => {
+    mockClient.listTools.mockResolvedValue({
+      tools: [
+        { name: 'devops__pipeline_status' },
+        { name: 'unrelated_tool' },
+      ],
+    });
+    mockClient.callTool.mockResolvedValue({ content: [{ type: 'text', text: 'ok' }] });
+
+    const client = new SalesforceMcpClient(baseConfig);
+    const result = await client.getPipelineStatus();
+
+    expect(mockClient.callTool).toHaveBeenCalledTimes(1);
+    expect(mockClient.callTool).toHaveBeenCalledWith({
+      name: 'devops__pipeline_status',
+      arguments: { targetOrg: 'dev-org' },
+    });
+    expect(result).toEqual({ devops__pipeline_status: [{ type: 'text', text: 'ok' }] });
+  });
+
+  it('returns null when no tools match the patterns', async () => {
+    mockClient.listTools.mockResolvedValue({ tools: [{ name: 'unrelated' }] });
+    const client = new SalesforceMcpClient(baseConfig);
+    expect(await client.getPipelineStatus()).toBeNull();
+  });
+
+  it('skips tools that throw and keeps successful results', async () => {
+    mockClient.listTools.mockResolvedValue({
+      tools: [{ name: 'get_work_item' }, { name: 'list_work_items' }],
+    });
+    mockClient.callTool
+      .mockRejectedValueOnce(new Error('not authorized'))
+      .mockResolvedValueOnce({ content: [{ type: 'text', text: 'items' }] });
+
+    const client = new SalesforceMcpClient(baseConfig);
+    const result = await client.getWorkItems();
+    expect(result).toEqual({ list_work_items: [{ type: 'text', text: 'items' }] });
+  });
+
+  describe('getDevOpsCenterContext', () => {
+    it('returns combined pipeline and work item data and caches it', async () => {
+      mockClient.listTools.mockResolvedValue({
+        tools: [{ name: 'devops__pipeline_status' }, { name: 'get_work_item' }],
+      });
+      mockClient.callTool.mockResolvedValue({ content: [{ type: 'text', text: 'x' }] });
+
+      const client = new SalesforceMcpClient(baseConfig);
+      const first = await client.getDevOpsCenterContext();
+      expect(first.pipeline).toBeTruthy();
+      expect(first.workItems).toBeTruthy();
+
+      const listCalls = mockClient.listTools.mock.calls.length;
+      const second = await client.getDevOpsCenterContext();
+      expect(second).toBe(first);
+      expect(mockClient.listTools.mock.calls.length).toBe(listCalls);
+    });
+
+    it('returns null when the connection fails', async () => {
+      mockClient.connect.mockRejectedValue(new Error('no sf CLI'));
+      const client = new SalesforceMcpClient(baseConfig);
+      expect(await client.getDevOpsCenterContext()).toBeNull();
+    });
+  });
+});

--- a/test/lib/mcp-parking.test.js
+++ b/test/lib/mcp-parking.test.js
@@ -74,7 +74,25 @@ describe('MCP Parking', () => {
       expect(result.ref).toMatch(/^parked:\/\/[a-f0-9-]{36}$/);
       expect(result.byteSize).toBeGreaterThan(100);
       expect(result.preview).toContain('a'.repeat(200));
-      expect(result.expiresAt).toBeDefined();
+      // SEP-2549 cache metadata shape — config sets ttlSeconds: 60
+      expect(result.ttlMs).toBe(60_000);
+      expect(result.cacheScope).toBe('session');
+      expect(result.expiresAt).toBeUndefined();
+    });
+
+    it('honors mcp.parking.cacheScope config override', async () => {
+      const scopedConfig = {
+        ...config,
+        mcp: {
+          parking: { ...config.mcp.parking, cacheScope: 'user' },
+        },
+      };
+      fs.ensureDir.mockResolvedValue(undefined);
+      fs.writeFile.mockResolvedValue(undefined);
+
+      const result = await parkIfNeeded({ data: 'a'.repeat(200) }, scopedConfig);
+      expect(result._parked).toBe(true);
+      expect(result.cacheScope).toBe('user');
     });
 
     it('handles string payload above threshold', async () => {

--- a/test/lib/mcp-server.test.js
+++ b/test/lib/mcp-server.test.js
@@ -81,6 +81,9 @@ describe('SfdtMcpServer', () => {
     const result = await handler({});
     expect(result.tools).toBeDefined();
     expect(result.tools.some((t) => t.name === 'sfdt_preflight')).toBe(true);
+    // SEP-2549 cache metadata: catalog is static, so long TTL + global scope
+    expect(result.ttlMs).toBe(86_400_000);
+    expect(result.cacheScope).toBe('global');
   });
 
   describe('call-tool actions', () => {
@@ -291,6 +294,81 @@ describe('SfdtMcpServer', () => {
       const result = await callTool('non_existent_tool', {});
       expect(result.isError).toBe(true);
       expect(result.content[0].text).toContain('Unknown tool');
+    });
+  });
+
+  describe('W3C trace context', () => {
+    const VALID_TRACEPARENT = `00-${'a'.repeat(32)}-${'b'.repeat(16)}-01`;
+    let callHandler;
+
+    beforeEach(() => {
+      callHandler = mockRegisteredHandlers.get('call-tool');
+    });
+
+    it('echoes traceparent and tracestate in result _meta on success', async () => {
+      execa.mockResolvedValueOnce({ exitCode: 0, stdout: 'ok', stderr: '' });
+
+      const result = await callHandler({
+        params: {
+          name: 'sfdt_preflight',
+          arguments: {},
+          _meta: { traceparent: VALID_TRACEPARENT, tracestate: 'vendor=x' },
+        },
+      });
+      expect(result._meta).toEqual({ traceparent: VALID_TRACEPARENT, tracestate: 'vendor=x' });
+    });
+
+    it('echoes trace context on the error path', async () => {
+      const result = await callHandler({
+        params: {
+          name: 'non_existent_tool',
+          arguments: {},
+          _meta: { traceparent: VALID_TRACEPARENT },
+        },
+      });
+      expect(result.isError).toBe(true);
+      expect(result._meta).toEqual({ traceparent: VALID_TRACEPARENT });
+    });
+
+    it('treats a malformed traceparent as absent', async () => {
+      execa.mockResolvedValueOnce({ exitCode: 0, stdout: 'ok', stderr: '' });
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const result = await callHandler({
+        params: {
+          name: 'sfdt_preflight',
+          arguments: {},
+          _meta: { traceparent: 'not-a-trace; rm -rf /' },
+        },
+      });
+      expect(result._meta).toBeUndefined();
+      const logged = errorSpy.mock.calls.flat().join(' ');
+      expect(logged).not.toContain('not-a-trace');
+      errorSpy.mockRestore();
+    });
+
+    it('omits _meta when no trace context is provided', async () => {
+      execa.mockResolvedValueOnce({ exitCode: 0, stdout: 'ok', stderr: '' });
+
+      const result = await callHandler({ params: { name: 'sfdt_preflight', arguments: {} } });
+      expect(result._meta).toBeUndefined();
+    });
+  });
+
+  describe('argument log redaction', () => {
+    it('logs arg keys but never arg values', async () => {
+      execa.mockResolvedValueOnce({ exitCode: 0, stdout: 'ok', stderr: '' });
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const callHandler = mockRegisteredHandlers.get('call-tool');
+      await callHandler({
+        params: { name: 'sfdt_validate', arguments: { targetOrg: 'SENTINEL-secret-org' } },
+      });
+
+      const logged = errorSpy.mock.calls.flat().join(' ');
+      expect(logged).toContain('targetOrg');
+      expect(logged).not.toContain('SENTINEL-secret-org');
+      errorSpy.mockRestore();
     });
   });
 });

--- a/test/lib/script-runner.test.js
+++ b/test/lib/script-runner.test.js
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('execa', () => ({
+  execa: vi.fn(),
+}));
+
+vi.mock('fs-extra', () => ({
+  default: {
+    pathExists: vi.fn(),
+    chmod: vi.fn(),
+  },
+}));
+
+import { execa } from 'execa';
+import fs from 'fs-extra';
+import { buildScriptEnv, runScript } from '../../src/lib/script-runner.js';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  fs.pathExists.mockResolvedValue(true);
+  fs.chmod.mockResolvedValue(undefined);
+  execa.mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' });
+});
+
+describe('buildScriptEnv', () => {
+  it('returns an empty object for invalid input', () => {
+    expect(buildScriptEnv(null)).toEqual({});
+    expect(buildScriptEnv('nope')).toEqual({});
+  });
+
+  it('maps core config keys with documented defaults', () => {
+    const env = buildScriptEnv({
+      _projectRoot: '/proj',
+      _configDir: '/proj/.sfdt',
+      defaultOrg: 'dev-org',
+    });
+    expect(env.SFDT_PROJECT_ROOT).toBe('/proj');
+    expect(env.SFDT_CONFIG_DIR).toBe('/proj/.sfdt');
+    expect(env.SFDT_DEFAULT_ORG).toBe('dev-org');
+    expect(env.SFDT_PROJECT_NAME).toBe('Salesforce Project');
+    expect(env.SFDT_SOURCE_PATH).toBe('force-app/main/default');
+    expect(env.SFDT_MANIFEST_DIR).toBe('manifest/release');
+    expect(env.SFDT_RELEASE_NOTES_DIR).toBe('release-notes');
+    expect(env.SFDT_COVERAGE_THRESHOLD).toBe('75');
+    expect(env.SFDT_MANIFEST_LAYOUT).toBe('flat');
+    expect(env.SFDT_CHANGELOG_DIR).toBe('changelogs');
+  });
+
+  it('maps preflight enforcement flags with their distinct default polarities', () => {
+    const env = buildScriptEnv({});
+    // Opt-in flags default to empty string
+    expect(env.SFDT_PREFLIGHT_ENFORCE_TESTS).toBe('');
+    expect(env.SFDT_PREFLIGHT_ENFORCE_BRANCH).toBe('');
+    expect(env.SFDT_PREFLIGHT_ENFORCE_CHANGELOG).toBe('');
+    expect(env.SFDT_PREFLIGHT_ENFORCE_UNTRACKED).toBe('');
+    expect(env.SFDT_PREFLIGHT_STRICT).toBe('');
+    // Opt-out flags default to 'true'
+    expect(env.SFDT_PREFLIGHT_ENFORCE_GIT_CLEAN).toBe('true');
+    expect(env.SFDT_PREFLIGHT_ENFORCE_SFDX_PROJECT).toBe('true');
+
+    const disabled = buildScriptEnv({
+      deployment: { preflight: { enforceGitClean: false, enforceSfdxProject: false, strict: true } },
+    });
+    expect(disabled.SFDT_PREFLIGHT_ENFORCE_GIT_CLEAN).toBe('false');
+    expect(disabled.SFDT_PREFLIGHT_ENFORCE_SFDX_PROJECT).toBe('false');
+    expect(disabled.SFDT_PREFLIGHT_STRICT).toBe('true');
+  });
+
+  it('flattens features into SFDT_FEATURE_* with camelCase split', () => {
+    const env = buildScriptEnv({ features: { ai: true, releaseManagement: false } });
+    expect(env.SFDT_FEATURE_AI).toBe('true');
+    expect(env.SFDT_FEATURE_RELEASE_MANAGEMENT).toBe('false');
+  });
+
+  it('flattens environments and test config lists', () => {
+    const env = buildScriptEnv({
+      environments: { default: 'qa', orgs: [{ alias: 'qa1' }, { name: 'qa2' }] },
+      testConfig: {
+        coverageThreshold: 80,
+        testLevel: 'RunLocalTests',
+        testClasses: ['ATest', 'BTest'],
+        apexClasses: ['A', 'B'],
+      },
+    });
+    expect(env.SFDT_DEFAULT_ENV).toBe('qa');
+    expect(env.SFDT_ENV_ORGS).toBe('qa1,qa2');
+    expect(env.SFDT_TEST_COVERAGE_THRESHOLD).toBe('80');
+    expect(env.SFDT_TEST_LEVEL).toBe('RunLocalTests');
+    expect(env.SFDT_TEST_CLASSES).toBe('ATest,BTest');
+    expect(env.SFDT_APEX_CLASSES).toBe('A,B');
+  });
+
+  it('serializes packageDirectories paths as a JSON array', () => {
+    const env = buildScriptEnv({
+      packageDirectories: [{ path: 'force-app/main/default' }, { path: 'force-app/mkt' }],
+    });
+    expect(JSON.parse(env.SFDT_PACKAGE_DIRS)).toEqual(['force-app/main/default', 'force-app/mkt']);
+  });
+});
+
+describe('runScript', () => {
+  const config = { _projectRoot: '/proj', defaultOrg: 'dev' };
+
+  it('throws when the script does not exist', async () => {
+    fs.pathExists.mockResolvedValue(false);
+    await expect(runScript('ops/missing.sh', config)).rejects.toThrow('Script not found');
+    expect(execa).not.toHaveBeenCalled();
+  });
+
+  it('runs the script with SFDT_ env vars and project root cwd', async () => {
+    await runScript('ops/preflight.sh', config, { env: { SFDT_TARGET_ORG: 'qa' } });
+
+    expect(fs.chmod).toHaveBeenCalled();
+    const [scriptPath, args, opts] = execa.mock.calls[0];
+    expect(scriptPath).toMatch(/scripts\/ops\/preflight\.sh$/);
+    expect(args).toEqual([]);
+    expect(opts.cwd).toBe('/proj');
+    expect(opts.env.SFDT_PROJECT_ROOT).toBe('/proj');
+    expect(opts.env.SFDT_DEFAULT_ORG).toBe('dev');
+    expect(opts.env.SFDT_TARGET_ORG).toBe('qa');
+  });
+
+  it('throws with exit code and output attached on non-zero exit', async () => {
+    execa.mockResolvedValue({ exitCode: 3, stdout: 'partial', stderr: 'boom' });
+
+    const err = await runScript('ops/preflight.sh', config).catch((e) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.message).toContain('exited with code 3');
+    expect(err.exitCode).toBe(3);
+    expect(err.stdout).toBe('partial');
+    expect(err.stderr).toBe('boom');
+  });
+
+  it('dry-run does not execute or chmod anything', async () => {
+    const result = await runScript('ops/preflight.sh', config, { dryRun: true });
+    expect(result.exitCode).toBe(0);
+    expect(execa).not.toHaveBeenCalled();
+    expect(fs.chmod).not.toHaveBeenCalled();
+  });
+});

--- a/test/lib/source-dirs.test.js
+++ b/test/lib/source-dirs.test.js
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { buildSourceDirArgs } from '../../src/lib/source-dirs.js';
+
+describe('buildSourceDirArgs', () => {
+  it('builds args from packageDirectories', () => {
+    const config = {
+      packageDirectories: [
+        { name: 'core', path: 'force-app/main/default' },
+        { name: 'marketing', path: 'force-app/marketing' },
+      ],
+    };
+    expect(buildSourceDirArgs(config)).toEqual([
+      '--source-dir', 'force-app/main/default',
+      '--source-dir', 'force-app/marketing',
+    ]);
+  });
+
+  it('falls back to defaultSourcePath when packageDirectories is empty', () => {
+    expect(buildSourceDirArgs({ packageDirectories: [], defaultSourcePath: 'src/main' }))
+      .toEqual(['--source-dir', 'src/main']);
+  });
+
+  it('falls back to the conventional default when nothing is configured', () => {
+    expect(buildSourceDirArgs({})).toEqual(['--source-dir', 'force-app/main/default']);
+  });
+});


### PR DESCRIPTION
## Summary

Two related work streams in four commits:

### 1. MCP RC alignment (`3a76009`)
Aligns the shipped sfdt MCP server and result-parking with the MCP 2026-07-28 release candidate (application-level — the pinned SDK predates the RC):

- **SDK pin tightened** `^1.29.0` → `~1.29.0` so an RC-aware SDK can't land silently via `npm install`; RELEASING.md gains a smoke-test gate for any future SDK bump
- **Parking envelope (SEP-2549):** `expiresAt` → `ttlMs` + `cacheScope` (**breaking envelope change**; new optional config key `mcp.parking.cacheScope`, default `"session"`)
- **tools/list** advertises `ttlMs: 86400000, cacheScope: "global"` (static catalog)
- **W3C Trace Context (SEP-414):** `traceparent`/`tracestate` read from `params._meta` (format-validated), included in stderr audit logs, echoed in result `_meta`
- **Security:** tool-call logging redacted to arg keys + byte size (previously logged full arg values)
- New "MCP RC Alignment" section in docs/MCP.md

### 2. Improvement-review remediation (`49f3aa9`, `6c30667`, `e530778`)
24 findings from a CLI + extension review: **21 resolved, 5 closed with rationale** (status doc in local `pr-analysis/improvement-review/`). Highlights:

**CLI**
- GUI server: log lines redacted at ingest — previously the live SSE stream sent raw (unredacted) lines to the browser
- `org-inventory`: metadata-type list failures now warn with the aggregate instead of silently returning partial inventories
- New shared libs `git-utils.js` (ref validation + merge-base resolution, now used by manifest/pr-description/GUI) and `source-dirs.js` (replaces 5 duplicated builders)
- `loadConfig` warns when `packageDirectories` paths don't exist on disk
- 45 new tests for previously-untested core libs (`config.js`, `mcp-client.js`, `script-runner.js`, + new libs)

**Extension / host**
- Bridge: per-call timeouts (deploy/rollback 60s), retry-once for idempotent kinds on transport failures only, kill-switch ping retries before flipping state
- Kill-switch cache ages out after 24h (timestamp was written but never read)
- Bridge failures tracked in telemetry by category, with recursion guard (telemetry ships over the bridge)
- User-facing API errors shortened (host/status breakdown moves to console); SOAP parsing namespace-safe; `response.data` casts replaced with a runtime guard
- Feature init failures surface a toast; host `NOT_IMPLEMENTED` errors direct users to `sfdt ui`; host version synced to CLI (0.11.0)
- Zero `any` left in soql-runner/event-monitor/salesforce-api

## Test plan
- [x] Root workspace: 1833/1833 tests, eslint clean
- [x] Extension: 339/339 vitest, `tsc --noEmit` clean
- [x] Host: 17/17
- [x] Live stdio smoke test of `sfdt mcp start`: RC fields survive the wire, `_meta` trace context round-trips, stderr log redacted
- Note: `extension/.output/` needs `npm run build:ext` before loading the extension locally