### PR TITLE
chore: release extension v0.2.0

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to `@sfdt/extension` are documented here. Format follows [Ke
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-06-16
+
+### Added
+- `export-for-prompt` — **Export Schema for Prompt**: copy a dense Markdown schema for a Salesforce object to the clipboard for pasting into an LLM prompt. Works on record pages and Lightning **Object Manager** setup pages; resolves the object from the Object Manager URL segment or the record-page key-prefix, with a Tooling `EntityDefinition` fallback for durable-id URLs, and uses the REST describe endpoint for the full field list (label, type, required, inline help).
+- `soql-runner` — **LangGraph Node generator**: a button that turns the current SOQL query and its result columns into a ready-to-paste LangGraph node definition (Pydantic result model + node stub).
+
+### Changed
+- `sfdt-bridge` — per-call `timeoutMs` option; deploy/rollback use a 60s long-running timeout; idempotent bridge kinds retry once on transport failure (mutating kinds and auth errors never retry); unsafe `response.data` casts replaced with a `getBridgeData<T>` runtime guard.
+- `salesforce-api` — user-facing request errors shortened to HTTP status + extracted Salesforce message (full per-host detail moved to `console.error`); SOAP lookups match by `localName`, so namespace-prefixed (`<soapenv:…>`) envelopes parse correctly.
+- `telemetry` — bridge failures tracked by category (offline/timeout/unauthorized/protocol/other) via an `onBridgeFailure` hook, emitted fire-and-forget.
+- `background` — kill-switch ping retries once before reporting the bridge down.
+- `feature-registry` — feature init failures surface a toast (teardown errors stay console-only).
+- DOM updates across features use `replaceChildren()` instead of `innerHTML = ''`.
+- `SalesforceApiClient.apiVersion` is now public/readonly, and remaining `any` casts in `soql-runner`/`event-monitor` were replaced with proper types.
+
+### Fixed
+- `export-for-prompt` is now reachable — it was missing from the `content.ts` ICONS map, so the menu builder dropped it and it could never activate.
+- `killswitch-cache` — cached reads age out entries older than 24h (the timestamp was written but never checked); un-stamped legacy entries are treated as stale.
+- `soql-runner`/`event-monitor` — GraphQL traversal uses type guards, fixing a latent crash on null records; `BayeuxMessage` is properly typed.
+
+### Security
+- `escapeCell` (`export-for-prompt`) escapes backslashes before pipes, closing an incomplete-Markdown-escaping issue (CodeQL `js/incomplete-sanitization`).
+- `salesforce-api` error logging passes dynamic values as separate `console.error` arguments rather than interpolating them into the format string (CodeQL `js/tainted-format-string`).
+- `generateLangGraphNode` escapes backslashes and double-quotes in the embedded SOQL so a query cannot break out of the generated Python triple-quoted string.
+- `SF_ID_RE` now matches exactly 15 or 18 characters (it previously also accepted invalid 16/17-char strings).
+
 ## [0.1.0] - 2026-06-07
 
 ### Added

--- a/extension/README.md
+++ b/extension/README.md
@@ -10,7 +10,7 @@ This is one of four workspaces in the [`sfdt` monorepo](../README.md):
 
 ---
 
-## Features (23)
+## Features (24)
 
 Every feature is opt-in (toggle off in the options page), and any feature can be remotely disabled without a Web Store re-review via `sfdt feature-flags disable <id>`.
 
@@ -30,7 +30,7 @@ Every feature is opt-in (toggle off in the options page), and any feature can be
 | `ai-assistant` | Surface AI provider answers about the current Flow (Claude / Gemini / OpenAI via bridge) | Flow Builder |
 | `subflow-graph` | SVG graph of subflow invocation relationships | Setup Flows |
 | `trigger-conflicts` | Detects overlapping record-triggered Flows that would fire on the same change | Setup Flows |
-| `soql-runner` | Run SOQL against the current org (REST or Tooling), with field/object autocomplete, history, and CSV export | Setup + Flow Builder + Trigger Explorer |
+| `soql-runner` | Run SOQL against the current org (REST or Tooling), with field/object autocomplete, history, CSV export, and a LangGraph node generator | Setup + Flow Builder + Trigger Explorer |
 | `org-limits` | Live view of the org's governor-limit usage (sorted by pressure, colour-banded) | Setup + Flow Builder + Trigger Explorer |
 | `rest-explore` | Fire arbitrary GET/POST/PATCH/PUT/DELETE against `/services/data/...` with response viewer + history | Setup + Flow Builder + Trigger Explorer |
 | `inspect-record` | Inspect a record's complete field set (including empty/system fields) via the REST API | Record page + Setup + Flow Builder |
@@ -39,6 +39,7 @@ Every feature is opt-in (toggle off in the options page), and any feature can be
 | `metadata-retrieve` | Retrieve and deploy metadata directly from the browser | Record page + Setup + Flow Builder |
 | `soap-explore` | Build and send SOAP API requests with a payload editor + response viewer | Record page + Setup + Flow Builder |
 | `event-monitor` | Subscribe to and monitor platform/streaming events live | Record page + Setup + Flow Builder |
+| `export-for-prompt` | Copy a dense Markdown schema for an object to the clipboard for pasting into an LLM prompt | Record page + Object Manager |
 
 Adding the next feature is a one-file change — see the existing modules in [`extension/features/`](./features/) and the registry in [`extension/lib/feature-registry.ts`](./lib/feature-registry.ts).
 

--- a/extension/features/soql-runner.ts
+++ b/extension/features/soql-runner.ts
@@ -255,10 +255,9 @@ export function generateLangGraphNode(soql: string, records: ReadonlyArray<Recor
 
   const fieldsDef = cols.map(c => `    ${c}: ${typeMap[c] || 'str'}`).join('\n');
 
-  return `from typing import Any, Dict, List
+  return `from typing import Any, Dict
 from langchain_core.runnables import RunnableConfig
-from langgraph.graph.message import add_messages
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
 class SoqlResult(BaseModel):
 ${fieldsDef || '    pass'}

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sfdt/extension",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Chrome MV3 extension for Salesforce Flow Builder. WXT + TypeScript. Replaces the v2.0.2 vanilla-JS extension.",
   "private": true,
   "type": "module",


### PR DESCRIPTION
## Extension Release v0.2.0

### Added
- `export-for-prompt` — copy a dense Markdown schema for an object to the clipboard for LLM prompts; works on record pages and Lightning Object Manager (Object Manager URL segment or record-page key-prefix, with a Tooling `EntityDefinition` fallback; REST describe for the full field list).
- `soql-runner` — LangGraph node generator (Pydantic result model + node stub from the current query/columns).

### Changed
- `sfdt-bridge`: per-call `timeoutMs`; 60s long-running timeout for deploy/rollback; idempotent kinds retry once on transport failure; `getBridgeData<T>` runtime guard replaces unsafe casts.
- `salesforce-api`: shorter user-facing errors; SOAP `localName` matching for namespace-prefixed envelopes.
- `telemetry`: bridge failures tracked by category via `onBridgeFailure`.
- `background`: kill-switch ping retries once; `feature-registry`: init-failure toast; DOM uses `replaceChildren()`; `apiVersion` public/readonly; `any` removed in `soql-runner`/`event-monitor`.

### Fixed
- `export-for-prompt` reachable (was missing from the `content.ts` ICONS map).
- `killswitch-cache` 24h age-out; `soql-runner`/`event-monitor` GraphQL null-record crash + typed `BayeuxMessage`.

### Security
- `escapeCell` escapes backslashes (CodeQL `js/incomplete-sanitization`).
- `salesforce-api` error logging avoids tainted format strings (CodeQL `js/tainted-format-string`).
- `generateLangGraphNode` escapes `\` and `"` so SOQL can't break out of the Python triple-quoted block.
- `SF_ID_RE` matches exactly 15 or 18 chars.

## Pre-release gates
- [x] `/pre-release-security` PASSED (report: `pr-analysis/security/2026-06-13-combined-report.md`) — whole-codebase scan incl. extension; H1 fixed
- [x] Extension test gate PASSED (`lint` / `compile` / `test:flow-core` 231 / `test:extension` 350)
- [x] Manual smoke test PASSED in Chrome against a live Salesforce org

## What happens on merge
`.github/workflows/extension.yml` will detect the `extension/package.json` bump, tag `ext-v0.2.0`, build the Chrome zip, and create a GitHub Release with the zip attached.

## Test checklist
- [x] Locally-built zip produced: `extension/.output/sfdtextension-0.2.0-chrome.zip` (199.42 kB)
- [ ] Loads as an unpacked extension in Chrome (smoke-tested pre-release)

## Notes
- Versions independently from `@sfdt/cli` (just released as 0.12.0). Does not publish `@sfdt/flow-core`.
- The diff is extension-only: `develop` and `main` are content-identical after the CLI v0.12.0 merge, so this PR carries just the extension release commit.
- Deferred review nits (tracked for follow-up): narrow `describeObject` fallback catch (no clean fix — errors carry no structured status; result already correct), and forward bridge-failure `kind` to telemetry (needs a telemetry-schema change).
