### PR TITLE
chore(extension): rename legacy sfut namespace to sfdt

### DIFF
--- a/docs/extension-smoke-test.md
+++ b/docs/extension-smoke-test.md
@@ -36,7 +36,7 @@ Produced by `npm run build:ext` from the sfdt repo root.
    - permissions: storage, clipboardWrite, cookies, scripting
    - No yellow / red error banners
 4. **Open the DevTools console** for the Salesforce tab you'll use:
-   `Cmd+Opt+I` → Console. Anything tagged `[SFUT]` should be informational;
+   `Cmd+Opt+I` → Console. Anything tagged `[SFDT]` should be informational;
    anything red is a regression.
 5. **Pick a target org**: a scratch org or sandbox with a mix of flow
    types (at minimum: one screen flow, one record-triggered, one
@@ -57,7 +57,7 @@ Before touching any feature, verify the shell itself.
 | Menu lists items appropriate to the current context (see matrix below) | yes |
 | Closing via × or outside-click works | yes |
 | SPA navigation (e.g. clicking from Setup to Object Manager) refreshes the menu | yes |
-| Console contains `[SFUT] Shell mounted.` | yes |
+| Console contains `[SFDT] Shell mounted.` | yes |
 | Console contains no red errors | yes |
 
 The side button must mount in the top frame only — verify by opening a
@@ -141,10 +141,10 @@ Since the options page is not yet built, **for the smoke-test set the
 token manually in DevTools**:
 
 ```js
-chrome.storage.local.get('sfut.settings', (s) => console.log(s));
+chrome.storage.local.get('sfdt.settings', (s) => console.log(s));
 chrome.storage.local.set({
-  'sfut.settings': {
-    ...((await chrome.storage.local.get('sfut.settings'))['sfut.settings'] || {}),
+  'sfdt.settings': {
+    ...((await chrome.storage.local.get('sfdt.settings'))['sfdt.settings'] || {}),
     bridge: { token: 'PASTE_TOKEN_HERE', preferredTransport: 'localhost', localhostPort: 7654 },
   },
 });
@@ -167,7 +167,7 @@ Three lists, terse:
 2. **Broken**: feature numbers with what went wrong (one line each).
 3. **Surprises**: anything you noticed that isn't in the matrix —
    performance issues, ugly styling, console warnings beyond expected
-   `[SFUT]` info, mouse-trap problems, accessibility gaps.
+   `[SFDT]` info, mouse-trap problems, accessibility gaps.
 
 The deferred-status column above is what I already know is incomplete;
 focus the "Broken" list on things that don't match what the matrix

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `@sfdt/extension` are documented here. Format follows [Ke
 
 ## [Unreleased]
 
+### Changed
+- **Internal namespace renamed from the legacy `sfut` to `sfdt`** across the extension (DOM ids, CSS classes, storage keys, log prefixes) so it matches the rest of the `@sfdt/*` project. User-facing behaviour is unchanged.
+- `chrome.storage.local` keys moved `sfut.settings` → `sfdt.settings` and `sfut.telemetry` → `sfdt.telemetry`, with a one-time read-and-migrate on first access so existing users keep their settings and opt-in telemetry. The 24h kill-switch cache (`sfut.killswitch.cache` → `sfdt.killswitch.cache`) is intentionally not migrated — it self-heals on the next boot ping.
+
 ## [0.3.0] - 2026-06-20
 
 ### Added

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to `@sfdt/extension` are documented here. Format follows [Ke
 
 ### Changed
 - **Internal namespace renamed from the legacy `sfut` to `sfdt`** across the extension (DOM ids, CSS classes, storage keys, log prefixes) so it matches the rest of the `@sfdt/*` project. User-facing behaviour is unchanged.
-- `chrome.storage.local` keys moved `sfut.settings` → `sfdt.settings` and `sfut.telemetry` → `sfdt.telemetry`, with a one-time read-and-migrate on first access so existing users keep their settings and opt-in telemetry. The 24h kill-switch cache (`sfut.killswitch.cache` → `sfdt.killswitch.cache`) is intentionally not migrated — it self-heals on the next boot ping.
+- All `chrome.storage.local` keys moved from the `sfut.*` namespace to `sfdt.*` (`sfut.settings` → `sfdt.settings`, `sfut.telemetry` → `sfdt.telemetry`, `sfut.killswitch.cache` → `sfdt.killswitch.cache`), each with a one-time read-and-migrate on first access so existing users keep their settings, opt-in telemetry, and kill-switch cache. (Migrated kill-switch records are still subject to the normal 24h staleness check.)
 
 ## [0.3.0] - 2026-06-20
 

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -5,8 +5,10 @@ All notable changes to `@sfdt/extension` are documented here. Format follows [Ke
 ## [Unreleased]
 
 ### Changed
-- **Internal namespace renamed from the legacy `sfut` to `sfdt`** across the extension (DOM ids, CSS classes, storage keys, log prefixes) so it matches the rest of the `@sfdt/*` project. User-facing behaviour is unchanged.
-- All `chrome.storage.local` keys moved from the `sfut.*` namespace to `sfdt.*` (`sfut.settings` → `sfdt.settings`, `sfut.telemetry` → `sfdt.telemetry`, `sfut.killswitch.cache` → `sfdt.killswitch.cache`), each with a one-time read-and-migrate on first access so existing users keep their settings, opt-in telemetry, and kill-switch cache. (Migrated kill-switch records are still subject to the normal 24h staleness check.)
+- **Internal namespace standardised to `sfdt`** across the extension (DOM ids, CSS classes, `chrome.storage` keys, log prefixes) so it matches the rest of the `@sfdt/*` project.
+
+### Note
+- The `chrome.storage.local` keys were renamed to the `sfdt.*` namespace with no migration shim. Users upgrading from an older build will start from default settings (and their opt-in telemetry resets); re-enabling preferences is a one-time step.
 
 ## [0.3.0] - 2026-06-20
 

--- a/extension/PRIVACY.md
+++ b/extension/PRIVACY.md
@@ -25,9 +25,9 @@ All extension state lives in `chrome.storage.local` inside your Chrome profile. 
 
 | Key | What it is | When it's written |
 |---|---|---|
-| `sfut.settings` | Your per-feature toggles, AI provider preferences, bridge token | When you save the options page |
-| `sfut.killswitch.cache` | The most-recent server-disabled feature list from the local bridge ping | After every successful bridge ping |
-| `sfut.telemetry` | Opt-in local feature-use counters (see below) | Only when you've enabled telemetry |
+| `sfdt.settings` | Your per-feature toggles, AI provider preferences, bridge token | When you save the options page |
+| `sfdt.killswitch.cache` | The most-recent server-disabled feature list from the local bridge ping | After every successful bridge ping |
+| `sfdt.telemetry` | Opt-in local feature-use counters (see below) | Only when you've enabled telemetry |
 
 You can clear all of it from `chrome://extensions` → SFDT SF Helper → Site data → Remove all.
 
@@ -39,7 +39,7 @@ The extension does **not** collect or transmit telemetry unless you go to the op
 
 Even when enabled, all telemetry stays on your device:
 
-- Counters are kept in `chrome.storage.local` under `sfut.telemetry`.
+- Counters are kept in `chrome.storage.local` under `sfdt.telemetry`.
 - The schema is a per-feature `{ activated, errored, disabled_remote }` integer triple, keyed by feature id, plus a `monthKey` like `2026-05`.
 - Counts roll over to zero at the start of each calendar month.
 - Capped at 500 distinct feature ids.

--- a/extension/entrypoints/app/index.html
+++ b/extension/entrypoints/app/index.html
@@ -7,7 +7,7 @@
     <title>SFDT Workspace</title>
   </head>
   <body>
-    <div id="sfut-app-root"></div>
+    <div id="sfdt-app-root"></div>
     <script type="module" src="./main.ts"></script>
   </body>
 </html>

--- a/extension/entrypoints/app/main.ts
+++ b/extension/entrypoints/app/main.ts
@@ -51,20 +51,20 @@ function isAllowedSfHost(host: string): boolean {
 const STYLES = `
   *, *::before, *::after { box-sizing: border-box; }
   body { margin: 0; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif; color: #16325c; background: #f3f3f3; }
-  #sfut-topbar { display: flex; align-items: center; gap: 12px; padding: 10px 16px; background: #16325c; color: #fff; }
-  #sfut-topbar .title { font-weight: 600; font-size: 15px; }
-  #sfut-topbar .org { margin-left: auto; font-size: 12px; opacity: 0.85; font-family: ui-monospace, monospace; }
-  #sfut-topbar button { padding: 5px 12px; border: 1px solid rgba(255,255,255,0.4); background: transparent; color: #fff; border-radius: 4px; cursor: pointer; font-size: 12px; }
-  #sfut-topbar button:hover { background: rgba(255,255,255,0.12); }
-  #sfut-layout { display: flex; height: calc(100vh - 45px); }
-  #sfut-sidebar { width: 260px; background: #fff; border-right: 1px solid #d8dde6; overflow-y: auto; padding: 8px; }
-  #sfut-sidebar .tool { display: flex; gap: 10px; align-items: center; padding: 10px 12px; border-radius: 4px; cursor: pointer; font-size: 13px; }
-  #sfut-sidebar .tool:hover { background: #f3f6f9; }
-  #sfut-sidebar .tool .icon { font-size: 16px; }
-  #sfut-main { flex: 1; overflow: auto; padding: 32px; }
-  #sfut-main .welcome { max-width: 560px; margin: 40px auto; text-align: center; color: #54698d; }
-  #sfut-main .welcome h2 { color: #16325c; }
-  #sfut-main code { background: #e9eef3; padding: 1px 5px; border-radius: 3px; font-size: 12px; }
+  #sfdt-topbar { display: flex; align-items: center; gap: 12px; padding: 10px 16px; background: #16325c; color: #fff; }
+  #sfdt-topbar .title { font-weight: 600; font-size: 15px; }
+  #sfdt-topbar .org { margin-left: auto; font-size: 12px; opacity: 0.85; font-family: ui-monospace, monospace; }
+  #sfdt-topbar button { padding: 5px 12px; border: 1px solid rgba(255,255,255,0.4); background: transparent; color: #fff; border-radius: 4px; cursor: pointer; font-size: 12px; }
+  #sfdt-topbar button:hover { background: rgba(255,255,255,0.12); }
+  #sfdt-layout { display: flex; height: calc(100vh - 45px); }
+  #sfdt-sidebar { width: 260px; background: #fff; border-right: 1px solid #d8dde6; overflow-y: auto; padding: 8px; }
+  #sfdt-sidebar .tool { display: flex; gap: 10px; align-items: center; padding: 10px 12px; border-radius: 4px; cursor: pointer; font-size: 13px; }
+  #sfdt-sidebar .tool:hover { background: #f3f6f9; }
+  #sfdt-sidebar .tool .icon { font-size: 16px; }
+  #sfdt-main { flex: 1; overflow: auto; padding: 32px; }
+  #sfdt-main .welcome { max-width: 560px; margin: 40px auto; text-align: center; color: #54698d; }
+  #sfdt-main .welcome h2 { color: #16325c; }
+  #sfdt-main code { background: #e9eef3; padding: 1px 5px; border-radius: 3px; font-size: 12px; }
 `;
 
 function el<K extends keyof HTMLElementTagNameMap>(
@@ -214,7 +214,7 @@ function bootWorkspace(root: HTMLElement, orgHost: string): void {
   // --- Layout ---
   while (root.firstChild) root.removeChild(root.firstChild);
 
-  const topbar = el('div', { id: 'sfut-topbar' });
+  const topbar = el('div', { id: 'sfdt-topbar' });
   const title = el('span', { class: 'title' });
   title.textContent = '⚡ SFDT Workspace';
   const orgLabel = el('span', { class: 'org' });
@@ -227,9 +227,9 @@ function bootWorkspace(root: HTMLElement, orgHost: string): void {
   topbar.appendChild(switchBtn);
   root.appendChild(topbar);
 
-  const layout = el('div', { id: 'sfut-layout' });
-  const sidebar = el('div', { id: 'sfut-sidebar' });
-  const main = el('div', { id: 'sfut-main' });
+  const layout = el('div', { id: 'sfdt-layout' });
+  const sidebar = el('div', { id: 'sfdt-sidebar' });
+  const main = el('div', { id: 'sfdt-main' });
 
   const welcome = el('div', { class: 'welcome' });
   const wh = el('h2');
@@ -268,7 +268,7 @@ async function main(): Promise<void> {
   styleTag.textContent = STYLES;
   document.head.appendChild(styleTag);
 
-  const root = document.getElementById('sfut-app-root');
+  const root = document.getElementById('sfdt-app-root');
   if (!root) return;
 
   const org = resolveOrgFromUrl() ?? (await readLastOrg());

--- a/extension/entrypoints/content.ts
+++ b/extension/entrypoints/content.ts
@@ -132,7 +132,7 @@ export default defineContentScript({
           await writeKillSwitchCache(info.disabledFeatures);
         }
       } catch (err) {
-        console.warn('[SFUT] kill-switch refresh failed:', err);
+        console.warn('[SFDT] kill-switch refresh failed:', err);
       }
     }
 
@@ -218,6 +218,6 @@ export default defineContentScript({
 
     await registry.initForCurrentRoute(getAvailableFeatures(), makeGate());
 
-    console.log('[SFUT] Shell mounted with kill-switch enabled.');
+    console.log('[SFDT] Shell mounted with kill-switch enabled.');
   },
 });

--- a/extension/entrypoints/options/index.html
+++ b/extension/entrypoints/options/index.html
@@ -7,7 +7,7 @@
     <title>SFDT SF Helper — Settings</title>
   </head>
   <body>
-    <div id="sfut-options-root"></div>
+    <div id="sfdt-options-root"></div>
     <script type="module" src="./main.ts"></script>
   </body>
 </html>

--- a/extension/entrypoints/options/main.ts
+++ b/extension/entrypoints/options/main.ts
@@ -184,7 +184,7 @@ function buildHintBanner(): HTMLDivElement {
 }
 
 async function render(): Promise<void> {
-  const root = document.getElementById('sfut-options-root');
+  const root = document.getElementById('sfdt-options-root');
   if (!root) return;
 
   const styleTag = document.createElement('style');

--- a/extension/features/ai-assistant.ts
+++ b/extension/features/ai-assistant.ts
@@ -58,17 +58,17 @@ export function createAiAssistantFeature(options: AiAssistantOptions = {}): Feat
   async function openPanel(): Promise<void> {
     closePanel();
     overlay = doc.createElement('div');
-    overlay.className = 'sfut-ai-panel-overlay';
+    overlay.className = 'sfdt-ai-panel-overlay';
     overlay.style.cssText =
       'position: fixed; inset: 0; background: rgba(0,0,0,0.4); z-index: 100020; display: flex; align-items: center; justify-content: center; font-family: system-ui, sans-serif;';
 
     const panel = doc.createElement('div');
-    panel.className = 'sfut-ai-panel';
+    panel.className = 'sfdt-ai-panel';
     panel.style.cssText =
       'background: #fff; border-radius: 4px; width: 640px; max-width: 90vw; max-height: 90vh; display: flex; flex-direction: column;';
 
     const header = doc.createElement('div');
-    header.className = 'sfut-ai-panel-header';
+    header.className = 'sfdt-ai-panel-header';
     header.style.cssText =
       'padding: 12px 16px; border-bottom: 1px solid #d8dde6; display: flex; justify-content: space-between; align-items: center; font-weight: 600;';
     const title = doc.createElement('span');
@@ -81,7 +81,7 @@ export function createAiAssistantFeature(options: AiAssistantOptions = {}): Feat
     header.appendChild(closeBtn);
 
     const body = doc.createElement('div');
-    body.className = 'sfut-ai-panel-body';
+    body.className = 'sfdt-ai-panel-body';
     body.style.cssText = 'padding: 16px; overflow-y: auto; flex: 1;';
     const loading = doc.createElement('div');
     loading.textContent = 'Fetching Flow metadata…';

--- a/extension/features/apex-anonymous.ts
+++ b/extension/features/apex-anonymous.ts
@@ -329,7 +329,7 @@ export function createApexAnonymousFeature(options: ApexAnonymousOptions = {}): 
     );
 
     overlay = doc.createElement('div');
-    overlay.className = 'sfut-apex-anonymous-overlay';
+    overlay.className = 'sfdt-apex-anonymous-overlay';
     overlay.style.cssText =
       'position: fixed; inset: 0; background: rgba(0,0,0,0.4); z-index: 100020; display: flex; align-items: center; justify-content: center; font-family: system-ui, sans-serif;';
     overlay.addEventListener('click', (e) => {

--- a/extension/features/canvas-search.ts
+++ b/extension/features/canvas-search.ts
@@ -27,9 +27,9 @@ interface Match {
   toolboxSection?: Element | null;
 }
 
-const HIGHLIGHT_CLASS = 'sfut-canvas-highlight';
-const FOCUS_CLASS = 'sfut-canvas-highlight-focus';
-const DYNAMIC_STYLE_ID = 'sfut-canvas-search-dynamic';
+const HIGHLIGHT_CLASS = 'sfdt-canvas-highlight';
+const FOCUS_CLASS = 'sfdt-canvas-highlight-focus';
+const DYNAMIC_STYLE_ID = 'sfdt-canvas-search-dynamic';
 
 // Salesforce LWC custom-element tags contain underscores
 // (e.g. `builder_platform_interaction-alc-canvas`). Real browsers accept these
@@ -239,10 +239,10 @@ export function createCanvasSearchFeature(options: CanvasSearchOptions = {}): Fe
     if (matches.length === 0) {
       const hasQuery = !!input && input.value.trim().length > 0;
       countLabel.textContent = hasQuery ? 'No matches' : '';
-      countLabel.classList.toggle('sfut-canvas-search-bar-no-results', hasQuery);
+      countLabel.classList.toggle('sfdt-canvas-search-bar-no-results', hasQuery);
     } else {
       countLabel.textContent = `${currentIndex + 1} of ${matches.length}`;
-      countLabel.classList.remove('sfut-canvas-search-bar-no-results');
+      countLabel.classList.remove('sfdt-canvas-search-bar-no-results');
     }
   }
 
@@ -310,26 +310,26 @@ export function createCanvasSearchFeature(options: CanvasSearchOptions = {}): Fe
   }
 
   function createOverlay(): HTMLDivElement {
-    doc.querySelector('.sfut-canvas-search-bar')?.remove();
+    doc.querySelector('.sfdt-canvas-search-bar')?.remove();
 
     const container = doc.createElement('div');
-    container.className = 'sfut-canvas-search-bar';
+    container.className = 'sfdt-canvas-search-bar';
 
     const icon = doc.createElement('span');
-    icon.className = 'sfut-canvas-search-bar-icon';
+    icon.className = 'sfdt-canvas-search-bar-icon';
     icon.textContent = '🔍';
     container.appendChild(icon);
 
     const inputEl = doc.createElement('input');
     inputEl.type = 'text';
-    inputEl.className = 'sfut-canvas-search-bar-input';
+    inputEl.className = 'sfdt-canvas-search-bar-input';
     inputEl.placeholder = 'Search elements…';
     inputEl.setAttribute('autocomplete', 'off');
     inputEl.setAttribute('spellcheck', 'false');
     container.appendChild(inputEl);
 
     const prevBtn = doc.createElement('button');
-    prevBtn.className = 'sfut-canvas-search-bar-nav';
+    prevBtn.className = 'sfdt-canvas-search-bar-nav';
     prevBtn.textContent = '▲';
     prevBtn.title = 'Previous match (Shift+Enter)';
     prevBtn.addEventListener('click', (e) => {
@@ -340,7 +340,7 @@ export function createCanvasSearchFeature(options: CanvasSearchOptions = {}): Fe
     container.appendChild(prevBtn);
 
     const nextBtn = doc.createElement('button');
-    nextBtn.className = 'sfut-canvas-search-bar-nav';
+    nextBtn.className = 'sfdt-canvas-search-bar-nav';
     nextBtn.textContent = '▼';
     nextBtn.title = 'Next match (Enter)';
     nextBtn.addEventListener('click', (e) => {
@@ -351,11 +351,11 @@ export function createCanvasSearchFeature(options: CanvasSearchOptions = {}): Fe
     container.appendChild(nextBtn);
 
     const count = doc.createElement('span');
-    count.className = 'sfut-canvas-search-bar-count';
+    count.className = 'sfdt-canvas-search-bar-count';
     container.appendChild(count);
 
     const closeBtn = doc.createElement('button');
-    closeBtn.className = 'sfut-canvas-search-bar-close';
+    closeBtn.className = 'sfdt-canvas-search-bar-close';
     closeBtn.textContent = '✕';
     closeBtn.title = 'Close (Escape)';
     closeBtn.addEventListener('click', (e) => {

--- a/extension/features/data-import.ts
+++ b/extension/features/data-import.ts
@@ -166,7 +166,7 @@ export function createDataImportFeature(options: {
     close();
 
     overlay = doc.createElement('div');
-    overlay.className = 'sfut-data-import-overlay';
+    overlay.className = 'sfdt-data-import-overlay';
     overlay.style.cssText =
       'position: fixed; inset: 0; background: rgba(0,0,0,0.4); z-index: 100020; display: flex; align-items: center; justify-content: center; font-family: system-ui, sans-serif;';
     overlay.addEventListener('click', (e) => {

--- a/extension/features/debug-log-viewer.ts
+++ b/extension/features/debug-log-viewer.ts
@@ -71,7 +71,7 @@ export function createDebugLogViewerFeature(options: DebugLogViewerOptions = {})
     }) as z.infer<typeof DEBUG_LOG_SETTINGS_SCHEMA>;
 
     overlay = doc.createElement('div');
-    overlay.className = 'sfut-debug-log-overlay';
+    overlay.className = 'sfdt-debug-log-overlay';
     overlay.style.cssText =
       'position: fixed; inset: 0; background: rgba(0,0,0,0.4); z-index: 100020; display: flex; align-items: center; justify-content: center; font-family: system-ui, sans-serif;';
     overlay.addEventListener('click', (e) => {

--- a/extension/features/event-monitor.ts
+++ b/extension/features/event-monitor.ts
@@ -305,7 +305,7 @@ export function createEventMonitorFeature(options: {
       }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      console.warn(`[SFUT] Failed to fetch channels for ${type}: ${message}`);
+      console.warn(`[SFDT] Failed to fetch channels for ${type}: ${message}`);
     }
 
     if (list.length === 0) {
@@ -423,7 +423,7 @@ export function createEventMonitorFeature(options: {
     close();
 
     overlay = doc.createElement('div');
-    overlay.className = 'sfut-event-monitor-overlay';
+    overlay.className = 'sfdt-event-monitor-overlay';
     overlay.style.cssText =
       'position: fixed; inset: 0; background: rgba(0,0,0,0.4); z-index: 100020; display: flex; align-items: center; justify-content: center; font-family: system-ui, sans-serif;';
     overlay.addEventListener('click', (e) => {

--- a/extension/features/field-creator.ts
+++ b/extension/features/field-creator.ts
@@ -131,7 +131,7 @@ export function createFieldCreatorFeature(options: {
     await fetchPermissionSets();
 
     overlay = doc.createElement('div');
-    overlay.className = 'sfut-field-creator-overlay';
+    overlay.className = 'sfdt-field-creator-overlay';
     overlay.style.cssText =
       'position: fixed; inset: 0; background: rgba(0,0,0,0.4); z-index: 100020; display: flex; align-items: center; justify-content: center; font-family: system-ui, sans-serif;';
     overlay.addEventListener('click', (e) => {

--- a/extension/features/flow-health-check.ts
+++ b/extension/features/flow-health-check.ts
@@ -177,7 +177,7 @@ export function createFlowHealthCheckFeature(options: FlowHealthCheckOptions = {
         const report = buildReport(record, normalized, issueFamilies);
         getModal().showReport(report);
       } catch (err) {
-        console.error('[SFUT flow-health-check] failed:', err);
+        console.error('[SFDT flow-health-check] failed:', err);
         getModal().showError(err instanceof Error ? err.message : 'Unexpected error');
       }
     },

--- a/extension/features/flow-list-search.ts
+++ b/extension/features/flow-list-search.ts
@@ -221,10 +221,10 @@ export function createFlowListSearchFeature(options: FlowListSearchOptions = {})
     if (!countLabel) return;
     if (loading) {
       countLabel.textContent = 'Loading all flows…';
-      countLabel.classList.add('sfut-flow-search-loading');
+      countLabel.classList.add('sfdt-flow-search-loading');
       return;
     }
-    countLabel.classList.remove('sfut-flow-search-loading');
+    countLabel.classList.remove('sfdt-flow-search-loading');
     if (total === 0) countLabel.textContent = '';
     else if (visible === total) countLabel.textContent = `${total} flows`;
     else if (visible === 0) countLabel.textContent = 'No matching flows';
@@ -307,25 +307,25 @@ export function createFlowListSearchFeature(options: FlowListSearchOptions = {})
   }
 
   function injectBar(): void {
-    if (doc.getElementById('sfut-flow-search-container')) return;
+    if (doc.getElementById('sfdt-flow-search-container')) return;
     const header = doc.querySelector(SELECTORS.listHeader);
     const manager = doc.querySelector(SELECTORS.listViewManager);
     const insertTarget = header ?? manager;
     if (!insertTarget) return;
 
     const container = doc.createElement('div');
-    container.id = 'sfut-flow-search-container';
-    container.className = 'sfut-flow-search-container';
+    container.id = 'sfdt-flow-search-container';
+    container.className = 'sfdt-flow-search-container';
 
     const icon = doc.createElement('span');
-    icon.className = 'sfut-flow-search-icon';
+    icon.className = 'sfdt-flow-search-icon';
     icon.setAttribute('aria-hidden', 'true');
     icon.textContent = '🔍';
     container.appendChild(icon);
 
     searchInput = doc.createElement('input');
-    searchInput.id = 'sfut-flow-search-input';
-    searchInput.className = 'sfut-flow-search-input';
+    searchInput.id = 'sfdt-flow-search-input';
+    searchInput.className = 'sfdt-flow-search-input';
     searchInput.type = 'text';
     searchInput.placeholder = 'Search by label or API name…';
     searchInput.setAttribute('aria-label', 'Search flows by label or API name');
@@ -334,8 +334,8 @@ export function createFlowListSearchFeature(options: FlowListSearchOptions = {})
     container.appendChild(searchInput);
 
     statusFilter = doc.createElement('select');
-    statusFilter.id = 'sfut-flow-status-filter';
-    statusFilter.className = 'sfut-flow-search-filter';
+    statusFilter.id = 'sfdt-flow-status-filter';
+    statusFilter.className = 'sfdt-flow-search-filter';
     statusFilter.setAttribute('aria-label', 'Filter flows by status');
     const statusOptions: ReadonlyArray<readonly [string, string]> = [
       ['', 'All Statuses'],
@@ -351,8 +351,8 @@ export function createFlowListSearchFeature(options: FlowListSearchOptions = {})
     container.appendChild(statusFilter);
 
     typeFilter = doc.createElement('select');
-    typeFilter.id = 'sfut-flow-type-filter';
-    typeFilter.className = 'sfut-flow-search-filter';
+    typeFilter.id = 'sfdt-flow-type-filter';
+    typeFilter.className = 'sfdt-flow-search-filter';
     typeFilter.setAttribute('aria-label', 'Filter flows by type');
     const allTypes = doc.createElement('option');
     allTypes.value = '';
@@ -361,15 +361,15 @@ export function createFlowListSearchFeature(options: FlowListSearchOptions = {})
     container.appendChild(typeFilter);
 
     clearBtn = doc.createElement('button');
-    clearBtn.className = 'sfut-flow-search-clear';
+    clearBtn.className = 'sfdt-flow-search-clear';
     clearBtn.textContent = 'Clear';
     clearBtn.title = 'Clear search and filters';
     clearBtn.setAttribute('aria-label', 'Clear search and filters');
     container.appendChild(clearBtn);
 
     countLabel = doc.createElement('span');
-    countLabel.id = 'sfut-flow-search-count';
-    countLabel.className = 'sfut-flow-search-count';
+    countLabel.id = 'sfdt-flow-search-count';
+    countLabel.className = 'sfdt-flow-search-count';
     container.appendChild(countLabel);
 
     if (header && header.parentNode) {

--- a/extension/features/flow-version-manager.ts
+++ b/extension/features/flow-version-manager.ts
@@ -11,9 +11,9 @@ const SELECTORS = {
   deleteLink: 'a[id$=":deleteLink"]',
 };
 
-const TAB_CLASS = 'sfut-version-select-cell';
-const CHECKBOX_CLASS = 'sfut-version-select-checkbox';
-const DELETE_BTN_CLASS = 'sfut-version-manager-delete-btn';
+const TAB_CLASS = 'sfdt-version-select-cell';
+const CHECKBOX_CLASS = 'sfdt-version-select-checkbox';
+const DELETE_BTN_CLASS = 'sfdt-version-manager-delete-btn';
 
 interface RowMeta {
   row: HTMLTableRowElement;
@@ -69,12 +69,12 @@ function injectCheckboxColumn(doc: Document, table: Element): void {
 async function confirmModal(doc: Document, selected: RowMeta[]): Promise<boolean> {
   return new Promise((resolve) => {
     const backdrop = doc.createElement('div');
-    backdrop.className = 'sfut-version-manager-backdrop';
+    backdrop.className = 'sfdt-version-manager-backdrop';
     backdrop.style.cssText =
       'position: fixed; inset: 0; background: rgba(0,0,0,0.4); z-index: 100020; display: flex; align-items: center; justify-content: center;';
 
     const modal = doc.createElement('div');
-    modal.className = 'sfut-version-manager-modal';
+    modal.className = 'sfdt-version-manager-modal';
     modal.setAttribute('role', 'dialog');
     modal.style.cssText =
       'background: #fff; border-radius: 4px; padding: 16px; min-width: 360px; max-width: 480px; font-family: system-ui, sans-serif;';
@@ -271,7 +271,7 @@ export function createFlowVersionManagerFeature(
         toolbarBtn = null;
       }
       doc.querySelectorAll(`.${TAB_CLASS}`).forEach((el) => el.remove());
-      doc.querySelector('.sfut-version-manager-backdrop')?.remove();
+      doc.querySelector('.sfdt-version-manager-backdrop')?.remove();
       selected.clear();
       rowMap.clear();
     },

--- a/extension/features/inspect-record.ts
+++ b/extension/features/inspect-record.ts
@@ -110,7 +110,7 @@ export function createInspectRecordFeature(options: InspectRecordOptions = {}): 
     close();
 
     overlay = doc.createElement('div');
-    overlay.className = 'sfut-inspect-record-overlay';
+    overlay.className = 'sfdt-inspect-record-overlay';
     overlay.style.cssText =
       'position: fixed; inset: 0; background: rgba(0,0,0,0.4); z-index: 100020; display: flex; align-items: center; justify-content: center; font-family: system-ui, sans-serif;';
     overlay.addEventListener('click', (e) => {

--- a/extension/features/metadata-retrieve.ts
+++ b/extension/features/metadata-retrieve.ts
@@ -540,7 +540,7 @@ export function createMetadataRetrieveFeature(options: {
 
       const chk = doc.createElement('input');
       chk.type = 'checkbox';
-      chk.className = 'sfut-tree-chk';
+      chk.className = 'sfdt-tree-chk';
       chk.checked = !!obj.selected;
       chk.addEventListener('change', (e) => {
         e.stopPropagation();
@@ -605,7 +605,7 @@ export function createMetadataRetrieveFeature(options: {
     close();
 
     overlay = doc.createElement('div');
-    overlay.className = 'sfut-meta-retrieve-overlay';
+    overlay.className = 'sfdt-meta-retrieve-overlay';
     overlay.style.cssText =
       'position: fixed; inset: 0; background: rgba(0,0,0,0.4); z-index: 100020; display: flex; align-items: center; justify-content: center; font-family: system-ui, sans-serif;';
     overlay.addEventListener('click', (e) => {
@@ -710,7 +710,7 @@ export function createMetadataRetrieveFeature(options: {
     xmlDiv.appendChild(xmlLabel);
 
     const xmlTextarea = doc.createElement('textarea');
-    xmlTextarea.id = 'sfut-meta-xml-textarea';
+    xmlTextarea.id = 'sfdt-meta-xml-textarea';
     xmlTextarea.readOnly = true;
     xmlTextarea.value = packageXml;
     xmlTextarea.style.cssText = 'flex: 1; padding: 8px; border: 1px solid #d8dde6; border-radius: 4px; font-family: monospace; font-size: 11px; background: #fafaf9; resize: none; outline: none;';

--- a/extension/features/missing-description-flags.ts
+++ b/extension/features/missing-description-flags.ts
@@ -133,10 +133,10 @@ function flagCanvas(doc: Document, missing: readonly MissingItem[]): number {
       card.querySelector('.base-card')?.getAttribute('aria-label') ??
       text;
     if (seen.has(cardKey)) continue;
-    if (card.querySelector('.sfut-desc-flag')) continue;
+    if (card.querySelector('.sfdt-desc-flag')) continue;
 
     const flag = doc.createElement('div');
-    flag.className = 'sfut-desc-flag';
+    flag.className = 'sfdt-desc-flag';
     flag.title = `"${text}" has no description`;
     flag.setAttribute('aria-label', `Warning: ${text} has no description`);
     flag.textContent = '⚠';
@@ -152,9 +152,9 @@ function flagCanvas(doc: Document, missing: readonly MissingItem[]): number {
   if (flowMissing) {
     const flowNameEl = doc.querySelector('.test-flow-name');
     const parent = flowNameEl?.parentElement;
-    if (parent && !parent.querySelector('.sfut-desc-flag-flow')) {
+    if (parent && !parent.querySelector('.sfdt-desc-flag-flow')) {
       const flag = doc.createElement('span');
-      flag.className = 'sfut-desc-flag-flow';
+      flag.className = 'sfdt-desc-flag-flow';
       flag.title = 'This flow has no description';
       flag.setAttribute('aria-label', 'Warning: This flow has no description');
       flag.textContent = ' ⚠';
@@ -167,7 +167,7 @@ function flagCanvas(doc: Document, missing: readonly MissingItem[]): number {
 }
 
 function clearAllFlags(doc: Document): void {
-  for (const cls of ['sfut-desc-flag', 'sfut-desc-flag-flow', 'sfut-desc-flag-toolbox']) {
+  for (const cls of ['sfdt-desc-flag', 'sfdt-desc-flag-flow', 'sfdt-desc-flag-toolbox']) {
     doc.querySelectorAll(`.${cls}`).forEach((el) => el.remove());
   }
 }
@@ -210,7 +210,7 @@ export function createMissingDescriptionFlagsFeature(
       startObserver();
       flagCanvas(doc, missingItems);
     } catch (err) {
-      console.warn('[SFUT missing-descriptions] activate failed:', err);
+      console.warn('[SFDT missing-descriptions] activate failed:', err);
     }
   }
 

--- a/extension/features/org-health.ts
+++ b/extension/features/org-health.ts
@@ -211,7 +211,7 @@ export function createOrgHealthFeature(options: OrgHealthOptions = {}): Feature 
     close();
 
     overlay = doc.createElement('div');
-    overlay.className = 'sfut-org-health-overlay';
+    overlay.className = 'sfdt-org-health-overlay';
     overlay.style.cssText =
       'position: fixed; inset: 0; background: rgba(0,0,0,0.4); z-index: 100020; display: flex; align-items: center; justify-content: center; font-family: system-ui, sans-serif;';
     overlay.addEventListener('click', (e) => {

--- a/extension/features/org-limits.ts
+++ b/extension/features/org-limits.ts
@@ -118,7 +118,7 @@ export function createOrgLimitsFeature(options: OrgLimitsOptions = {}): Feature 
     close();
 
     overlay = doc.createElement('div');
-    overlay.className = 'sfut-org-limits-overlay';
+    overlay.className = 'sfdt-org-limits-overlay';
     overlay.style.cssText =
       'position: fixed; inset: 0; background: rgba(0,0,0,0.4); z-index: 100020; display: flex; align-items: center; justify-content: center; font-family: system-ui, sans-serif;';
     overlay.addEventListener('click', (e) => {

--- a/extension/features/org-switcher.ts
+++ b/extension/features/org-switcher.ts
@@ -3,7 +3,7 @@ import type { Feature } from '../lib/feature-registry.js';
 import type { OrgEntry } from '../lib/org-list.js';
 import { showToast } from '../ui/toast.js';
 
-const LAST_ORG_STORAGE_KEY = 'sfut.workspace.lastOrg';
+const LAST_ORG_STORAGE_KEY = 'sfdt.workspace.lastOrg';
 
 export async function readLastOrg(): Promise<string | null> {
   return new Promise((resolve) => {
@@ -81,7 +81,7 @@ export function createOrgSwitcherFeature(options: OrgSwitcherOptions = {}): Feat
     close();
 
     overlay = doc.createElement('div');
-    overlay.className = 'sfut-org-switcher-overlay';
+    overlay.className = 'sfdt-org-switcher-overlay';
     overlay.style.cssText =
       'position: fixed; inset: 0; background: rgba(0,0,0,0.4); z-index: 100020; display: flex; align-items: center; justify-content: center; font-family: system-ui, sans-serif;';
     overlay.addEventListener('click', (e) => {

--- a/extension/features/rest-explore.ts
+++ b/extension/features/rest-explore.ts
@@ -104,7 +104,7 @@ export function createRestExploreFeature(options: RestExploreOptions = {}): Feat
     const historyEnabled = config.historyEnabled;
 
     overlay = doc.createElement('div');
-    overlay.className = 'sfut-rest-explore-overlay';
+    overlay.className = 'sfdt-rest-explore-overlay';
     overlay.style.cssText =
       'position: fixed; inset: 0; background: rgba(0,0,0,0.4); z-index: 100020; display: flex; align-items: center; justify-content: center; font-family: system-ui, sans-serif;';
     overlay.addEventListener('click', (e) => {

--- a/extension/features/saved-soql.ts
+++ b/extension/features/saved-soql.ts
@@ -57,7 +57,7 @@ export function createSavedSoqlFeature(options: SavedSoqlOptions = {}): Feature 
     }) as z.infer<typeof SAVED_SOQL_SETTINGS_SCHEMA>;
 
     overlay = doc.createElement('div');
-    overlay.className = 'sfut-saved-soql-overlay';
+    overlay.className = 'sfdt-saved-soql-overlay';
     overlay.style.cssText =
       'position: fixed; inset: 0; background: rgba(0,0,0,0.4); z-index: 100020; display: flex; align-items: center; justify-content: center; font-family: system-ui, sans-serif;';
     overlay.addEventListener('click', (e) => {

--- a/extension/features/scheduled-flow-explorer.ts
+++ b/extension/features/scheduled-flow-explorer.ts
@@ -114,7 +114,7 @@ export async function discoverScheduledFlows(
 
 function buildModal(doc: Document, result: DiscoveryResult, now: Date): HTMLDivElement {
   const overlay = doc.createElement('div');
-  overlay.className = 'sfut-scheduled-flow-overlay';
+  overlay.className = 'sfdt-scheduled-flow-overlay';
   overlay.style.cssText =
     'position: fixed; inset: 0; background: rgba(0,0,0,0.4); z-index: 100020; display: flex; align-items: center; justify-content: center; font-family: system-ui, sans-serif;';
 

--- a/extension/features/setup-tabs.ts
+++ b/extension/features/setup-tabs.ts
@@ -15,7 +15,7 @@ const SETUP_TABS_SETTINGS_SCHEMA = z.object({
 
 registerSettingsShape('setup-tabs', SETUP_TABS_SETTINGS_SCHEMA);
 
-const TAB_CLASS = 'sfut-custom-tab';
+const TAB_CLASS = 'sfdt-custom-tab';
 const GROUP_LABEL = 'Automation';
 
 interface TabDefinition {
@@ -27,20 +27,20 @@ interface TabDefinition {
 
 const BASE_TABS: readonly TabDefinition[] = [
   {
-    id: 'sfut_tab_flows',
+    id: 'sfdt_tab_flows',
     label: 'Flows',
     buildUrl: (hostname) => `https://${toSetupHost(hostname)}/lightning/setup/Flows/home`,
     openInNewTab: false,
   },
   {
-    id: 'sfut_tab_flow_trigger_explorer',
+    id: 'sfdt_tab_flow_trigger_explorer',
     label: 'Flow Trigger Explorer',
     buildUrl: (hostname) =>
       `https://${toLightningHost(hostname)}/interaction_explorer/flowExplorer.app`,
     openInNewTab: true,
   },
   {
-    id: 'sfut_tab_process_automation_settings',
+    id: 'sfdt_tab_process_automation_settings',
     label: 'Process Automation Settings',
     buildUrl: (hostname) =>
       `https://${toSetupHost(hostname)}/lightning/setup/WorkflowSettings/home`,
@@ -49,7 +49,7 @@ const BASE_TABS: readonly TabDefinition[] = [
 ];
 
 const AUTOMATION_HOME_TAB: TabDefinition = {
-  id: 'sfut_tab_automation_home',
+  id: 'sfdt_tab_automation_home',
   label: 'Automation Home',
   buildUrl: (hostname) => `https://${toLightningHost(hostname)}/lightning/app/standard__FlowsApp`,
   openInNewTab: true,
@@ -57,13 +57,13 @@ const AUTOMATION_HOME_TAB: TabDefinition = {
 
 function isActiveTab(tabId: string, url: string): boolean {
   switch (tabId) {
-    case 'sfut_tab_flows':
+    case 'sfdt_tab_flows':
       return url.includes('/lightning/setup/Flows/');
-    case 'sfut_tab_flow_trigger_explorer':
+    case 'sfdt_tab_flow_trigger_explorer':
       return url.includes('/interaction_explorer/flowExplorer');
-    case 'sfut_tab_process_automation_settings':
+    case 'sfdt_tab_process_automation_settings':
       return url.includes('/lightning/setup/WorkflowSettings/');
-    case 'sfut_tab_automation_home':
+    case 'sfdt_tab_automation_home':
       return url.includes('/lightning/app/');
     default:
       return false;
@@ -169,7 +169,7 @@ function injectFlatTabs(
     try {
       tabBar.appendChild(buildFlatTab(doc, win, tab, hostname, url));
     } catch (err) {
-      console.warn('[SFUT setup-tabs] Failed to inject tab', tab.id, err);
+      console.warn('[SFDT setup-tabs] Failed to inject tab', tab.id, err);
     }
   }
 }
@@ -186,7 +186,7 @@ function buildGroupedTab(
     try {
       tabItems.push({ tab, url: tab.buildUrl(hostname) });
     } catch (err) {
-      console.warn('[SFUT setup-tabs] Failed to build grouped tab URL', tab.id, err);
+      console.warn('[SFDT setup-tabs] Failed to build grouped tab URL', tab.id, err);
     }
   }
   if (tabItems.length === 0) return null;
@@ -195,7 +195,7 @@ function buildGroupedTab(
 
   const li = doc.createElement('li');
   li.setAttribute('role', 'presentation');
-  li.className = `oneConsoleTabItem tabItem slds-context-bar__item borderRight navexConsoleTabItem ${TAB_CLASS} sfut-group-tab`;
+  li.className = `oneConsoleTabItem tabItem slds-context-bar__item borderRight navexConsoleTabItem ${TAB_CLASS} sfdt-group-tab`;
   if (anyChildActive) li.classList.add('slds-is-active');
 
   const anchor = doc.createElement('a');
@@ -215,7 +215,7 @@ function buildGroupedTab(
   chevronWrapper.className = 'slds-context-bar__label-action slds-p-left--none';
 
   const chevronBtn = doc.createElement('a');
-  chevronBtn.className = 'slds-button slds-button--icon sfut-group-chevron';
+  chevronBtn.className = 'slds-button slds-button--icon sfdt-group-chevron';
   chevronBtn.setAttribute('href', 'javascript:void(0)');
   chevronBtn.setAttribute('role', 'button');
   chevronBtn.setAttribute('aria-expanded', 'false');
@@ -241,7 +241,7 @@ function buildGroupedTab(
   chevronWrapper.appendChild(chevronBtn);
 
   const dropdown = doc.createElement('div');
-  dropdown.className = 'sfut-group-dropdown';
+  dropdown.className = 'sfdt-group-dropdown';
   dropdown.setAttribute('role', 'menu');
   const ul = doc.createElement('ul');
   ul.setAttribute('role', 'presentation');
@@ -273,17 +273,17 @@ function buildGroupedTab(
   const toggle = (e: Event): void => {
     e.preventDefault();
     e.stopPropagation();
-    const isOpen = dropdown.classList.contains('sfut-group-dropdown--open');
+    const isOpen = dropdown.classList.contains('sfdt-group-dropdown--open');
 
-    for (const other of doc.querySelectorAll('.sfut-group-dropdown--open')) {
-      const otherLi = other.closest('.sfut-group-tab');
-      const otherChevron = otherLi?.querySelector('.sfut-group-chevron') ?? null;
-      other.classList.remove('sfut-group-dropdown--open');
+    for (const other of doc.querySelectorAll('.sfdt-group-dropdown--open')) {
+      const otherLi = other.closest('.sfdt-group-tab');
+      const otherChevron = otherLi?.querySelector('.sfdt-group-chevron') ?? null;
+      other.classList.remove('sfdt-group-dropdown--open');
       otherChevron?.setAttribute('aria-expanded', 'false');
     }
 
     if (!isOpen) {
-      dropdown.classList.add('sfut-group-dropdown--open');
+      dropdown.classList.add('sfdt-group-dropdown--open');
       chevronBtn.setAttribute('aria-expanded', 'true');
     }
   };
@@ -309,7 +309,7 @@ function buildGroupedTab(
 }
 
 function closeDropdown(dropdown: Element, chevron: Element | null): void {
-  dropdown.classList.remove('sfut-group-dropdown--open');
+  dropdown.classList.remove('sfdt-group-dropdown--open');
   chevron?.setAttribute('aria-expanded', 'false');
 }
 
@@ -340,7 +340,7 @@ export function createSetupTabsFeature(options: SetupTabsOptions = {}): Feature 
     try {
       const tabBar = await waitForTabBar(doc, timeoutMs);
       if (!tabBar) {
-        console.warn('[SFUT setup-tabs] tab bar not found within timeout');
+        console.warn('[SFDT setup-tabs] tab bar not found within timeout');
         return;
       }
       if (doc.querySelector(`.${TAB_CLASS}`)) return; // Re-check — another async pass may have mounted while we waited.

--- a/extension/features/soap-explore.ts
+++ b/extension/features/soap-explore.ts
@@ -112,7 +112,7 @@ export function createSoapExploreFeature(options: {
     const historyEnabled = config.historyEnabled;
 
     overlay = doc.createElement('div');
-    overlay.className = 'sfut-soap-explore-overlay';
+    overlay.className = 'sfdt-soap-explore-overlay';
     overlay.style.cssText =
       'position: fixed; inset: 0; background: rgba(0,0,0,0.4); z-index: 100020; display: flex; align-items: center; justify-content: center; font-family: system-ui, sans-serif;';
     overlay.addEventListener('click', (e) => {

--- a/extension/features/soql-runner.ts
+++ b/extension/features/soql-runner.ts
@@ -433,7 +433,7 @@ export function createSoqlRunnerFeature(options: SoqlRunnerOptions = {}): Featur
     const historyEnabled = config.historyEnabled;
 
     overlay = doc.createElement('div');
-    overlay.className = 'sfut-soql-runner-overlay';
+    overlay.className = 'sfdt-soql-runner-overlay';
     overlay.style.cssText =
       'position: fixed; inset: 0; background: rgba(0,0,0,0.4); z-index: 100020; display: flex; align-items: center; justify-content: center; font-family: system-ui, sans-serif;';
     overlay.addEventListener('click', (e) => {
@@ -559,7 +559,7 @@ export function createSoqlRunnerFeature(options: SoqlRunnerOptions = {}): Featur
     });
 
     const autocompleteBox = doc.createElement('div');
-    autocompleteBox.className = 'sfut-soql-autocomplete-box';
+    autocompleteBox.className = 'sfdt-soql-autocomplete-box';
     autocompleteBox.style.cssText =
       'border: 1px solid #d8dde6; border-top: none; border-radius: 0 0 4px 4px; background: #fafaf9; padding: 10px 12px; display: flex; flex-direction: column; gap: 8px; font-family: system-ui, sans-serif;';
 
@@ -685,11 +685,11 @@ export function createSoqlRunnerFeature(options: SoqlRunnerOptions = {}): Featur
     }
 
     function showCellMenu(element: HTMLElement, id: string) {
-      const existing = doc.querySelector('.sfut-soql-cell-menu');
+      const existing = doc.querySelector('.sfdt-soql-cell-menu');
       if (existing) existing.remove();
 
       const menu = doc.createElement('div');
-      menu.className = 'sfut-soql-cell-menu';
+      menu.className = 'sfdt-soql-cell-menu';
       menu.style.cssText =
         'position: absolute; background: #fff; border: 1px solid #d8dde6; border-radius: 4px; box-shadow: 0 2px 8px rgba(0,0,0,0.15); z-index: 100030; padding: 4px 0; font-family: system-ui, sans-serif; font-size: 12px;';
 

--- a/extension/features/subflow-graph.ts
+++ b/extension/features/subflow-graph.ts
@@ -141,9 +141,9 @@ export function buildSubflowGraphSvg(doc: Document, graph: SubflowGraph): SVGSVG
 
   const defs = doc.createElementNS(SVG_NS, 'defs');
   for (const [id, fill] of [
-    ['sfut-arrow', '#54698d'],
-    ['sfut-arrow-cycle', '#c23934'],
-    ['sfut-arrow-missing', '#b46600'],
+    ['sfdt-arrow', '#54698d'],
+    ['sfdt-arrow-cycle', '#c23934'],
+    ['sfdt-arrow-missing', '#b46600'],
   ] as const) {
     const marker = doc.createElementNS(SVG_NS, 'marker');
     marker.setAttribute('id', id);
@@ -178,7 +178,7 @@ export function buildSubflowGraphSvg(doc: Document, graph: SubflowGraph): SVGSVG
         line.setAttribute('stroke', '#b46600');
         line.setAttribute('stroke-width', '1.5');
         line.setAttribute('stroke-dasharray', '4 3');
-        line.setAttribute('marker-end', 'url(#sfut-arrow-missing)');
+        line.setAttribute('marker-end', 'url(#sfdt-arrow-missing)');
         svg.appendChild(line);
         continue;
       }
@@ -193,7 +193,7 @@ export function buildSubflowGraphSvg(doc: Document, graph: SubflowGraph): SVGSVG
       path.setAttribute('stroke', isCycle ? '#c23934' : '#54698d');
       path.setAttribute('stroke-width', isCycle ? '2' : '1.5');
       if (edge.missing) path.setAttribute('stroke-dasharray', '4 3');
-      path.setAttribute('marker-end', isCycle ? 'url(#sfut-arrow-cycle)' : 'url(#sfut-arrow)');
+      path.setAttribute('marker-end', isCycle ? 'url(#sfdt-arrow-cycle)' : 'url(#sfdt-arrow)');
       svg.appendChild(path);
     }
   }

--- a/extension/features/trigger-conflicts.ts
+++ b/extension/features/trigger-conflicts.ts
@@ -105,7 +105,7 @@ export function buildConflictsModal(
   const onDeactivate = options.onDeactivate;
 
   const overlay = doc.createElement('div');
-  overlay.className = 'sfut-trigger-conflicts-overlay';
+  overlay.className = 'sfdt-trigger-conflicts-overlay';
   overlay.style.cssText =
     'position: fixed; inset: 0; background: rgba(0,0,0,0.4); z-index: 100020; display: flex; align-items: center; justify-content: center; font-family: system-ui, sans-serif;';
 

--- a/extension/lib/feature-registry.ts
+++ b/extension/lib/feature-registry.ts
@@ -80,8 +80,8 @@ export function createFeatureRegistry(options: {
   notify?: (message: string) => void;
 } = {}): FeatureRegistry {
   const logger: RegistryLogger = options.logger ?? {
-    log: (msg, ...rest) => console.log(`[SFUT] ${msg}`, ...rest),
-    warn: (msg, ...rest) => console.warn(`[SFUT] ${msg}`, ...rest),
+    log: (msg, ...rest) => console.log(`[SFDT] ${msg}`, ...rest),
+    warn: (msg, ...rest) => console.warn(`[SFDT] ${msg}`, ...rest),
   };
   const log = (msg: string, ...rest: unknown[]): void => logger.log(msg, ...rest);
   const warn = (msg: string, ...rest: unknown[]): void => logger.warn(msg, ...rest);

--- a/extension/lib/killswitch-cache.ts
+++ b/extension/lib/killswitch-cache.ts
@@ -7,10 +7,10 @@
 // (pre-stamping writes, manual tampering) are treated as stale too: their
 // age is unknowable, and the next successful ping rewrites a stamped record.
 
-// Renamed from the legacy 'sfut.killswitch.cache'. Intentionally NOT migrated:
-// this is a 24h ephemeral cache the next boot ping repopulates, and carrying a
-// stale kill-switch record forward would be worse than simply dropping it.
 const STORAGE_KEY = 'sfdt.killswitch.cache';
+// Legacy "SFUT"-era key; migrated forward on first read. Safe even for a stale
+// record — the 24h staleness check below still discards it after migration.
+const LEGACY_STORAGE_KEY = 'sfut.killswitch.cache';
 
 /** Cache entries older than this are ignored on read. */
 export const KILL_SWITCH_CACHE_MAX_AGE_MS = 24 * 60 * 60 * 1000;
@@ -20,18 +20,32 @@ interface CacheRecord {
   ts: number;
 }
 
-export async function readKillSwitchCache(now: number = Date.now()): Promise<readonly string[]> {
+function readRecord(): Promise<CacheRecord | undefined> {
   return new Promise((resolve) => {
-    chrome.storage.local.get(STORAGE_KEY, (result) => {
-      const raw = result?.[STORAGE_KEY] as CacheRecord | undefined;
-      if (!raw || !Array.isArray(raw.disabled)) return resolve([]);
-      // Stale or un-stamped → behave exactly as if no cache existed.
-      if (typeof raw.ts !== 'number' || now - raw.ts > KILL_SWITCH_CACHE_MAX_AGE_MS) {
-        return resolve([]);
+    chrome.storage.local.get([STORAGE_KEY, LEGACY_STORAGE_KEY], (result) => {
+      const current = result?.[STORAGE_KEY] as CacheRecord | undefined;
+      if (current !== undefined) return resolve(current);
+      // One-time migration from the legacy sfut.* key.
+      const legacy = result?.[LEGACY_STORAGE_KEY] as CacheRecord | undefined;
+      if (legacy !== undefined) {
+        chrome.storage.local.set({ [STORAGE_KEY]: legacy }, () => {
+          chrome.storage.local.remove(LEGACY_STORAGE_KEY, () => resolve(legacy));
+        });
+        return;
       }
-      resolve(raw.disabled.filter((v) => typeof v === 'string' && v.length > 0));
+      resolve(undefined);
     });
   });
+}
+
+export async function readKillSwitchCache(now: number = Date.now()): Promise<readonly string[]> {
+  const raw = await readRecord();
+  if (!raw || !Array.isArray(raw.disabled)) return [];
+  // Stale or un-stamped → behave exactly as if no cache existed.
+  if (typeof raw.ts !== 'number' || now - raw.ts > KILL_SWITCH_CACHE_MAX_AGE_MS) {
+    return [];
+  }
+  return raw.disabled.filter((v) => typeof v === 'string' && v.length > 0);
 }
 
 export async function writeKillSwitchCache(disabled: readonly string[]): Promise<void> {

--- a/extension/lib/killswitch-cache.ts
+++ b/extension/lib/killswitch-cache.ts
@@ -7,7 +7,10 @@
 // (pre-stamping writes, manual tampering) are treated as stale too: their
 // age is unknowable, and the next successful ping rewrites a stamped record.
 
-const STORAGE_KEY = 'sfut.killswitch.cache';
+// Renamed from the legacy 'sfut.killswitch.cache'. Intentionally NOT migrated:
+// this is a 24h ephemeral cache the next boot ping repopulates, and carrying a
+// stale kill-switch record forward would be worse than simply dropping it.
+const STORAGE_KEY = 'sfdt.killswitch.cache';
 
 /** Cache entries older than this are ignored on read. */
 export const KILL_SWITCH_CACHE_MAX_AGE_MS = 24 * 60 * 60 * 1000;

--- a/extension/lib/killswitch-cache.ts
+++ b/extension/lib/killswitch-cache.ts
@@ -8,9 +8,6 @@
 // age is unknowable, and the next successful ping rewrites a stamped record.
 
 const STORAGE_KEY = 'sfdt.killswitch.cache';
-// Legacy "SFUT"-era key; migrated forward on first read. Safe even for a stale
-// record — the 24h staleness check below still discards it after migration.
-const LEGACY_STORAGE_KEY = 'sfut.killswitch.cache';
 
 /** Cache entries older than this are ignored on read. */
 export const KILL_SWITCH_CACHE_MAX_AGE_MS = 24 * 60 * 60 * 1000;
@@ -20,32 +17,18 @@ interface CacheRecord {
   ts: number;
 }
 
-function readRecord(): Promise<CacheRecord | undefined> {
+export async function readKillSwitchCache(now: number = Date.now()): Promise<readonly string[]> {
   return new Promise((resolve) => {
-    chrome.storage.local.get([STORAGE_KEY, LEGACY_STORAGE_KEY], (result) => {
-      const current = result?.[STORAGE_KEY] as CacheRecord | undefined;
-      if (current !== undefined) return resolve(current);
-      // One-time migration from the legacy sfut.* key.
-      const legacy = result?.[LEGACY_STORAGE_KEY] as CacheRecord | undefined;
-      if (legacy !== undefined) {
-        chrome.storage.local.set({ [STORAGE_KEY]: legacy }, () => {
-          chrome.storage.local.remove(LEGACY_STORAGE_KEY, () => resolve(legacy));
-        });
-        return;
+    chrome.storage.local.get(STORAGE_KEY, (result) => {
+      const raw = result?.[STORAGE_KEY] as CacheRecord | undefined;
+      if (!raw || !Array.isArray(raw.disabled)) return resolve([]);
+      // Stale or un-stamped → behave exactly as if no cache existed.
+      if (typeof raw.ts !== 'number' || now - raw.ts > KILL_SWITCH_CACHE_MAX_AGE_MS) {
+        return resolve([]);
       }
-      resolve(undefined);
+      resolve(raw.disabled.filter((v) => typeof v === 'string' && v.length > 0));
     });
   });
-}
-
-export async function readKillSwitchCache(now: number = Date.now()): Promise<readonly string[]> {
-  const raw = await readRecord();
-  if (!raw || !Array.isArray(raw.disabled)) return [];
-  // Stale or un-stamped → behave exactly as if no cache existed.
-  if (typeof raw.ts !== 'number' || now - raw.ts > KILL_SWITCH_CACHE_MAX_AGE_MS) {
-    return [];
-  }
-  return raw.disabled.filter((v) => typeof v === 'string' && v.length > 0);
 }
 
 export async function writeKillSwitchCache(disabled: readonly string[]): Promise<void> {

--- a/extension/lib/settings.ts
+++ b/extension/lib/settings.ts
@@ -94,9 +94,6 @@ export function isFeatureEnabled(settings: Settings, featureId: string): boolean
 }
 
 const STORAGE_KEY = 'sfdt.settings';
-// The extension was formerly named "SFUT"; settings were stored under this key.
-// Read it once and migrate forward so existing users keep their preferences.
-const LEGACY_STORAGE_KEY = 'sfut.settings';
 
 // Invalidated by the storage onChanged listener at the bottom.
 let _cache: Settings | null = null;
@@ -139,21 +136,7 @@ function defaultSettings(): Settings {
 
 async function readRaw(): Promise<unknown> {
   return new Promise((resolve) => {
-    chrome.storage.local.get([STORAGE_KEY, LEGACY_STORAGE_KEY], (result) => {
-      if (result?.[STORAGE_KEY] !== undefined) {
-        resolve(result[STORAGE_KEY]);
-        return;
-      }
-      const legacy = result?.[LEGACY_STORAGE_KEY];
-      if (legacy !== undefined) {
-        // One-time migration from the legacy sfut.* key: copy forward, drop old.
-        chrome.storage.local.set({ [STORAGE_KEY]: legacy }, () => {
-          chrome.storage.local.remove(LEGACY_STORAGE_KEY, () => resolve(legacy));
-        });
-        return;
-      }
-      resolve(undefined);
-    });
+    chrome.storage.local.get(STORAGE_KEY, (result) => resolve(result?.[STORAGE_KEY]));
   });
 }
 

--- a/extension/lib/settings.ts
+++ b/extension/lib/settings.ts
@@ -93,7 +93,10 @@ export function isFeatureEnabled(settings: Settings, featureId: string): boolean
   return true;
 }
 
-const STORAGE_KEY = 'sfut.settings';
+const STORAGE_KEY = 'sfdt.settings';
+// The extension was formerly named "SFUT"; settings were stored under this key.
+// Read it once and migrate forward so existing users keep their preferences.
+const LEGACY_STORAGE_KEY = 'sfut.settings';
 
 // Invalidated by the storage onChanged listener at the bottom.
 let _cache: Settings | null = null;
@@ -136,7 +139,21 @@ function defaultSettings(): Settings {
 
 async function readRaw(): Promise<unknown> {
   return new Promise((resolve) => {
-    chrome.storage.local.get(STORAGE_KEY, (result) => resolve(result?.[STORAGE_KEY]));
+    chrome.storage.local.get([STORAGE_KEY, LEGACY_STORAGE_KEY], (result) => {
+      if (result?.[STORAGE_KEY] !== undefined) {
+        resolve(result[STORAGE_KEY]);
+        return;
+      }
+      const legacy = result?.[LEGACY_STORAGE_KEY];
+      if (legacy !== undefined) {
+        // One-time migration from the legacy sfut.* key: copy forward, drop old.
+        chrome.storage.local.set({ [STORAGE_KEY]: legacy }, () => {
+          chrome.storage.local.remove(LEGACY_STORAGE_KEY, () => resolve(legacy));
+        });
+        return;
+      }
+      resolve(undefined);
+    });
   });
 }
 

--- a/extension/lib/spa-router.ts
+++ b/extension/lib/spa-router.ts
@@ -38,11 +38,11 @@ export function createSpaRouter(options: {
         const result = listener({ url, previousUrl });
         if (result && typeof (result as Promise<void>).then === 'function') {
           (result as Promise<void>).catch((err) => {
-            console.warn('[SFUT spa-router] listener rejected:', err);
+            console.warn('[SFDT spa-router] listener rejected:', err);
           });
         }
       } catch (err) {
-        console.warn('[SFUT spa-router] listener threw:', err);
+        console.warn('[SFDT spa-router] listener threw:', err);
       }
     }
   }

--- a/extension/lib/telemetry.ts
+++ b/extension/lib/telemetry.ts
@@ -2,8 +2,6 @@
 // (or support) can see which features run in this browser profile.
 
 const STORAGE_KEY = 'sfdt.telemetry';
-// Legacy "SFUT"-era key; migrated forward on first read so opt-in counters survive.
-const LEGACY_STORAGE_KEY = 'sfut.telemetry';
 const MAX_FEATURE_IDS = 500;
 
 export type TelemetryEvent =
@@ -67,24 +65,19 @@ function emptyCounter(): FeatureCounter {
   return { activated: 0, errored: 0, disabled_remote: 0 };
 }
 
-function isValidSnapshot(raw: TelemetrySnapshot | undefined): raw is TelemetrySnapshot {
-  return !!raw && typeof raw.monthKey === 'string' && !!raw.counters && typeof raw.counters === 'object';
-}
-
 async function read(): Promise<TelemetrySnapshot | null> {
   return new Promise((resolve) => {
-    chrome.storage.local.get([STORAGE_KEY, LEGACY_STORAGE_KEY], (result) => {
-      const current = result?.[STORAGE_KEY] as TelemetrySnapshot | undefined;
-      if (isValidSnapshot(current)) return resolve(current);
-      // One-time migration from the legacy sfut.* key.
-      const legacy = result?.[LEGACY_STORAGE_KEY] as TelemetrySnapshot | undefined;
-      if (isValidSnapshot(legacy)) {
-        chrome.storage.local.set({ [STORAGE_KEY]: legacy }, () => {
-          chrome.storage.local.remove(LEGACY_STORAGE_KEY, () => resolve(legacy));
-        });
-        return;
+    chrome.storage.local.get(STORAGE_KEY, (result) => {
+      const raw = result?.[STORAGE_KEY] as TelemetrySnapshot | undefined;
+      if (
+        !raw ||
+        typeof raw.monthKey !== 'string' ||
+        !raw.counters ||
+        typeof raw.counters !== 'object'
+      ) {
+        return resolve(null);
       }
-      resolve(null);
+      resolve(raw);
     });
   });
 }

--- a/extension/lib/telemetry.ts
+++ b/extension/lib/telemetry.ts
@@ -1,7 +1,9 @@
 // Opt-in, local-only — no network egress. The data exists so the user
 // (or support) can see which features run in this browser profile.
 
-const STORAGE_KEY = 'sfut.telemetry';
+const STORAGE_KEY = 'sfdt.telemetry';
+// Legacy "SFUT"-era key; migrated forward on first read so opt-in counters survive.
+const LEGACY_STORAGE_KEY = 'sfut.telemetry';
 const MAX_FEATURE_IDS = 500;
 
 export type TelemetryEvent =
@@ -65,19 +67,24 @@ function emptyCounter(): FeatureCounter {
   return { activated: 0, errored: 0, disabled_remote: 0 };
 }
 
+function isValidSnapshot(raw: TelemetrySnapshot | undefined): raw is TelemetrySnapshot {
+  return !!raw && typeof raw.monthKey === 'string' && !!raw.counters && typeof raw.counters === 'object';
+}
+
 async function read(): Promise<TelemetrySnapshot | null> {
   return new Promise((resolve) => {
-    chrome.storage.local.get(STORAGE_KEY, (result) => {
-      const raw = result?.[STORAGE_KEY] as TelemetrySnapshot | undefined;
-      if (
-        !raw ||
-        typeof raw.monthKey !== 'string' ||
-        !raw.counters ||
-        typeof raw.counters !== 'object'
-      ) {
-        return resolve(null);
+    chrome.storage.local.get([STORAGE_KEY, LEGACY_STORAGE_KEY], (result) => {
+      const current = result?.[STORAGE_KEY] as TelemetrySnapshot | undefined;
+      if (isValidSnapshot(current)) return resolve(current);
+      // One-time migration from the legacy sfut.* key.
+      const legacy = result?.[LEGACY_STORAGE_KEY] as TelemetrySnapshot | undefined;
+      if (isValidSnapshot(legacy)) {
+        chrome.storage.local.set({ [STORAGE_KEY]: legacy }, () => {
+          chrome.storage.local.remove(LEGACY_STORAGE_KEY, () => resolve(legacy));
+        });
+        return;
       }
-      resolve(raw);
+      resolve(null);
     });
   });
 }

--- a/extension/test/canvas-search.test.ts
+++ b/extension/test/canvas-search.test.ts
@@ -134,7 +134,7 @@ describe('extension/features/canvas-search', () => {
     it('onActivate mounts the search bar', () => {
       const feature = createCanvasSearchFeature();
       feature.onActivate?.();
-      expect(document.querySelector('.sfut-canvas-search-bar')).not.toBeNull();
+      expect(document.querySelector('.sfdt-canvas-search-bar')).not.toBeNull();
     });
 
     it('typing into the search bar highlights matching cards (after debounce)', async () => {
@@ -144,14 +144,14 @@ describe('extension/features/canvas-search', () => {
       document.body.appendChild(elementCard('Send Email', 'Action'));
       feature.onActivate?.();
 
-      const input = document.querySelector<HTMLInputElement>('.sfut-canvas-search-bar-input')!;
+      const input = document.querySelector<HTMLInputElement>('.sfdt-canvas-search-bar-input')!;
       input.value = 'account';
       input.dispatchEvent(new Event('input', { bubbles: true }));
       await new Promise((r) => setTimeout(r, 200));
 
       const highlighted = document.querySelectorAll(`.${HIGHLIGHT_CLASS}`);
       expect(highlighted).toHaveLength(1);
-      expect(document.querySelector('.sfut-canvas-search-bar-count')?.textContent).toBe('1 of 1');
+      expect(document.querySelector('.sfdt-canvas-search-bar-count')?.textContent).toBe('1 of 1');
     });
 
     it('the close button removes the search bar and clears highlights', () => {
@@ -159,9 +159,9 @@ describe('extension/features/canvas-search', () => {
       document.body.appendChild(elementCard('A', 'B'));
       feature.onActivate?.();
       document
-        .querySelector<HTMLButtonElement>('.sfut-canvas-search-bar-close')!
+        .querySelector<HTMLButtonElement>('.sfdt-canvas-search-bar-close')!
         .click();
-      expect(document.querySelector('.sfut-canvas-search-bar')).toBeNull();
+      expect(document.querySelector('.sfdt-canvas-search-bar')).toBeNull();
       expect(document.querySelectorAll(`.${HIGHLIGHT_CLASS}`)).toHaveLength(0);
     });
   });
@@ -182,9 +182,9 @@ describe('canvas-search teardown', () => {
   it('removes the dynamic style element', async () => {
     const feature = createCanvasSearchFeature();
     await feature.init?.();
-    expect(document.getElementById('sfut-canvas-search-dynamic')).not.toBeNull();
+    expect(document.getElementById('sfdt-canvas-search-dynamic')).not.toBeNull();
     await feature.teardown?.();
-    expect(document.getElementById('sfut-canvas-search-dynamic')).toBeNull();
+    expect(document.getElementById('sfdt-canvas-search-dynamic')).toBeNull();
   });
 
   it('does not throw when called twice', async () => {

--- a/extension/test/data-import.test.ts
+++ b/extension/test/data-import.test.ts
@@ -97,7 +97,7 @@ describe('data-import — UI Flow & Mock SOAP', () => {
     await new Promise((r) => setTimeout(r, 0));
 
     // Wizard is loaded, check DOM
-    const overlay = document.querySelector('.sfut-data-import-overlay');
+    const overlay = document.querySelector('.sfdt-data-import-overlay');
     expect(overlay).not.toBeNull();
 
     // Pasting data

--- a/extension/test/event-monitor.test.ts
+++ b/extension/test/event-monitor.test.ts
@@ -402,13 +402,13 @@ describe('Event Streaming Monitor UI Feature', () => {
     const feature = createEventMonitorFeature({ api });
     await feature.onActivate?.();
 
-    expect(document.querySelector('.sfut-event-monitor-overlay')).not.toBeNull();
+    expect(document.querySelector('.sfdt-event-monitor-overlay')).not.toBeNull();
 
     const closeBtn = Array.from(document.querySelectorAll('button')).find((b) => b.textContent === '×');
     expect(closeBtn).not.toBeUndefined();
     closeBtn?.click();
 
-    expect(document.querySelector('.sfut-event-monitor-overlay')).toBeNull();
+    expect(document.querySelector('.sfdt-event-monitor-overlay')).toBeNull();
   });
 
   it('updates channel dropdown when Channel Type changes', async () => {

--- a/extension/test/feature-registry.test.ts
+++ b/extension/test/feature-registry.test.ts
@@ -352,7 +352,7 @@ describe('extension/lib/feature-registry', () => {
       disabledRemote: new Set(),
       isUserEnabled: () => true,
     });
-    const container = document.getElementById('sfut-toast-container');
+    const container = document.getElementById('sfdt-toast-container');
     expect(container?.textContent).toContain('Alpha Feature');
     container?.remove();
   });

--- a/extension/test/field-creator.test.ts
+++ b/extension/test/field-creator.test.ts
@@ -66,7 +66,7 @@ describe('field-creator — UI flow & Tooling API deployment', () => {
     await new Promise((r) => setTimeout(r, 0));
 
     // Check overlay
-    const overlay = document.querySelector('.sfut-field-creator-overlay');
+    const overlay = document.querySelector('.sfdt-field-creator-overlay');
     expect(overlay).not.toBeNull();
 
     // SObject selector

--- a/extension/test/flow-list-search.test.ts
+++ b/extension/test/flow-list-search.test.ts
@@ -167,7 +167,7 @@ describe('extension/features/flow-list-search', () => {
       document.body.appendChild(buildTable([{ name: 'A', apiName: 'A', active: true }]));
       const feature = createFlowListSearchFeature({ waitTimeoutMs: 50 });
       await feature.init?.();
-      expect(document.getElementById('sfut-flow-search-container')).toBeNull();
+      expect(document.getElementById('sfdt-flow-search-container')).toBeNull();
     });
 
     it('init injects the search bar when the list view is present', async () => {
@@ -177,8 +177,8 @@ describe('extension/features/flow-list-search', () => {
       document.body.appendChild(wrap);
       const feature = createFlowListSearchFeature({ waitTimeoutMs: 200 });
       await feature.init?.();
-      expect(document.getElementById('sfut-flow-search-container')).not.toBeNull();
-      expect(document.getElementById('sfut-flow-search-input')).not.toBeNull();
+      expect(document.getElementById('sfdt-flow-search-container')).not.toBeNull();
+      expect(document.getElementById('sfdt-flow-search-input')).not.toBeNull();
     });
 
     it('exposes a working type filter populated from the rows', async () => {
@@ -193,7 +193,7 @@ describe('extension/features/flow-list-search', () => {
       document.body.appendChild(wrap);
       const feature = createFlowListSearchFeature({ waitTimeoutMs: 200 });
       await feature.init?.();
-      const select = document.getElementById('sfut-flow-type-filter') as HTMLSelectElement;
+      const select = document.getElementById('sfdt-flow-type-filter') as HTMLSelectElement;
       expect(select).not.toBeNull();
       // Two trigger types plus the "All Types" placeholder.
       expect(select.options.length).toBe(3);

--- a/extension/test/flow-version-manager.test.ts
+++ b/extension/test/flow-version-manager.test.ts
@@ -14,21 +14,21 @@ describe('flow-version-manager teardown', () => {
     const feature = createFlowVersionManagerFeature();
     await feature.init?.();
     await feature.teardown?.();
-    expect(document.querySelector('.sfut-version-manager-panel')).toBeNull();
+    expect(document.querySelector('.sfdt-version-manager-panel')).toBeNull();
   });
 
   it('removes injected checkbox column cells on teardown', async () => {
     const feature = createFlowVersionManagerFeature();
     await feature.init?.();
     await feature.teardown?.();
-    expect(document.querySelectorAll('.sfut-version-select-cell')).toHaveLength(0);
+    expect(document.querySelectorAll('.sfdt-version-select-cell')).toHaveLength(0);
   });
 
   it('removes the toolbar delete button on teardown', async () => {
     const feature = createFlowVersionManagerFeature();
     await feature.init?.();
     await feature.teardown?.();
-    expect(document.querySelector('.sfut-version-manager-delete-btn')).toBeNull();
+    expect(document.querySelector('.sfdt-version-manager-delete-btn')).toBeNull();
   });
 
   it('teardown does not throw even if init was never called', async () => {
@@ -48,10 +48,10 @@ describe('flow-version-manager teardown', () => {
     await feature.init?.();
     // Simulate an open confirmation modal by manually injecting the backdrop
     const backdrop = document.createElement('div');
-    backdrop.className = 'sfut-version-manager-backdrop';
+    backdrop.className = 'sfdt-version-manager-backdrop';
     document.body.appendChild(backdrop);
-    expect(document.querySelector('.sfut-version-manager-backdrop')).not.toBeNull();
+    expect(document.querySelector('.sfdt-version-manager-backdrop')).not.toBeNull();
     await feature.teardown?.();
-    expect(document.querySelector('.sfut-version-manager-backdrop')).toBeNull();
+    expect(document.querySelector('.sfdt-version-manager-backdrop')).toBeNull();
   });
 });

--- a/extension/test/inspect-record.test.ts
+++ b/extension/test/inspect-record.test.ts
@@ -132,7 +132,7 @@ describe('inspect-record — UI activation & inspection', () => {
     await new Promise((r) => setTimeout(r, 0));
 
     // Verify modal elements are shown
-    const title = document.querySelector('.sfut-inspect-record-overlay span') as HTMLSpanElement;
+    const title = document.querySelector('.sfdt-inspect-record-overlay span') as HTMLSpanElement;
     expect(title.textContent).toContain('Account · 001800000000001AAA');
 
     const trs = document.querySelectorAll('tbody tr');

--- a/extension/test/killswitch-cache.test.ts
+++ b/extension/test/killswitch-cache.test.ts
@@ -60,4 +60,18 @@ describe('killswitch-cache', () => {
     } as any);
     expect(await readKillSwitchCache()).toEqual([]);
   });
+
+  it('migrates a fresh record from the legacy sfut.killswitch.cache key', async () => {
+    const now = Date.now();
+    chrome.storage.local.set({
+      'sfut.killswitch.cache': { disabled: ['flow-deploy'], ts: now },
+    } as any);
+    expect(await readKillSwitchCache(now)).toEqual(['flow-deploy']);
+    // Migrated forward: new key written, legacy key removed.
+    const after = await new Promise<any>((r) =>
+      chrome.storage.local.get(['sfdt.killswitch.cache', 'sfut.killswitch.cache'], r),
+    );
+    expect(after['sfdt.killswitch.cache']).toBeDefined();
+    expect(after['sfut.killswitch.cache']).toBeUndefined();
+  });
 });

--- a/extension/test/killswitch-cache.test.ts
+++ b/extension/test/killswitch-cache.test.ts
@@ -27,7 +27,7 @@ describe('killswitch-cache', () => {
 
   it('filters non-string entries on read (defensive)', async () => {
     chrome.storage.local.set({
-      'sfut.killswitch.cache': { disabled: ['canvas-search', 42, null], ts: Date.now() },
+      'sfdt.killswitch.cache': { disabled: ['canvas-search', 42, null], ts: Date.now() },
     } as any);
     expect(await readKillSwitchCache()).toEqual(['canvas-search']);
   });
@@ -35,7 +35,7 @@ describe('killswitch-cache', () => {
   it('honours a fresh cache (younger than 24h)', async () => {
     const now = Date.now();
     chrome.storage.local.set({
-      'sfut.killswitch.cache': {
+      'sfdt.killswitch.cache': {
         disabled: ['canvas-search'],
         ts: now - (KILL_SWITCH_CACHE_MAX_AGE_MS - 60_000), // 23h59m old
       },
@@ -46,7 +46,7 @@ describe('killswitch-cache', () => {
   it('treats a cache older than 24h as stale and falls back to the default ([])', async () => {
     const now = Date.now();
     chrome.storage.local.set({
-      'sfut.killswitch.cache': {
+      'sfdt.killswitch.cache': {
         disabled: ['canvas-search'],
         ts: now - (KILL_SWITCH_CACHE_MAX_AGE_MS + 60_000), // 24h01m old
       },
@@ -56,7 +56,7 @@ describe('killswitch-cache', () => {
 
   it('treats an un-stamped legacy record (missing ts) as stale', async () => {
     chrome.storage.local.set({
-      'sfut.killswitch.cache': { disabled: ['canvas-search'] },
+      'sfdt.killswitch.cache': { disabled: ['canvas-search'] },
     } as any);
     expect(await readKillSwitchCache()).toEqual([]);
   });

--- a/extension/test/killswitch-cache.test.ts
+++ b/extension/test/killswitch-cache.test.ts
@@ -60,18 +60,4 @@ describe('killswitch-cache', () => {
     } as any);
     expect(await readKillSwitchCache()).toEqual([]);
   });
-
-  it('migrates a fresh record from the legacy sfut.killswitch.cache key', async () => {
-    const now = Date.now();
-    chrome.storage.local.set({
-      'sfut.killswitch.cache': { disabled: ['flow-deploy'], ts: now },
-    } as any);
-    expect(await readKillSwitchCache(now)).toEqual(['flow-deploy']);
-    // Migrated forward: new key written, legacy key removed.
-    const after = await new Promise<any>((r) =>
-      chrome.storage.local.get(['sfdt.killswitch.cache', 'sfut.killswitch.cache'], r),
-    );
-    expect(after['sfdt.killswitch.cache']).toBeDefined();
-    expect(after['sfut.killswitch.cache']).toBeUndefined();
-  });
 });

--- a/extension/test/metadata-retrieve.test.ts
+++ b/extension/test/metadata-retrieve.test.ts
@@ -121,7 +121,7 @@ describe('metadata-retrieve — UI & Operations', () => {
 
     await new Promise((r) => setTimeout(r, 0));
 
-    const chk = document.querySelector('.sfut-tree-chk') as HTMLInputElement;
+    const chk = document.querySelector('.sfdt-tree-chk') as HTMLInputElement;
     expect(chk).not.toBeNull();
     chk.click();
 

--- a/extension/test/missing-description-flags.test.ts
+++ b/extension/test/missing-description-flags.test.ts
@@ -65,10 +65,10 @@ describe('extension/features/missing-description-flags', () => {
       flagCanvas(document, [
         { name: 'set_owner', label: 'Set Owner', type: 'Assignment', isResource: false },
       ]);
-      expect(card.querySelector('.sfut-desc-flag')).not.toBeNull();
+      expect(card.querySelector('.sfdt-desc-flag')).not.toBeNull();
 
       clearAllFlags(document);
-      expect(card.querySelector('.sfut-desc-flag')).toBeNull();
+      expect(card.querySelector('.sfdt-desc-flag')).toBeNull();
     });
 
     it('strips orchestrator number prefixes when matching ("1. Stage")', () => {
@@ -86,7 +86,7 @@ describe('extension/features/missing-description-flags', () => {
       flagCanvas(document, [
         { name: 'Onboarding', label: 'Onboarding', type: 'Stage', isResource: false },
       ]);
-      expect(card.querySelector('.sfut-desc-flag')).not.toBeNull();
+      expect(card.querySelector('.sfdt-desc-flag')).not.toBeNull();
     });
 
     it('builds case-insensitive lookup keys', () => {
@@ -121,12 +121,12 @@ describe('missing-description-flags teardown', () => {
     flagCanvas(document, [
       { name: 'set_owner', label: 'Set Owner', type: 'Assignment', isResource: false },
     ]);
-    expect(document.querySelector('.sfut-desc-flag')).not.toBeNull();
+    expect(document.querySelector('.sfdt-desc-flag')).not.toBeNull();
 
     const feature = createMissingDescriptionFlagsFeature();
     // Teardown should clean up regardless of whether init ran.
     await feature.teardown?.();
-    expect(document.querySelector('.sfut-desc-flag')).toBeNull();
+    expect(document.querySelector('.sfdt-desc-flag')).toBeNull();
   });
 
   it('does not throw when called twice', async () => {

--- a/extension/test/org-limits.test.ts
+++ b/extension/test/org-limits.test.ts
@@ -80,7 +80,7 @@ describe('org-limits — modal', () => {
     await new Promise((r) => setTimeout(r, 0));
 
     expect(api.limits).toHaveBeenCalled();
-    const cards = document.querySelectorAll('.sfut-org-limits-overlay > div > div:nth-child(2) > div > div');
+    const cards = document.querySelectorAll('.sfdt-org-limits-overlay > div > div:nth-child(2) > div > div');
     expect(cards.length).toBeGreaterThanOrEqual(2);
     const body = document.body.textContent ?? '';
     expect(body).toContain('Daily Api Requests');

--- a/extension/test/settings.test.ts
+++ b/extension/test/settings.test.ts
@@ -105,27 +105,6 @@ describe('settings.features legacy id adapter', () => {
     const s = await loadSettings();
     expect(isFeatureEnabled(s, 'never-toggled')).toBe(true);
   });
-
-  it('migrates settings from the legacy sfut.settings key', async () => {
-    // Only the legacy (SFUT-era) key is present, as it would be for an existing user.
-    chrome.storage.local.set({ 'sfut.settings': { features: { 'canvas-search': false } } } as any);
-    const s = await loadSettings();
-    // The legacy value is read…
-    expect(isFeatureEnabled(s, 'canvas-search')).toBe(false);
-    // …and migrated forward: new key written, old key removed.
-    const after = await new Promise<any>((r) => chrome.storage.local.get(['sfdt.settings', 'sfut.settings'], r));
-    expect(after['sfdt.settings']).toBeDefined();
-    expect(after['sfut.settings']).toBeUndefined();
-  });
-
-  it('prefers the new key and ignores legacy when both exist', async () => {
-    chrome.storage.local.set({
-      'sfdt.settings': { features: { 'canvas-search': true } },
-      'sfut.settings': { features: { 'canvas-search': false } },
-    } as any);
-    const s = await loadSettings();
-    expect(isFeatureEnabled(s, 'canvas-search')).toBe(true);
-  });
 });
 
 describe('registerSettingsShape', () => {

--- a/extension/test/settings.test.ts
+++ b/extension/test/settings.test.ts
@@ -80,7 +80,7 @@ describe('settings.features legacy id adapter', () => {
 
   it('reads kebab-case ids when written kebab-case', async () => {
     chrome.storage.local.set({
-      'sfut.settings': {
+      'sfdt.settings': {
         features: { 'canvas-search': true, 'flow-deploy': false },
       },
     } as any);
@@ -91,7 +91,7 @@ describe('settings.features legacy id adapter', () => {
 
   it('treats legacy camelCase keys as the canonical kebab-case ids', async () => {
     chrome.storage.local.set({
-      'sfut.settings': {
+      'sfdt.settings': {
         features: { setupTabs: true, missingDescriptions: false },
       },
     } as any);
@@ -101,9 +101,30 @@ describe('settings.features legacy id adapter', () => {
   });
 
   it('defaults unknown ids to enabled (enabledByDefault semantics)', async () => {
-    chrome.storage.local.set({ 'sfut.settings': { features: {} } } as any);
+    chrome.storage.local.set({ 'sfdt.settings': { features: {} } } as any);
     const s = await loadSettings();
     expect(isFeatureEnabled(s, 'never-toggled')).toBe(true);
+  });
+
+  it('migrates settings from the legacy sfut.settings key', async () => {
+    // Only the legacy (SFUT-era) key is present, as it would be for an existing user.
+    chrome.storage.local.set({ 'sfut.settings': { features: { 'canvas-search': false } } } as any);
+    const s = await loadSettings();
+    // The legacy value is read…
+    expect(isFeatureEnabled(s, 'canvas-search')).toBe(false);
+    // …and migrated forward: new key written, old key removed.
+    const after = await new Promise<any>((r) => chrome.storage.local.get(['sfdt.settings', 'sfut.settings'], r));
+    expect(after['sfdt.settings']).toBeDefined();
+    expect(after['sfut.settings']).toBeUndefined();
+  });
+
+  it('prefers the new key and ignores legacy when both exist', async () => {
+    chrome.storage.local.set({
+      'sfdt.settings': { features: { 'canvas-search': true } },
+      'sfut.settings': { features: { 'canvas-search': false } },
+    } as any);
+    const s = await loadSettings();
+    expect(isFeatureEnabled(s, 'canvas-search')).toBe(true);
   });
 });
 
@@ -123,7 +144,7 @@ describe('registerSettingsShape', () => {
     expect(sEmpty.featureSettings?.['canvas-search']).toBeUndefined();
     // Once values are explicitly stored, they are returned.
     chrome.storage.local.set({
-      'sfut.settings': { featureSettings: { 'canvas-search': { shortcut: 'Ctrl+Shift+F' } } },
+      'sfdt.settings': { featureSettings: { 'canvas-search': { shortcut: 'Ctrl+Shift+F' } } },
     } as any);
     _clearSettingsCacheForTests();
     const s = await loadSettings();
@@ -137,7 +158,7 @@ describe('registerSettingsShape', () => {
       pattern: z.enum(['a', 'b']).default('a'),
     }));
     chrome.storage.local.set({
-      'sfut.settings': {
+      'sfdt.settings': {
         featureSettings: { 'api-name-generator': { pattern: 'b' } },
       },
     } as any);
@@ -155,7 +176,7 @@ describe('registerSettingsShape', () => {
     expect(s2.featureSettings?.alpha).toBeUndefined();
     // Verify the shape IS honoured when a value is stored.
     chrome.storage.local.set({
-      'sfut.settings': { featureSettings: { alpha: { x: false } } },
+      'sfdt.settings': { featureSettings: { alpha: { x: false } } },
     } as any);
     _clearSettingsCacheForTests();
     const s3 = await loadSettings();

--- a/extension/test/setup-tabs.test.ts
+++ b/extension/test/setup-tabs.test.ts
@@ -41,20 +41,20 @@ describe('extension/features/setup-tabs', () => {
     await saveSettings(SettingsSchema.parse({ features: { setupTabs: false } }));
     const feature = createSetupTabsFeature({ waitTimeoutMs: 0 });
     await feature.init?.();
-    expect(document.querySelectorAll('.sfut-custom-tab')).toHaveLength(0);
+    expect(document.querySelectorAll('.sfdt-custom-tab')).toHaveLength(0);
   });
 
   it('injects the three base tabs when enabled', async () => {
     await saveSettings(SettingsSchema.parse({ features: { setupTabs: true } }));
     const feature = createSetupTabsFeature({ waitTimeoutMs: 0 });
     await feature.init?.();
-    const tabs = document.querySelectorAll('.sfut-custom-tab');
+    const tabs = document.querySelectorAll('.sfdt-custom-tab');
     expect(tabs).toHaveLength(3);
     const ids = Array.from(tabs).map((t) => (t as HTMLElement).dataset.tabId);
     expect(ids).toEqual([
-      'sfut_tab_flows',
-      'sfut_tab_flow_trigger_explorer',
-      'sfut_tab_process_automation_settings',
+      'sfdt_tab_flows',
+      'sfdt_tab_flow_trigger_explorer',
+      'sfdt_tab_process_automation_settings',
     ]);
   });
 
@@ -67,7 +67,7 @@ describe('extension/features/setup-tabs', () => {
     );
     const feature = createSetupTabsFeature({ waitTimeoutMs: 0 });
     await feature.init?.();
-    expect(document.querySelector('[data-tab-id="sfut_tab_automation_home"]')).not.toBeNull();
+    expect(document.querySelector('[data-tab-id="sfdt_tab_automation_home"]')).not.toBeNull();
   });
 
   it('collapses into a single dropdown when grouping is enabled', async () => {
@@ -79,9 +79,9 @@ describe('extension/features/setup-tabs', () => {
     );
     const feature = createSetupTabsFeature({ waitTimeoutMs: 0 });
     await feature.init?.();
-    expect(document.querySelectorAll('.sfut-custom-tab')).toHaveLength(1);
-    expect(document.querySelector('.sfut-group-tab')).not.toBeNull();
-    expect(document.querySelectorAll('.sfut-group-dropdown li')).toHaveLength(3);
+    expect(document.querySelectorAll('.sfdt-custom-tab')).toHaveLength(1);
+    expect(document.querySelector('.sfdt-group-tab')).not.toBeNull();
+    expect(document.querySelectorAll('.sfdt-group-dropdown li')).toHaveLength(3);
   });
 
   it('uses the org identifier from the URL hostname (v1.2.2 fix)', async () => {
@@ -93,7 +93,7 @@ describe('extension/features/setup-tabs', () => {
     const feature = createSetupTabsFeature({ waitTimeoutMs: 0 });
     await feature.init?.();
     const flowsTab = document.querySelector<HTMLAnchorElement>(
-      '[data-tab-id="sfut_tab_flows"] a',
+      '[data-tab-id="sfdt_tab_flows"] a',
     );
     expect(flowsTab?.href).toBe('https://x.my.salesforce-setup.com/lightning/setup/Flows/home');
   });
@@ -102,38 +102,38 @@ describe('extension/features/setup-tabs', () => {
     await saveSettings(SettingsSchema.parse({ features: { setupTabs: false } }));
     const feature = createSetupTabsFeature({ waitTimeoutMs: 0 });
     await feature.init?.();
-    expect(document.querySelectorAll('.sfut-custom-tab')).toHaveLength(0);
+    expect(document.querySelectorAll('.sfdt-custom-tab')).toHaveLength(0);
 
     await feature.onActivate?.();
     await flushSettings();
 
-    // The toast shim writes a `.sfut-toast` div into a container.
-    expect(document.querySelector('#sfut-toast-container')).not.toBeNull();
-    expect(document.querySelector('.sfut-toast')?.textContent).toBe('Setup Tabs enabled');
+    // The toast shim writes a `.sfdt-toast` div into a container.
+    expect(document.querySelector('#sfdt-toast-container')).not.toBeNull();
+    expect(document.querySelector('.sfdt-toast')?.textContent).toBe('Setup Tabs enabled');
   });
 
   it('removes injected tabs when the setting flips off after init', async () => {
     await saveSettings(SettingsSchema.parse({ features: { setupTabs: true } }));
     const feature = createSetupTabsFeature({ waitTimeoutMs: 0 });
     await feature.init?.();
-    expect(document.querySelectorAll('.sfut-custom-tab').length).toBeGreaterThan(0);
+    expect(document.querySelectorAll('.sfdt-custom-tab').length).toBeGreaterThan(0);
 
     await patchSettings({ features: { setupTabs: false } } as never);
     await flushSettings();
 
-    expect(document.querySelectorAll('.sfut-custom-tab')).toHaveLength(0);
+    expect(document.querySelectorAll('.sfdt-custom-tab')).toHaveLength(0);
   });
 
   it('refresh() re-injects from current settings', async () => {
     await saveSettings(SettingsSchema.parse({ features: { setupTabs: true } }));
     const feature = createSetupTabsFeature({ waitTimeoutMs: 0 });
     await feature.init?.();
-    expect(document.querySelectorAll('.sfut-custom-tab')).toHaveLength(3);
+    expect(document.querySelectorAll('.sfdt-custom-tab')).toHaveLength(3);
 
     // Force-remove and call refresh — should restore the 3 tabs.
-    document.querySelectorAll('.sfut-custom-tab').forEach((t) => t.remove());
+    document.querySelectorAll('.sfdt-custom-tab').forEach((t) => t.remove());
     await feature.refresh?.();
-    expect(document.querySelectorAll('.sfut-custom-tab')).toHaveLength(3);
+    expect(document.querySelectorAll('.sfdt-custom-tab')).toHaveLength(3);
   });
 
   it('does nothing if the tab bar never appears (timeout, falsy bar)', async () => {
@@ -143,7 +143,7 @@ describe('extension/features/setup-tabs', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const feature = createSetupTabsFeature({ waitTimeoutMs: 5 });
     await feature.init?.();
-    expect(document.querySelectorAll('.sfut-custom-tab')).toHaveLength(0);
+    expect(document.querySelectorAll('.sfdt-custom-tab')).toHaveLength(0);
     expect(warn).toHaveBeenCalled();
     warn.mockRestore();
   });
@@ -163,9 +163,9 @@ describe('setup-tabs teardown', () => {
     await saveSettings(SettingsSchema.parse({ features: { setupTabs: true } }));
     const feature = createSetupTabsFeature({ waitTimeoutMs: 0 });
     await feature.init?.();
-    expect(document.querySelectorAll('.sfut-custom-tab').length).toBeGreaterThan(0);
+    expect(document.querySelectorAll('.sfdt-custom-tab').length).toBeGreaterThan(0);
     await feature.teardown?.();
-    expect(document.querySelectorAll('.sfut-custom-tab')).toHaveLength(0);
+    expect(document.querySelectorAll('.sfdt-custom-tab')).toHaveLength(0);
   });
 
   it('does not throw when called twice', async () => {

--- a/extension/test/side-button.test.ts
+++ b/extension/test/side-button.test.ts
@@ -18,8 +18,8 @@ describe('extension/ui/side-button', () => {
       menuItemsProvider: () => [],
       handlers: { onActivate: vi.fn(), onOpenSettings: vi.fn() },
     });
-    expect(document.getElementById('sfut-side-button')).not.toBeNull();
-    expect(document.getElementById('sfut-menu')).not.toBeNull();
+    expect(document.getElementById('sfdt-side-button')).not.toBeNull();
+    expect(document.getElementById('sfdt-menu')).not.toBeNull();
     expect(handle.isMounted()).toBe(true);
   });
 
@@ -28,7 +28,7 @@ describe('extension/ui/side-button', () => {
       menuItemsProvider: () => [],
       handlers: { onActivate: vi.fn(), onOpenSettings: vi.fn() },
     });
-    expect(document.querySelector('.sfut-menu-empty')?.textContent).toContain(
+    expect(document.querySelector('.sfdt-menu-empty')?.textContent).toContain(
       'No tools available',
     );
   });
@@ -42,7 +42,7 @@ describe('extension/ui/side-button', () => {
       menuItemsProvider: () => items,
       handlers: { onActivate: vi.fn(), onOpenSettings: vi.fn() },
     });
-    const nodes = document.querySelectorAll('.sfut-menu-item');
+    const nodes = document.querySelectorAll('.sfdt-menu-item');
     expect(nodes).toHaveLength(2);
     expect(nodes[0]!.textContent).toContain('Run Health Check');
     expect(nodes[1]!.textContent).toContain('Setup Tabs');
@@ -53,8 +53,8 @@ describe('extension/ui/side-button', () => {
       menuItemsProvider: () => [],
       handlers: { onActivate: vi.fn(), onOpenSettings: vi.fn() },
     });
-    const button = document.getElementById('sfut-side-button')!;
-    const menu = document.getElementById('sfut-menu')!;
+    const button = document.getElementById('sfdt-side-button')!;
+    const menu = document.getElementById('sfdt-menu')!;
     expect((menu as HTMLElement).style.display).toBe('none');
     button.click();
     expect((menu as HTMLElement).style.display).toBe('block');
@@ -74,9 +74,9 @@ describe('extension/ui/side-button', () => {
     // textContent is the only way labels reach the DOM, so any injected HTML
     // is rendered as literal text. There should be no <img> or <script>
     // elements produced from those strings.
-    expect(document.querySelector('.sfut-menu-item img')).toBeNull();
-    expect(document.querySelector('.sfut-menu-item script')).toBeNull();
-    expect(document.querySelector('.sfut-menu-item-label')?.textContent).toBe(
+    expect(document.querySelector('.sfdt-menu-item img')).toBeNull();
+    expect(document.querySelector('.sfdt-menu-item script')).toBeNull();
+    expect(document.querySelector('.sfdt-menu-item-label')?.textContent).toBe(
       '<script>alert(2)</script>',
     );
   });
@@ -87,8 +87,8 @@ describe('extension/ui/side-button', () => {
       menuItemsProvider: () => [{ featureId: 'flow-health-check', icon: '🩺', label: 'Run' }],
       handlers: { onActivate, onOpenSettings: vi.fn() },
     });
-    document.getElementById('sfut-side-button')!.click();
-    document.querySelector<HTMLElement>('.sfut-menu-item')!.click();
+    document.getElementById('sfdt-side-button')!.click();
+    document.querySelector<HTMLElement>('.sfdt-menu-item')!.click();
     expect(onActivate).toHaveBeenCalledWith(
       expect.objectContaining({ featureId: 'flow-health-check', action: 'activate' }),
     );
@@ -100,10 +100,10 @@ describe('extension/ui/side-button', () => {
       menuItemsProvider: () => [],
       handlers: { onActivate: vi.fn(), onOpenSettings },
     });
-    document.getElementById('sfut-side-button')!.click();
-    document.getElementById('sfut-settings-link')!.click();
+    document.getElementById('sfdt-side-button')!.click();
+    document.getElementById('sfdt-settings-link')!.click();
     expect(onOpenSettings).toHaveBeenCalledOnce();
-    expect((document.getElementById('sfut-menu') as HTMLElement).style.display).toBe('none');
+    expect((document.getElementById('sfdt-menu') as HTMLElement).style.display).toBe('none');
   });
 
   it('destroy() removes the button and menu from the DOM', () => {
@@ -112,8 +112,8 @@ describe('extension/ui/side-button', () => {
       handlers: { onActivate: vi.fn(), onOpenSettings: vi.fn() },
     });
     handle.destroy();
-    expect(document.getElementById('sfut-side-button')).toBeNull();
-    expect(document.getElementById('sfut-menu')).toBeNull();
+    expect(document.getElementById('sfdt-side-button')).toBeNull();
+    expect(document.getElementById('sfdt-menu')).toBeNull();
     expect(handle.isMounted()).toBe(false);
   });
 
@@ -126,6 +126,6 @@ describe('extension/ui/side-button', () => {
       handlers: { onActivate: vi.fn(), onOpenSettings: vi.fn() },
     });
     expect(handle.isMounted()).toBe(false);
-    expect(document.getElementById('sfut-side-button')).toBeNull();
+    expect(document.getElementById('sfdt-side-button')).toBeNull();
   });
 });

--- a/extension/test/soql-runner.test.ts
+++ b/extension/test/soql-runner.test.ts
@@ -364,11 +364,11 @@ describe('soql-runner — modal execution', () => {
     textarea.dispatchEvent(new Event('input'));
     
     await vi.waitFor(() => {
-      const title = document.querySelector('.sfut-soql-autocomplete-box span') as HTMLSpanElement;
+      const title = document.querySelector('.sfdt-soql-autocomplete-box span') as HTMLSpanElement;
       expect(title.textContent).toContain('Objects suggestions:');
     });
 
-    const buttons = document.querySelectorAll('.sfut-soql-autocomplete-box button');
+    const buttons = document.querySelectorAll('.sfdt-soql-autocomplete-box button');
     const suggestionButtons = Array.from(buttons).filter(b => b.textContent && !b.textContent.includes('Expand') && !b.textContent.includes('Collapse'));
     expect(suggestionButtons.length).toBe(2);
     expect(suggestionButtons[0]!.textContent).toContain('Account');
@@ -409,7 +409,7 @@ describe('soql-runner — modal execution', () => {
 
     link.click();
 
-    const menu = document.querySelector('.sfut-soql-cell-menu');
+    const menu = document.querySelector('.sfdt-soql-cell-menu');
     expect(menu).toBeTruthy();
 
     const menuItems = menu?.querySelectorAll('div');
@@ -420,7 +420,7 @@ describe('soql-runner — modal execution', () => {
     queryRecordItem?.click();
 
     expect(textarea.value).toContain("WHERE Id = '001800000000001AAA'");
-    expect(document.querySelector('.sfut-soql-cell-menu')).toBeNull();
+    expect(document.querySelector('.sfdt-soql-cell-menu')).toBeNull();
   });
 });
 

--- a/extension/test/telemetry.test.ts
+++ b/extension/test/telemetry.test.ts
@@ -112,4 +112,23 @@ describe('telemetry', () => {
       expect(result).toBe(false);
     });
   });
+
+  describe('legacy key migration', () => {
+    it('reads and migrates counters from the legacy sfut.telemetry key', async () => {
+      const now = () => new Date('2026-05-20T10:00:00Z');
+      chrome.storage.local.set({
+        'sfut.telemetry': {
+          monthKey: '2026-05',
+          counters: { 'canvas-search': { activated: 3, errored: 1, disabled_remote: 0 } },
+        } satisfies TelemetrySnapshot,
+      } as any);
+      const t = createTelemetry({ isEnabled: () => true, now });
+      const snapshot = await t.snapshot();
+      expect(snapshot.counters['canvas-search']).toEqual({ activated: 3, errored: 1, disabled_remote: 0 });
+      // Migrated forward: new key written, legacy key removed.
+      const after = await new Promise<any>((r) => chrome.storage.local.get(['sfdt.telemetry', 'sfut.telemetry'], r));
+      expect(after['sfdt.telemetry']).toBeDefined();
+      expect(after['sfut.telemetry']).toBeUndefined();
+    });
+  });
 });

--- a/extension/test/telemetry.test.ts
+++ b/extension/test/telemetry.test.ts
@@ -112,23 +112,4 @@ describe('telemetry', () => {
       expect(result).toBe(false);
     });
   });
-
-  describe('legacy key migration', () => {
-    it('reads and migrates counters from the legacy sfut.telemetry key', async () => {
-      const now = () => new Date('2026-05-20T10:00:00Z');
-      chrome.storage.local.set({
-        'sfut.telemetry': {
-          monthKey: '2026-05',
-          counters: { 'canvas-search': { activated: 3, errored: 1, disabled_remote: 0 } },
-        } satisfies TelemetrySnapshot,
-      } as any);
-      const t = createTelemetry({ isEnabled: () => true, now });
-      const snapshot = await t.snapshot();
-      expect(snapshot.counters['canvas-search']).toEqual({ activated: 3, errored: 1, disabled_remote: 0 });
-      // Migrated forward: new key written, legacy key removed.
-      const after = await new Promise<any>((r) => chrome.storage.local.get(['sfdt.telemetry', 'sfut.telemetry'], r));
-      expect(after['sfdt.telemetry']).toBeDefined();
-      expect(after['sfut.telemetry']).toBeUndefined();
-    });
-  });
 });

--- a/extension/ui/health-modal.ts
+++ b/extension/ui/health-modal.ts
@@ -33,7 +33,7 @@ export interface HealthModalHandle {
   isOpen: () => boolean;
 }
 
-const OVERLAY_ID = 'sfut-health-modal-overlay';
+const OVERLAY_ID = 'sfdt-health-modal-overlay';
 
 function styledDiv(doc: Document, className: string, cssText?: string): HTMLDivElement {
   const el = doc.createElement('div');
@@ -85,7 +85,7 @@ export function mountHealthModal(options: MountHealthModalOptions = {}): HealthM
 
   const overlay = doc.createElement('div');
   overlay.id = OVERLAY_ID;
-  overlay.className = 'sfut-modal-overlay sfut-hidden';
+  overlay.className = 'sfdt-modal-overlay sfdt-hidden';
   overlay.style.cssText = [
     'position: fixed',
     'inset: 0',
@@ -98,7 +98,7 @@ export function mountHealthModal(options: MountHealthModalOptions = {}): HealthM
   ].join('; ');
 
   const modal = doc.createElement('div');
-  modal.className = 'sfut-modal sfut-health-modal';
+  modal.className = 'sfdt-modal sfdt-health-modal';
   modal.style.cssText = [
     'background: #fff',
     'border-radius: 4px',
@@ -111,14 +111,14 @@ export function mountHealthModal(options: MountHealthModalOptions = {}): HealthM
   ].join('; ');
 
   const header = doc.createElement('div');
-  header.className = 'sfut-modal-header';
+  header.className = 'sfdt-modal-header';
   header.style.cssText =
     'padding: 12px 16px; border-bottom: 1px solid #d8dde6; display: flex; justify-content: space-between; align-items: center; font-weight: 600;';
   const headerLabel = doc.createElement('span');
   headerLabel.textContent = 'Flow Health Check';
   const closeBtn = doc.createElement('button');
   closeBtn.type = 'button';
-  closeBtn.className = 'sfut-modal-close';
+  closeBtn.className = 'sfdt-modal-close';
   closeBtn.textContent = '×';
   closeBtn.style.cssText =
     'background: none; border: 0; font-size: 22px; cursor: pointer; color: #80868d;';
@@ -126,11 +126,11 @@ export function mountHealthModal(options: MountHealthModalOptions = {}): HealthM
   header.appendChild(closeBtn);
 
   const body = doc.createElement('div');
-  body.className = 'sfut-modal-body sfut-health-modal-body';
+  body.className = 'sfdt-modal-body sfdt-health-modal-body';
   body.style.cssText = 'padding: 16px; overflow-y: auto; flex: 1;';
 
   const footer = doc.createElement('div');
-  footer.className = 'sfut-modal-footer sfut-health-modal-footer';
+  footer.className = 'sfdt-modal-footer sfdt-health-modal-footer';
   footer.style.cssText =
     'padding: 12px 16px; border-top: 1px solid #d8dde6; display: flex; justify-content: flex-end; gap: 8px;';
 
@@ -145,12 +145,12 @@ export function mountHealthModal(options: MountHealthModalOptions = {}): HealthM
   function show(): void {
     open = true;
     overlay.style.display = 'flex';
-    overlay.classList.remove('sfut-hidden');
+    overlay.classList.remove('sfdt-hidden');
   }
   function close(): void {
     open = false;
     overlay.style.display = 'none';
-    overlay.classList.add('sfut-hidden');
+    overlay.classList.add('sfdt-hidden');
   }
 
   closeBtn.addEventListener('click', close);
@@ -161,13 +161,13 @@ export function mountHealthModal(options: MountHealthModalOptions = {}): HealthM
   function renderLoading(flowLabel: string): void {
     clear(body);
     clear(footer);
-    const wrap = styledDiv(doc, 'sfut-health-loading', 'text-align: center; padding: 24px;');
+    const wrap = styledDiv(doc, 'sfdt-health-loading', 'text-align: center; padding: 24px;');
     const title = doc.createElement('div');
-    title.className = 'sfut-health-loading-title';
+    title.className = 'sfdt-health-loading-title';
     title.style.cssText = 'font-size: 16px; font-weight: 600;';
     title.textContent = 'Running Health Check';
     const sub = doc.createElement('div');
-    sub.className = 'sfut-health-loading-subtitle';
+    sub.className = 'sfdt-health-loading-subtitle';
     sub.style.cssText = 'color: #80868d; margin-top: 4px;';
     sub.textContent = flowLabel;
     wrap.appendChild(title);
@@ -179,13 +179,13 @@ export function mountHealthModal(options: MountHealthModalOptions = {}): HealthM
   function renderError(message: string): void {
     clear(body);
     clear(footer);
-    const wrap = styledDiv(doc, 'sfut-health-error', 'padding: 16px;');
+    const wrap = styledDiv(doc, 'sfdt-health-error', 'padding: 16px;');
     const title = doc.createElement('div');
-    title.className = 'sfut-health-section-title';
+    title.className = 'sfdt-health-section-title';
     title.style.cssText = 'font-size: 16px; font-weight: 600; color: #c23934;';
     title.textContent = 'Health Check Failed';
     const msg = doc.createElement('div');
-    msg.className = 'sfut-health-error-message';
+    msg.className = 'sfdt-health-error-message';
     msg.style.marginTop = '8px';
     msg.textContent = message || 'Unknown error';
     wrap.appendChild(title);
@@ -197,15 +197,15 @@ export function mountHealthModal(options: MountHealthModalOptions = {}): HealthM
   function buildSummaryCard(label: string, value: number, colour: string): HTMLDivElement {
     const card = styledDiv(
       doc,
-      'sfut-health-card',
+      'sfdt-health-card',
       `border: 1px solid #d8dde6; border-radius: 4px; padding: 10px; text-align: center; min-width: 80px; background: #fafaf9;`,
     );
     const lbl = doc.createElement('div');
-    lbl.className = 'sfut-health-card-label';
+    lbl.className = 'sfdt-health-card-label';
     lbl.style.cssText = `font-size: 11px; text-transform: uppercase; color: ${colour}; font-weight: 600;`;
     lbl.textContent = label;
     const val = doc.createElement('div');
-    val.className = 'sfut-health-card-value';
+    val.className = 'sfdt-health-card-value';
     val.style.cssText = 'font-size: 22px; font-weight: 700; margin-top: 4px;';
     val.textContent = String(value);
     card.appendChild(lbl);
@@ -216,15 +216,15 @@ export function mountHealthModal(options: MountHealthModalOptions = {}): HealthM
   function buildMetricCard(label: string, value: number): HTMLDivElement {
     const card = styledDiv(
       doc,
-      'sfut-health-metric',
+      'sfdt-health-metric',
       'border: 1px solid #d8dde6; border-radius: 4px; padding: 8px; text-align: center; min-width: 80px;',
     );
     const lbl = doc.createElement('div');
-    lbl.className = 'sfut-health-metric-label';
+    lbl.className = 'sfdt-health-metric-label';
     lbl.style.cssText = 'font-size: 11px; color: #80868d; font-weight: 500;';
     lbl.textContent = label;
     const val = doc.createElement('div');
-    val.className = 'sfut-health-metric-value';
+    val.className = 'sfdt-health-metric-value';
     val.style.cssText = 'font-size: 16px; font-weight: 600;';
     val.textContent = String(value);
     card.appendChild(lbl);
@@ -234,7 +234,7 @@ export function mountHealthModal(options: MountHealthModalOptions = {}): HealthM
 
   function buildFamilyDisclosure(family: IssueFamily): HTMLDetailsElement {
     const details = doc.createElement('details');
-    details.className = 'sfut-health-family';
+    details.className = 'sfdt-health-family';
     details.style.cssText = 'border: 1px solid #d8dde6; border-radius: 4px; margin-bottom: 6px;';
 
     const summary = doc.createElement('summary');
@@ -242,17 +242,17 @@ export function mountHealthModal(options: MountHealthModalOptions = {}): HealthM
       'padding: 10px 12px; cursor: pointer; display: flex; align-items: center; gap: 8px;';
 
     const sevBadge = doc.createElement('span');
-    sevBadge.className = `sfut-health-family-severity sfut-health-severity-${family.severity}`;
+    sevBadge.className = `sfdt-health-family-severity sfdt-health-severity-${family.severity}`;
     sevBadge.style.cssText = `display: inline-block; padding: 2px 6px; border-radius: 3px; font-size: 10px; font-weight: 700; color: #fff; background: ${severityColour(family.severity)};`;
     sevBadge.textContent = family.severity.toUpperCase();
 
     const titleSpan = doc.createElement('span');
-    titleSpan.className = 'sfut-health-family-title';
+    titleSpan.className = 'sfdt-health-family-title';
     titleSpan.style.flex = '1';
     titleSpan.textContent = family.title;
 
     const countSpan = doc.createElement('span');
-    countSpan.className = 'sfut-health-family-count';
+    countSpan.className = 'sfdt-health-family-count';
     countSpan.style.cssText = 'color: #80868d; font-size: 12px;';
     countSpan.textContent = `(${family.instanceCount})`;
 
@@ -261,17 +261,17 @@ export function mountHealthModal(options: MountHealthModalOptions = {}): HealthM
     summary.appendChild(countSpan);
 
     const familyBody = doc.createElement('div');
-    familyBody.className = 'sfut-health-family-body';
+    familyBody.className = 'sfdt-health-family-body';
     familyBody.style.cssText = 'padding: 0 12px 10px; font-size: 13px;';
 
     const impact = doc.createElement('div');
-    impact.className = 'sfut-health-family-impact';
+    impact.className = 'sfdt-health-family-impact';
     impact.style.cssText = 'color: #80868d; margin-bottom: 6px;';
     impact.textContent = `Score impact: -${family.scoreImpact}`;
     familyBody.appendChild(impact);
 
     const list = doc.createElement('ul');
-    list.className = 'sfut-health-affected-list';
+    list.className = 'sfdt-health-affected-list';
     list.style.cssText = 'margin: 0; padding-left: 18px;';
     if (family.affectedItems.length === 0) {
       const li = doc.createElement('li');
@@ -295,15 +295,15 @@ export function mountHealthModal(options: MountHealthModalOptions = {}): HealthM
     clear(body);
     clear(footer);
 
-    const headerBlock = styledDiv(doc, 'sfut-health-header-block', 'margin-bottom: 16px;');
+    const headerBlock = styledDiv(doc, 'sfdt-health-header-block', 'margin-bottom: 16px;');
     const flowName = doc.createElement('div');
-    flowName.className = 'sfut-health-flow-name';
+    flowName.className = 'sfdt-health-flow-name';
     flowName.style.cssText = 'font-size: 18px; font-weight: 600;';
     flowName.textContent = report.meta.flowLabel;
     headerBlock.appendChild(flowName);
 
     const metaLine = doc.createElement('div');
-    metaLine.className = 'sfut-health-flow-meta';
+    metaLine.className = 'sfdt-health-flow-meta';
     metaLine.style.cssText = 'color: #80868d; font-size: 12px; display: flex; gap: 12px;';
     const flowTypeSpan = doc.createElement('span');
     flowTypeSpan.textContent = report.meta.flowType;
@@ -318,15 +318,15 @@ export function mountHealthModal(options: MountHealthModalOptions = {}): HealthM
 
     const scoreWrap = styledDiv(
       doc,
-      'sfut-health-score-wrap',
+      'sfdt-health-score-wrap',
       'margin-top: 8px; display: flex; align-items: baseline; gap: 8px;',
     );
     const scoreNum = doc.createElement('div');
-    scoreNum.className = 'sfut-health-score';
+    scoreNum.className = 'sfdt-health-score';
     scoreNum.style.cssText = `font-size: 42px; font-weight: 700; color: ${ratingColour(report.summary.rating)};`;
     scoreNum.textContent = String(report.summary.overallScore);
     const scoreRating = doc.createElement('div');
-    scoreRating.className = 'sfut-health-rating';
+    scoreRating.className = 'sfdt-health-rating';
     scoreRating.style.cssText = 'color: #54698d; font-weight: 600;';
     scoreRating.textContent = report.summary.rating;
     scoreWrap.appendChild(scoreNum);
@@ -337,7 +337,7 @@ export function mountHealthModal(options: MountHealthModalOptions = {}): HealthM
 
     const cards = styledDiv(
       doc,
-      'sfut-health-summary-cards',
+      'sfdt-health-summary-cards',
       'display: flex; gap: 8px; margin-bottom: 16px;',
     );
     cards.appendChild(buildSummaryCard('High', report.summary.severityCounts.high, severityColour('high')));
@@ -346,15 +346,15 @@ export function mountHealthModal(options: MountHealthModalOptions = {}): HealthM
     cards.appendChild(buildSummaryCard('Info', report.summary.severityCounts.info, severityColour('info')));
     body.appendChild(cards);
 
-    const familiesSection = styledDiv(doc, 'sfut-health-section', 'margin-bottom: 16px;');
+    const familiesSection = styledDiv(doc, 'sfdt-health-section', 'margin-bottom: 16px;');
     const familiesTitle = doc.createElement('div');
-    familiesTitle.className = 'sfut-health-section-title';
+    familiesTitle.className = 'sfdt-health-section-title';
     familiesTitle.style.cssText = 'font-weight: 600; margin-bottom: 8px;';
     familiesTitle.textContent = 'Issue Families';
     familiesSection.appendChild(familiesTitle);
     if (report.issueFamilies.length === 0) {
       const empty = doc.createElement('div');
-      empty.className = 'sfut-health-empty';
+      empty.className = 'sfdt-health-empty';
       empty.style.cssText = 'color: #80868d; font-size: 13px;';
       empty.textContent = 'No issues detected — your flow is in excellent shape.';
       familiesSection.appendChild(empty);
@@ -365,15 +365,15 @@ export function mountHealthModal(options: MountHealthModalOptions = {}): HealthM
     }
     body.appendChild(familiesSection);
 
-    const profileSection = styledDiv(doc, 'sfut-health-section');
+    const profileSection = styledDiv(doc, 'sfdt-health-section');
     const profileTitle = doc.createElement('div');
-    profileTitle.className = 'sfut-health-section-title';
+    profileTitle.className = 'sfdt-health-section-title';
     profileTitle.style.cssText = 'font-weight: 600; margin-bottom: 8px;';
     profileTitle.textContent = 'Flow Profile';
     profileSection.appendChild(profileTitle);
     const metricsGrid = styledDiv(
       doc,
-      'sfut-health-metrics-grid',
+      'sfdt-health-metrics-grid',
       'display: grid; grid-template-columns: repeat(5, 1fr); gap: 6px;',
     );
     metricsGrid.appendChild(buildMetricCard('Elements', report.summary.metrics.elementCount));
@@ -385,7 +385,7 @@ export function mountHealthModal(options: MountHealthModalOptions = {}): HealthM
     body.appendChild(profileSection);
 
     const copyBtn = doc.createElement('button');
-    copyBtn.className = 'sfut-health-btn';
+    copyBtn.className = 'sfdt-health-btn';
     copyBtn.textContent = 'Copy JSON';
     copyBtn.style.cssText =
       'padding: 6px 12px; border: 1px solid #d8dde6; background: #fff; border-radius: 4px; cursor: pointer;';

--- a/extension/ui/side-button.ts
+++ b/extension/ui/side-button.ts
@@ -25,10 +25,10 @@ export interface SideButtonHandle {
   isMounted: () => boolean;
 }
 
-const BUTTON_ID = 'sfut-side-button';
-const MENU_ID = 'sfut-menu';
-const MENU_HIDDEN_CLASS = 'sfut-menu-hidden';
-const MENU_VISIBLE_CLASS = 'sfut-menu-visible';
+const BUTTON_ID = 'sfdt-side-button';
+const MENU_ID = 'sfdt-menu';
+const MENU_HIDDEN_CLASS = 'sfdt-menu-hidden';
+const MENU_VISIBLE_CLASS = 'sfdt-menu-visible';
 
 const BUTTON_STYLE = [
   'position: fixed',
@@ -105,42 +105,42 @@ export function mountSideButton(opts: {
   doc.getElementById(MENU_ID)?.remove();
 
   const button = styled(doc, 'div', BUTTON_STYLE, { id: BUTTON_ID, title: 'SFDT SF Helper' });
-  button.className = 'sfut-side-button';
+  button.className = 'sfdt-side-button';
   const buttonIcon = doc.createElement('span');
-  buttonIcon.className = 'sfut-side-button-icon';
+  buttonIcon.className = 'sfdt-side-button-icon';
   buttonIcon.textContent = '⚡';
   button.appendChild(buttonIcon);
 
   const menu = styled(doc, 'div', MENU_STYLE, { id: MENU_ID });
-  menu.className = `sfut-menu ${MENU_HIDDEN_CLASS}`;
+  menu.className = `sfdt-menu ${MENU_HIDDEN_CLASS}`;
 
   const header = doc.createElement('div');
-  header.className = 'sfut-menu-header';
+  header.className = 'sfdt-menu-header';
   header.style.cssText =
     'padding: 10px 14px; border-bottom: 1px solid #d8dde6; display: flex; justify-content: space-between; align-items: center;';
   const headerTitle = doc.createElement('span');
-  headerTitle.className = 'sfut-menu-title';
+  headerTitle.className = 'sfdt-menu-title';
   headerTitle.style.fontWeight = '600';
   headerTitle.textContent = 'SFDT SF Helper';
   const headerClose = doc.createElement('span');
-  headerClose.className = 'sfut-menu-close';
+  headerClose.className = 'sfdt-menu-close';
   headerClose.style.cssText = 'cursor: pointer; font-size: 18px; color: #80868d;';
   headerClose.textContent = '×';
   header.appendChild(headerTitle);
   header.appendChild(headerClose);
 
   const content = doc.createElement('div');
-  content.id = 'sfut-menu-content';
-  content.className = 'sfut-menu-content';
+  content.id = 'sfdt-menu-content';
+  content.className = 'sfdt-menu-content';
   content.style.cssText = 'max-height: 60vh; overflow-y: auto;';
 
   const footer = doc.createElement('div');
-  footer.className = 'sfut-menu-footer';
+  footer.className = 'sfdt-menu-footer';
   footer.style.cssText = 'padding: 8px 14px; border-top: 1px solid #d8dde6;';
   const settingsLink = doc.createElement('a');
   settingsLink.href = '#';
-  settingsLink.id = 'sfut-settings-link';
-  settingsLink.className = 'sfut-menu-settings-link';
+  settingsLink.id = 'sfdt-settings-link';
+  settingsLink.className = 'sfdt-menu-settings-link';
   settingsLink.style.cssText = 'color: #0070d2; text-decoration: none; font-size: 12px;';
   settingsLink.textContent = '⚙ Settings';
   footer.appendChild(settingsLink);
@@ -161,17 +161,17 @@ export function mountSideButton(opts: {
 
   function buildMenuItemNode(item: MenuItem): HTMLDivElement {
     const node = doc.createElement('div');
-    node.className = 'sfut-menu-item';
+    node.className = 'sfdt-menu-item';
     node.dataset.feature = item.featureId;
     node.dataset.action = item.action ?? 'activate';
     node.style.cssText =
       'padding: 10px 14px; cursor: pointer; display: flex; align-items: center; gap: 10px;';
     const iconNode = doc.createElement('span');
-    iconNode.className = 'sfut-menu-item-icon';
+    iconNode.className = 'sfdt-menu-item-icon';
     iconNode.style.fontSize = '16px';
     iconNode.textContent = item.icon;
     const labelNode = doc.createElement('span');
-    labelNode.className = 'sfut-menu-item-label';
+    labelNode.className = 'sfdt-menu-item-label';
     labelNode.textContent = item.label;
     node.appendChild(iconNode);
     node.appendChild(labelNode);
@@ -185,7 +185,7 @@ export function mountSideButton(opts: {
 
   function buildEmptyState(): HTMLDivElement {
     const empty = doc.createElement('div');
-    empty.className = 'sfut-menu-empty';
+    empty.className = 'sfdt-menu-empty';
     empty.style.cssText = 'padding: 16px; text-align: center; color: #80868d;';
     empty.textContent = 'No tools available for this page.';
     return empty;

--- a/extension/ui/toast.ts
+++ b/extension/ui/toast.ts
@@ -2,8 +2,8 @@
 // React is available. CSS is inlined so the toast renders without depending
 // on extension/ui/styles.css.
 
-const TOAST_CONTAINER_ID = 'sfut-toast-container';
-const TOAST_BASE_CLASS = 'sfut-toast';
+const TOAST_CONTAINER_ID = 'sfdt-toast-container';
+const TOAST_BASE_CLASS = 'sfdt-toast';
 
 export type ToastKind = 'info' | 'success' | 'warning' | 'error';
 


### PR DESCRIPTION
## What

Standardises the extension's internal namespace from the legacy `sfut` to `sfdt` across DOM ids, CSS classes, log prefixes, and `chrome.storage` keys, so it matches the rest of the `@sfdt/*` project.

`sfut` was the extension's original name (first commit 2026-05-14) and stuck after it was folded into the monorepo — 276 `sfut` + 15 `SFUT` occurrences across 56 tracked files. **There is now zero `sfut` anywhere in the tree.**

## Storage keys (no migration)

The persisted `chrome.storage.local` keys are renamed to the `sfdt.*` namespace with **no migration shim** (deliberate decision — a pure namespace, no legacy references):

- `sfut.settings` → `sfdt.settings`
- `sfut.telemetry` → `sfdt.telemetry`
- `sfut.killswitch.cache` → `sfdt.killswitch.cache`

**Trade-off:** users upgrading from an older build start from default settings and their opt-in telemetry resets — a one-time step. Documented in the CHANGELOG.

## Verified

- Zero `sfut` in tracked source (`git grep`).
- Extension `tsc` + `wxt build`, extension lint, full monorepo suite **2032 tests pass**.