### PR TITLE
🔒 Fix potential path traversal in test log deletion

### DIFF
--- a/src/lib/gui-server/index.js
+++ b/src/lib/gui-server/index.js
@@ -437,10 +437,15 @@ export function createGuiApp(config, version, port = 7654) {
     if (!requireCsrfToken(req, res, csrfToken)) return;
     try {
       const { filename } = req.params;
-      if (!filename.endsWith('.json') || filename.includes('/') || filename.includes('..')) {
+      if (!filename.endsWith('.json') || path.basename(filename) !== filename || filename.includes('..')) {
         return res.status(400).json({ error: 'Invalid filename' });
       }
-      const filePath = path.join(logDir, 'test-results', filename);
+      const testResultsDir = path.resolve(logDir, 'test-results');
+      const filePath = path.resolve(testResultsDir, filename);
+      if (!filePath.startsWith(testResultsDir + path.sep)) {
+        return res.status(400).json({ error: 'Invalid filename' });
+      }
+
       if (!(await fs.pathExists(filePath))) return res.status(404).json({ error: 'Not found' });
       await fs.remove(filePath);
       res.json({ ok: true });

--- a/test/lib/gui-server-routes3.test.js
+++ b/test/lib/gui-server-routes3.test.js
@@ -205,6 +205,74 @@ describe('POST /api/init — already initialized', () => {
   });
 });
 
+// ─── DELETE /api/test-runs/:filename ──────────────────────────────────────────
+
+describe('DELETE /api/test-runs/:filename', () => {
+  let app;
+
+  beforeAll(() => {
+    app = createGuiApp(MOCK_CONFIG, VERSION, PORT);
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('deletes a valid log file', async () => {
+    const fsMock = await import('fs-extra');
+    fsMock.default.pathExists.mockResolvedValueOnce(true);
+
+    const res = await request(app)
+      .delete('/api/test-runs/my-test-run.json')
+      .set('Authorization', `Bearer ${app.launchToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(fsMock.default.remove).toHaveBeenCalled();
+  });
+
+  it('rejects path traversal attempts', async () => {
+    // Note: express router naturally blocks / in params by 404ing
+    // So we test encoded slashes or backslashes which would make it into the parameter
+    const maliciousPaths = [
+      '..%5Ctest-runs%5Cmy-test-run.json', // ..\test-runs\my-test-run.json
+      '%2e%2e%2fmy-test-run.json', // ../my-test-run.json
+      'subdir%2fmy-test-run.json', // subdir/my-test-run.json
+      '..%2fmy-test-run.json' // ../my-test-run.json
+    ];
+
+    for (const p of maliciousPaths) {
+      const res = await request(app)
+        .delete(`/api/test-runs/${p}`) // already URI encoded in the strings above for slashes
+        .set('Authorization', `Bearer ${app.launchToken}`);
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('Invalid filename');
+    }
+  });
+
+  it('returns 404 for non-existent file', async () => {
+    const fsMock = await import('fs-extra');
+    fsMock.default.pathExists.mockResolvedValueOnce(false);
+
+    const res = await request(app)
+      .delete('/api/test-runs/non-existent.json')
+      .set('Authorization', `Bearer ${app.launchToken}`);
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('Not found');
+  });
+
+  it('rejects non-json files', async () => {
+    const res = await request(app)
+      .delete('/api/test-runs/not-json.txt')
+      .set('Authorization', `Bearer ${app.launchToken}`);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Invalid filename');
+  });
+});
+
 // ─── GET /api/test-runs (with data) ──────────────────────────────────────────
 
 describe('GET /api/test-runs with test results directory', () => {


### PR DESCRIPTION
🎯 **What:** The `app.delete('/api/test-runs/:filename')` endpoint was vulnerable to path traversal because the filename string checks were insufficient on Windows or when facing encoded path segments.

⚠️ **Risk:** An attacker could potentially construct malicious input (like `..\\` or URL-encoded traversals) to break out of the `test-results` directory and delete arbitrary files accessible to the application process, leading to data loss or denial of service.

🛡️ **Solution:** 
1. Added strict validation via `path.basename(filename) === filename` to categorically reject any filepath segments (slashes or backslashes).
2. Added defense-in-depth absolute path validation using `path.resolve` to verify the resulting deletion path explicitly starts with `test-results + path.sep`.
3. Extended the unit tests in `test/lib/gui-server-routes3.test.js` to assert that malformed or malicious payload deletion requests yield `400 Bad Request`.

---
*PR created automatically by Jules for task [18279912852200418742](https://jules.google.com/task/18279912852200418742) started by @scoobydrew83*