### PR TITLE
chore(deps-dev): bump undici 7.27.2 → 7.28.0 on develop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11355,9 +11355,9 @@
       "license": "ISC"
     },
     "node_modules/undici": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.2.tgz",
-      "integrity": "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Why

`undici@7.27.2` carries 7 high-severity advisories (GHSA-vmh5-mc38-953g and others). It is a **dev-only transitive** dependency (`@sfdt/gui` → `jsdom@29.1.1` → `undici`) and never ships to users — but CI's `npm audit --audit-level=high` gate fails on it, which is why **every PR into develop (incl. the just-merged #129) shows a red `test` check**.

## Why not just let Dependabot handle it

Dependabot's fix is **PR #126**, but that's a *security* update — and Dependabot security updates **always target the repository's default branch (`main`)** and can't be redirected via `target-branch`. So it never reaches develop on its own. This applies the identical lockfile bump directly to develop.

## Change

- `package-lock.json`: `undici` 7.27.2 → 7.28.0 (lockfile-only, 3 lines). jsdom permits `^7.25.0`, so 7.28.0 is in range — no other deps move.

## Verification

- `npm audit --audit-level=high` → **found 0 vulnerabilities**
- Diff is undici-only (version + resolved + integrity)