### PR TITLE
fix: post-0.13.0 review follow-ups (org-query dedup, structured errors, skipped-query surfacing)

### DIFF
--- a/docs/extension-smoke-test.md
+++ b/docs/extension-smoke-test.md
@@ -28,12 +28,12 @@ Produced by `npm run build:ext` from the sfdt repo root.
 2. **Load unpacked** into Chrome:
    - `chrome://extensions/` → Developer Mode ON → "Load unpacked" →
      pick `extension/.output/chrome-mv3/`.
-   - Extension should appear as "SFDT SF Helper" v0.0.1.
+   - Extension should appear as "SFDT SF Helper" v0.3.2.
    - Note the assigned extension ID (will need it for Phase 7 native
      messaging manifests).
 3. **Confirm the manifest looks right** in `chrome://extensions/`:
    - host_permissions for the 4 Salesforce domains
-   - permissions: storage, clipboardWrite, cookies, scripting
+   - permissions: storage, clipboardWrite, cookies
    - No yellow / red error banners
 4. **Open the DevTools console** for the Salesforce tab you'll use:
    `Cmd+Opt+I` → Console. Anything tagged `[SFDT]` should be informational;

--- a/extension/PRIVACY.md
+++ b/extension/PRIVACY.md
@@ -1,6 +1,6 @@
 # Privacy Policy — SFDT SF Helper (`@sfdt/extension`)
 
-**Last updated: 2026-05-17**
+**Last updated: 2026-06-25**
 
 This Chrome extension is designed for Salesforce admins and developers. Its full source code is published in the public [`sfdt` repository on GitHub](https://github.com/scoobydrew83/sfdt) — you can verify every claim below against the code.
 
@@ -56,6 +56,8 @@ The extension reads Flow metadata via the Salesforce Tooling API using your exis
 
 The SOQL Query Runner, Org Limits, and REST API Explorer features call Salesforce REST and Tooling endpoints (`/services/data/...`) against the same session — queries, requests, and responses stay between your browser and the org you're already authenticated to.
 
+The Workspace org picker and the Switch Org feature read your existing Salesforce session cookies to list the orgs you're already logged in to, so you can target a tool at the org you choose. Only the org hostnames are used (to label and select an org); cookie values are never displayed and never leave your device. The Org Health panel reads the CLI's local audit/monitor snapshots through the same `http://127.0.0.1:7654` bridge described below.
+
 When you use a feature that calls the local bridge (e.g. "Deploy this Flow"), the extension sends the Flow's developer name (e.g. `My_Flow`) to `http://127.0.0.1:7654` so the local sfdt CLI on your machine can run the deploy. The data goes from your browser to a process running on the same machine — it never leaves your device.
 
 ---
@@ -67,11 +69,10 @@ The extension manifest requests the following permissions. Each is used for the 
 | Permission | Why |
 |---|---|
 | `storage` | Save your per-feature toggles and (opt-in) local telemetry counters |
-| `activeTab` | Run feature scripts on the Salesforce page you're currently viewing |
-| `clipboardWrite` | The Flow Health Check feature copies the report to your clipboard on demand |
-| `host_permissions: http://127.0.0.1/*` | Talk to the local sfdt CLI bridge running on your own machine |
-| `host_permissions: *://*.salesforce.com/* / *.force.com/* / *.lightning.force.com/*` | Run feature scripts on Salesforce pages |
-| `nativeMessaging` | Optional fallback transport to talk to the local sfdt CLI when the HTTP bridge isn't running. Only used if you install the native host. |
+| `clipboardWrite` | Copy generated output to your clipboard on demand — e.g. the Flow Health Check report, SOQL results, the object schema for prompts, and the Copy-JSON actions on the Org Limits / Org Health panels |
+| `cookies` | Detect which Salesforce orgs you're logged in to by reading your existing Salesforce session cookies, so the Workspace org picker / Switch Org can target the org you choose. Cookies are read locally and never transmitted off your device. |
+| `host_permissions: https://*.salesforce.com/*, https://*.salesforce-setup.com/*, https://*.my.salesforce.com/*, https://*.lightning.force.com/*` | Run feature scripts and call the Tooling/REST APIs on Salesforce pages of your logged-in org |
+| `host_permissions: http://localhost/*, http://127.0.0.1/*` | Talk to the local sfdt CLI bridge running on your own machine (default port 7654); inactive until you start the bridge yourself |
 
 ---
 

--- a/extension/README.md
+++ b/extension/README.md
@@ -28,7 +28,7 @@ window that reports the chosen org's URL, so the existing tools run unchanged.
 
 ---
 
-## Features (28)
+## Features (29)
 
 Every feature is opt-in (toggle off in the options page), and any feature can be remotely disabled without a Web Store re-review via `sfdt feature-flags disable <id>`.
 
@@ -62,6 +62,7 @@ Every feature is opt-in (toggle off in the options page), and any feature can be
 | `debug-log-viewer` | List recent `ApexLog` records and view full log bodies | Workspace + Setup |
 | `saved-soql` | Browse bookmarked + recent SOQL and load any query straight into the runner | Workspace |
 | `org-switcher` | Switch the Workspace between logged-in orgs | Workspace |
+| `org-health` | Side panel surfacing the CLI's audit/monitor snapshots (status dots, findings, Copy JSON) via the bridge's `org-health` request | Setup + Flow Builder |
 
 Adding the next feature is a one-file change — see the existing modules in [`extension/features/`](./features/) and the registry in [`extension/lib/feature-registry.ts`](./lib/feature-registry.ts).
 

--- a/extension/store-assets/README.md
+++ b/extension/store-assets/README.md
@@ -32,4 +32,5 @@ The extension's **runtime** icons live in `../public/icon/{16,32,48,128}.png` �
 The screenshot set above is submission-ready. Nice-to-haves, none required:
 
 - A dedicated `final_17` for **Copy Schema for Prompt** (`export-for-prompt`) — it's already visible in the `final_06` Workspace nav, so a standalone shot is optional (menu label is "Copy Schema for Prompt", not "Export…").
+- A shot of the **Org Health** panel (`org-health`, added in 0.3.2) — the screenshot set currently has no capture of it; consider a `final_18` for the audit/monitor snapshot view if you want the newest feature represented in the store.
 - CWS promo tiles (440×280 small; 1400×560 marquee) — none exist yet.

--- a/extension/store-assets/listing.md
+++ b/extension/store-assets/listing.md
@@ -1,12 +1,12 @@
 # Chrome Web Store Listing
 
-> **Store-sync status:** Updated for **v0.3.1** (28 features). The 0.3.x line adds
-> a standalone **Workspace** tab plus four new tools — Execute Anonymous Apex,
-> Debug Logs, Saved SOQL, and Switch Org (multi-org). As of the last manual
-> upload the *live* CWS listing still reflects the older **17-feature** copy —
-> this file is ahead of the store. Paste the sections below into the CWS
-> dashboard during the manual v0.3.1 upload, then this file and the store will
-> be back in sync.
+> **Store-sync status:** Updated for **v0.3.2** (29 features). The 0.3.x line adds
+> a standalone **Workspace** tab plus five new tools — Execute Anonymous Apex,
+> Debug Logs, Saved SOQL, Switch Org (multi-org), and **Org Health** (audit/monitor
+> snapshots via the local CLI bridge). As of the last manual upload the *live* CWS
+> listing still reflects the older **17-feature** copy — this file is ahead of the
+> store. Paste the sections below into the CWS dashboard during the manual v0.3.2
+> upload, then this file and the store will be back in sync.
 >
 > Screenshots and the store icon live alongside this file in `extension/store-assets/`
 > (`store-icon-128.png` + `final_01`–`final_16`). The set was refreshed for 0.3.0:
@@ -27,7 +27,7 @@ Developer Tools (alt: Workflow & Planning)
 English (United States)
 
 ## Detailed description
-SFDT SF Helper adds 28 productivity features for Salesforce admins and developers across Flow Builder, Setup, Object Manager, and record pages — now including a standalone Workspace tab that runs SOQL, Apex, and other tools in their own browser tab so they never disturb the Salesforce page you're on. Features span flow analysis, schema and data tooling, SOQL/REST/SOAP exploration, anonymous Apex, debug-log and event monitoring, and optional AI assistance. Every feature is opt-in via the options page, and any feature can be remotely disabled without a Web Store re-review.
+SFDT SF Helper adds 29 productivity features for Salesforce admins and developers across Flow Builder, Setup, Object Manager, and record pages — now including a standalone Workspace tab that runs SOQL, Apex, and other tools in their own browser tab so they never disturb the Salesforce page you're on. Features span flow analysis, schema and data tooling, SOQL/REST/SOAP exploration, anonymous Apex, debug-log and event monitoring, org health diagnostics, and optional AI assistance. Every feature is opt-in via the options page, and any feature can be remotely disabled without a Web Store re-review.
 
 Features include:
 - Setup Tabs — adds an Automation Home tab plus reorderable, groupable tabs to the Setup tab bar
@@ -58,6 +58,7 @@ Features include:
 - Debug Logs — list ApexLog debug logs and view raw log bodies
 - Saved SOQL — bookmark and re-run SOQL queries and history
 - Switch Org — discover every org you're logged into and run any tool against it (multi-org)
+- Org Health — view native sfdt audit and monitor snapshots (org limits, license usage, MFA coverage, security health score, Apex job failures, and more) in a side panel via the local CLI bridge
 
 Privacy
 - No user data is sent to any third-party service.

--- a/src/commands/data.js
+++ b/src/commands/data.js
@@ -94,7 +94,15 @@ function makeDeleteAction() {
         throw err;
       }
       if (jsonMode) {
-        process.stdout.write(JSON.stringify({ status: 'success', ...result }, null, 2) + '\n');
+        // Signal partial completion when queries were skipped, so a machine
+        // consumer (CI checking `status === 'success'`) doesn't treat an
+        // incomplete delete as a clean one. skippedCount lets them branch
+        // without iterating sobjects[].
+        process.stdout.write(JSON.stringify({
+          status: skipped.length ? 'partial' : 'success',
+          skippedCount: skipped.length,
+          ...result,
+        }, null, 2) + '\n');
       } else {
         if (skipped.length) {
           console.warn(chalk.yellow(`⚠ ${skipped.length} query(ies) were skipped (could not parse the sObject from the FROM clause); their records were NOT deleted.`));

--- a/src/commands/data.js
+++ b/src/commands/data.js
@@ -82,7 +82,12 @@ function makeDeleteAction() {
       let result;
       try {
         result = await deleteDataSet(config, setName, org);
-        spinner?.succeed(`Delete complete: ${setName}`);
+        const skipped = (result.sobjects ?? []).filter((s) => s.status === 'skipped');
+        if (skipped.length) {
+          spinner?.warn(`Delete complete: ${setName} (${skipped.length} query(ies) skipped — unparseable FROM clause)`);
+        } else {
+          spinner?.succeed(`Delete complete: ${setName}`);
+        }
       } catch (err) {
         spinner?.fail('Delete failed');
         throw err;
@@ -90,6 +95,10 @@ function makeDeleteAction() {
       if (jsonMode) {
         process.stdout.write(JSON.stringify({ status: 'success', ...result }, null, 2) + '\n');
       } else {
+        const skipped = (result.sobjects ?? []).filter((s) => s.status === 'skipped');
+        if (skipped.length) {
+          console.warn(chalk.yellow(`⚠ ${skipped.length} query(ies) were skipped (could not parse the sObject from the FROM clause); their records were NOT deleted.`));
+        }
         console.log(chalk.green(`\n${JSON.stringify(result, null, 2)}`));
       }
     } catch (err) {

--- a/src/commands/data.js
+++ b/src/commands/data.js
@@ -80,9 +80,10 @@ function makeDeleteAction() {
 
       const spinner = jsonMode ? null : ora(`Delete data set "${setName}" (${org})…`).start();
       let result;
+      let skipped = [];
       try {
         result = await deleteDataSet(config, setName, org);
-        const skipped = (result.sobjects ?? []).filter((s) => s.status === 'skipped');
+        skipped = (result.sobjects ?? []).filter((s) => s.status === 'skipped');
         if (skipped.length) {
           spinner?.warn(`Delete complete: ${setName} (${skipped.length} query(ies) skipped — unparseable FROM clause)`);
         } else {
@@ -95,7 +96,6 @@ function makeDeleteAction() {
       if (jsonMode) {
         process.stdout.write(JSON.stringify({ status: 'success', ...result }, null, 2) + '\n');
       } else {
-        const skipped = (result.sobjects ?? []).filter((s) => s.status === 'skipped');
         if (skipped.length) {
           console.warn(chalk.yellow(`⚠ ${skipped.length} query(ies) were skipped (could not parse the sObject from the FROM clause); their records were NOT deleted.`));
         }

--- a/src/commands/data.js
+++ b/src/commands/data.js
@@ -99,9 +99,9 @@ function makeDeleteAction() {
         // incomplete delete as a clean one. skippedCount lets them branch
         // without iterating sobjects[].
         process.stdout.write(JSON.stringify({
+          ...result,
           status: skipped.length ? 'partial' : 'success',
           skippedCount: skipped.length,
-          ...result,
         }, null, 2) + '\n');
       } else {
         if (skipped.length) {

--- a/src/lib/data-runner.js
+++ b/src/lib/data-runner.js
@@ -112,8 +112,7 @@ export async function deleteDataSet(config, setName, orgAlias) {
   for (const query of queries) {
     const sobject = extractSObject(query);
     if (!sobject) {
-      // The FROM clause couldn't be parsed, so we don't know what to delete.
-      // Record it as skipped rather than silently dropping it — the user already
+      // Record as skipped rather than silently dropping — the user already
       // confirmed deletion and would otherwise have no way to know a query was
       // not run.
       results.push({ sobject: null, status: 'skipped', query: oneLine(query) });

--- a/src/lib/data-runner.js
+++ b/src/lib/data-runner.js
@@ -2,6 +2,7 @@ import path from 'path';
 import fs from 'fs-extra';
 import { glob } from 'glob';
 import { execa } from 'execa';
+import { safeParse } from './org-query.js';
 
 /**
  * Data set import/export runner.
@@ -129,15 +130,6 @@ export async function deleteDataSet(config, setName, orgAlias) {
     }
   }
   return { set: setName, org: orgAlias, sobjects: results };
-}
-
-function safeParse(text) {
-  if (!text) return null;
-  try {
-    return JSON.parse(text);
-  } catch {
-    return null;
-  }
 }
 
 function oneLine(s) {

--- a/src/lib/data-runner.js
+++ b/src/lib/data-runner.js
@@ -111,7 +111,14 @@ export async function deleteDataSet(config, setName, orgAlias) {
   // leave the records matched by all but the first such query behind.
   for (const query of queries) {
     const sobject = extractSObject(query);
-    if (!sobject) continue;
+    if (!sobject) {
+      // The FROM clause couldn't be parsed, so we don't know what to delete.
+      // Record it as skipped rather than silently dropping it — the user already
+      // confirmed deletion and would otherwise have no way to know a query was
+      // not run.
+      results.push({ sobject: null, status: 'skipped', query: oneLine(query) });
+      continue;
+    }
     try {
       await execa('sf', ['data', 'delete', 'bulk', '--sobject', sobject, '--query', query, '--target-org', orgAlias, '--json']);
       results.push({ sobject, status: 'ok' });

--- a/src/lib/data-runner.js
+++ b/src/lib/data-runner.js
@@ -122,7 +122,10 @@ export async function deleteDataSet(config, setName, orgAlias) {
       await execa('sf', ['data', 'delete', 'bulk', '--sobject', sobject, '--query', query, '--target-org', orgAlias, '--json']);
       results.push({ sobject, status: 'ok' });
     } catch (err) {
-      results.push({ sobject, status: 'error', error: oneLine(err.message) });
+      // Prefer sf's structured error (stdout/stderr) over the opaque execa
+      // message, matching org-query/monitor-runner.
+      const sfMsg = safeParse(err?.stdout)?.message ?? safeParse(err?.stderr)?.message;
+      results.push({ sobject, status: 'error', error: oneLine(sfMsg ?? err.message) });
     }
   }
   return { set: setName, org: orgAlias, sobjects: results };

--- a/src/lib/monitor-runner.js
+++ b/src/lib/monitor-runner.js
@@ -205,7 +205,9 @@ function errored(id, title, err) {
   // alias). Prefer its structured `message` over the opaque execa error so the
   // friendly sf text surfaces. Checks that go through query()/rawQuery() already
   // get this; this covers checks that call execa directly (e.g. checkLimits).
-  const structured = safeParse(err?.stdout)?.message;
+  // sf usually writes its JSON error envelope to stdout, but some commands
+  // (auth/alias failures) route it to stderr — check both.
+  const structured = safeParse(err?.stdout)?.message ?? safeParse(err?.stderr)?.message;
   return {
     id,
     title,

--- a/src/lib/monitor-runner.js
+++ b/src/lib/monitor-runner.js
@@ -201,7 +201,18 @@ function result_(id, title, status, summary, findings) {
 }
 
 function errored(id, title, err) {
-  return { id, title, status: 'error', summary: `Check failed: ${oneLine(err.message)}`, findings: [] };
+  // sf emits a JSON error envelope on stdout (e.g. auth failure, invalid org
+  // alias). Prefer its structured `message` over the opaque execa error so the
+  // friendly sf text surfaces. Checks that go through query()/rawQuery() already
+  // get this; this covers checks that call execa directly (e.g. checkLimits).
+  const structured = safeParse(err?.stdout)?.message;
+  return {
+    id,
+    title,
+    status: 'error',
+    summary: `Check failed: ${oneLine(structured || err?.message)}`,
+    findings: [],
+  };
 }
 
 function sanitize(s) {

--- a/src/lib/org-query.js
+++ b/src/lib/org-query.js
@@ -37,8 +37,11 @@ async function _execQuery(orgAlias, soql, { tooling = false, all = false } = {})
     result = await execa('sf', args);
   } catch (err) {
     // sf usually writes its JSON error envelope to stdout, but some commands
-    // route it to stderr — check both for the structured message.
-    const parsed = safeParse(err.stdout) ?? safeParse(err.stderr);
+    // route it to stderr — check both for the structured message. Only commit
+    // to the stdout parse when it actually carries a message, otherwise a
+    // messageless stdout envelope would mask a real message on stderr.
+    const fromOut = safeParse(err.stdout);
+    const parsed = fromOut?.message ? fromOut : safeParse(err.stderr);
     if (parsed?.message) {
       const e = new Error(parsed.message);
       e.stderr = err.stderr;

--- a/src/lib/org-query.js
+++ b/src/lib/org-query.js
@@ -36,7 +36,9 @@ async function _execQuery(orgAlias, soql, { tooling = false, all = false } = {})
   try {
     result = await execa('sf', args);
   } catch (err) {
-    const parsed = safeParse(err.stdout);
+    // sf usually writes its JSON error envelope to stdout, but some commands
+    // route it to stderr — check both for the structured message.
+    const parsed = safeParse(err.stdout) ?? safeParse(err.stderr);
     if (parsed?.message) {
       const e = new Error(parsed.message);
       e.stderr = err.stderr;

--- a/src/lib/org-query.js
+++ b/src/lib/org-query.js
@@ -12,6 +12,42 @@ import { execa } from 'execa';
  */
 
 /**
+ * Shared execa core for query()/rawQuery(): builds the `sf data query` argv,
+ * runs it, and returns the parsed `result` object. On failure, sf emits a JSON
+ * error envelope on stdout (malformed SOQL, missing sObject) — surface that
+ * structured message instead of the opaque execa error.
+ *
+ * @param {string} orgAlias
+ * @param {string} soql
+ * @param {object} [options]
+ * @param {boolean} [options.tooling]
+ * @param {boolean} [options.all]
+ * @returns {Promise<object|null>} The parsed sf `result` object (or null).
+ */
+async function _execQuery(orgAlias, soql, { tooling = false, all = false } = {}) {
+  if (!orgAlias) {
+    throw new Error('No org specified — pass --org <alias> or set defaultOrg in .sfdt/config.json');
+  }
+  const args = ['data', 'query', '--query', soql, '--target-org', orgAlias, '--json'];
+  if (tooling) args.push('--use-tooling-api');
+  if (all) args.push('--all-rows');
+
+  let result;
+  try {
+    result = await execa('sf', args);
+  } catch (err) {
+    const parsed = safeParse(err.stdout);
+    if (parsed?.message) {
+      const e = new Error(parsed.message);
+      e.stderr = err.stderr;
+      throw e;
+    }
+    throw err;
+  }
+  return safeParse(result.stdout)?.result ?? null;
+}
+
+/**
  * Run a SOQL query against an org and return its records.
  *
  * @param {string} orgAlias - Target org alias.
@@ -21,40 +57,9 @@ import { execa } from 'execa';
  * @param {boolean} [options.all] - Include deleted/archived rows (`--all-rows`).
  * @returns {Promise<Array<object>>} Query records (empty array when none).
  */
-export async function query(orgAlias, soql, { tooling = false, all = false } = {}) {
-  if (!orgAlias) {
-    throw new Error('No org specified — pass --org <alias> or set defaultOrg in .sfdt/config.json');
-  }
-  const args = [
-    'data',
-    'query',
-    '--query',
-    soql,
-    '--target-org',
-    orgAlias,
-    '--json',
-  ];
-  if (tooling) args.push('--use-tooling-api');
-  if (all) args.push('--all-rows');
-
-  let result;
-  try {
-    result = await execa('sf', args);
-  } catch (err) {
-    // execa attaches stdout/stderr; sf emits a JSON error envelope on stdout
-    // for query failures (e.g. malformed SOQL, missing sObject). Prefer the
-    // structured message when present, else re-throw the raw error.
-    const parsed = safeParse(err.stdout);
-    if (parsed?.message) {
-      const e = new Error(parsed.message);
-      e.stderr = err.stderr;
-      throw e;
-    }
-    throw err;
-  }
-
-  const parsed = safeParse(result.stdout);
-  return parsed?.result?.records ?? [];
+export async function query(orgAlias, soql, options = {}) {
+  const result = await _execQuery(orgAlias, soql, options);
+  return result?.records ?? [];
 }
 
 /**
@@ -86,32 +91,11 @@ export async function count(orgAlias, soql, options = {}) {
  * @returns {Promise<{records: Array<object>, totalSize: number, done: boolean}>}
  */
 export async function rawQuery(orgAlias, soql, options = {}) {
-  if (!orgAlias) {
-    throw new Error('No org specified — pass --org <alias> or set defaultOrg in .sfdt/config.json');
-  }
-  const args = ['data', 'query', '--query', soql, '--target-org', orgAlias, '--json'];
-  if (options.tooling) args.push('--use-tooling-api');
-  if (options.all) args.push('--all-rows');
-  let result;
-  try {
-    result = await execa('sf', args);
-  } catch (err) {
-    // Mirror query(): sf emits a JSON error envelope on stdout for query
-    // failures (malformed SOQL, missing sObject). Surface the structured
-    // message instead of the opaque execa error.
-    const parsed = safeParse(err.stdout);
-    if (parsed?.message) {
-      const e = new Error(parsed.message);
-      e.stderr = err.stderr;
-      throw e;
-    }
-    throw err;
-  }
-  const parsed = safeParse(result.stdout);
+  const result = await _execQuery(orgAlias, soql, options);
   return {
-    records: parsed?.result?.records ?? [],
-    totalSize: parsed?.result?.totalSize ?? 0,
-    done: parsed?.result?.done ?? true,
+    records: result?.records ?? [],
+    totalSize: result?.totalSize ?? 0,
+    done: result?.done ?? true,
   };
 }
 

--- a/test/commands/data.test.js
+++ b/test/commands/data.test.js
@@ -90,6 +90,22 @@ describe('data delete confirmation', () => {
     writeSpy.mockRestore();
   });
 
+  it('reports status "partial" + skippedCount in --json when a query was skipped', async () => {
+    deleteDataSet.mockResolvedValueOnce({
+      set: 'qa',
+      org: 'dev',
+      sobjects: [
+        { sobject: 'Account', status: 'ok' },
+        { sobject: null, status: 'skipped', query: 'not soql' },
+      ],
+    });
+    const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    await createProgram().parseAsync(['node', 'sfdt', 'data', 'delete', 'qa', '--yes', '--json']);
+    const out = writeSpy.mock.calls.map((c) => c[0]).join('');
+    expect(JSON.parse(out)).toMatchObject({ status: 'partial', skippedCount: 1 });
+    writeSpy.mockRestore();
+  });
+
   it('refuses to delete non-interactively without --yes', async () => {
     const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
     // --json forces non-interactive; without --yes the delete must be refused.

--- a/test/lib/data-runner.test.js
+++ b/test/lib/data-runner.test.js
@@ -118,6 +118,15 @@ describe('deleteDataSet', () => {
     const res = await deleteDataSet(config, 'qa', 'dev');
     expect(res.sobjects[0]).toMatchObject({ sobject: 'Account', status: 'error' });
   });
+  it('prefers sf\'s structured error message over the opaque execa message', async () => {
+    fs.readJson.mockResolvedValueOnce({ queries: ['SELECT Id FROM Account'] });
+    const err = new Error('Command failed with exit code 1: sf data delete bulk');
+    err.stdout = JSON.stringify({ status: 1, message: 'No authorization information found for dev.' });
+    execa.mockRejectedValueOnce(err);
+    const res = await deleteDataSet(config, 'qa', 'dev');
+    expect(res.sobjects[0].error).toMatch(/No authorization information found for dev\./);
+    expect(res.sobjects[0].error).not.toMatch(/Command failed with exit code/);
+  });
   it('runs every query, including multiple for the same sObject', async () => {
     fs.readJson.mockResolvedValueOnce({
       queries: ["SELECT Id FROM Account WHERE Region='US'", "SELECT Id FROM Account WHERE Region='EU'"],

--- a/test/lib/data-runner.test.js
+++ b/test/lib/data-runner.test.js
@@ -128,6 +128,17 @@ describe('deleteDataSet', () => {
     expect(execa).toHaveBeenCalledTimes(2);
     expect(res.sobjects).toHaveLength(2);
   });
+  it('records unparseable queries as skipped instead of silently dropping them', async () => {
+    fs.readJson.mockResolvedValueOnce({ queries: ['SELECT Id FROM Account', 'not soql'] });
+    execa.mockResolvedValue({ stdout: '{}' });
+    const res = await deleteDataSet(config, 'qa', 'dev');
+    // Only the parseable query runs a delete…
+    expect(execa).toHaveBeenCalledTimes(1);
+    // …but the skipped one is still surfaced in the results.
+    expect(res.sobjects).toHaveLength(2);
+    expect(res.sobjects[0]).toMatchObject({ sobject: 'Account', status: 'ok' });
+    expect(res.sobjects[1]).toMatchObject({ sobject: null, status: 'skipped' });
+  });
 });
 
 describe('listDataSets', () => {

--- a/test/lib/monitor-runner.test.js
+++ b/test/lib/monitor-runner.test.js
@@ -57,6 +57,16 @@ describe('checkLimits', () => {
     expect(r.status).toBe('error');
     expect(r.summary).toMatch(/auth failure/);
   });
+
+  it('prefers the structured sf error message over the opaque execa error', async () => {
+    const err = new Error('Command failed with exit code 1: sf org list limits');
+    err.stdout = JSON.stringify({ status: 1, message: 'No authorization information found for dev.' });
+    execa.mockRejectedValueOnce(err);
+    const r = await checkLimits('dev');
+    expect(r.status).toBe('error');
+    expect(r.summary).toMatch(/No authorization information found for dev\./);
+    expect(r.summary).not.toMatch(/Command failed with exit code/);
+  });
 });
 
 describe('checkErrors', () => {

--- a/test/lib/monitor-runner.test.js
+++ b/test/lib/monitor-runner.test.js
@@ -67,6 +67,17 @@ describe('checkLimits', () => {
     expect(r.summary).toMatch(/No authorization information found for dev\./);
     expect(r.summary).not.toMatch(/Command failed with exit code/);
   });
+
+  it('falls back to the structured message on stderr when stdout is empty', async () => {
+    const err = new Error('Command failed with exit code 1: sf org list limits');
+    err.stdout = '';
+    err.stderr = JSON.stringify({ status: 1, message: 'No authorization information found for dev.' });
+    execa.mockRejectedValueOnce(err);
+    const r = await checkLimits('dev');
+    expect(r.status).toBe('error');
+    expect(r.summary).toMatch(/No authorization information found for dev\./);
+    expect(r.summary).not.toMatch(/Command failed with exit code/);
+  });
 });
 
 describe('checkErrors', () => {

--- a/test/lib/org-query.test.js
+++ b/test/lib/org-query.test.js
@@ -55,6 +55,14 @@ describe('org-query query()', () => {
     execa.mockRejectedValueOnce(err);
     await expect(query('dev', 'SELECT Foo FROM Account')).rejects.toThrow(/No such column Foo/);
   });
+
+  it('falls back to the structured error message on stderr when stdout is empty', async () => {
+    const err = new Error('Command failed with exit code 1');
+    err.stdout = '';
+    err.stderr = JSON.stringify({ status: 1, message: 'No authorization information found for dev.' });
+    execa.mockRejectedValueOnce(err);
+    await expect(query('dev', 'SELECT Id FROM Account')).rejects.toThrow(/No authorization information found/);
+  });
 });
 
 describe('org-query rawQuery()', () => {


### PR DESCRIPTION
Fast-follow for the actionable findings from the #138 (v0.13.0) review. The release already shipped; these are the small correctness/cleanup items the bot flagged that were worth doing.

## Fixed
- **`data delete` no longer silently drops unparseable queries** (`data-runner.js`) — a query whose FROM clause can't be parsed is now recorded as `{ status: 'skipped' }` and the `data` command warns when any query was skipped. Previously it was `continue`d silently, leaving the user (who already confirmed deletion) with no signal that records were not deleted. *(review bug #2)*
- **`checkLimits` surfaces friendly sf errors** (`monitor-runner.js`) — `errored()` now prefers sf's structured JSON error message (`err.stdout`) over the opaque execa message, matching the `query()`/`rawQuery()` path. Auth failures / invalid org aliases now read clearly. *(review bug #3)*

## Changed
- **`org-query.js` deduplicated** — extracted a private `_execQuery` core; `query()` and `rawQuery()` now share one copy of the execa + structured-error + parse plumbing (a fix in one previously didn't reach the other). *(review simplification)*

## Security
- **CodeQL alert #107 (client-side URL redirect, `app/main.ts:85`) assessed as a false positive and dismissed.** The flagged `href` populates a *synthetic* `fakeLocation` (cast `as Location`) used only to derive the API host — it's never assigned to the real `document.location`. The only real navigation targets the extension's own `app.html` with an `encodeURIComponent`-encoded `?org=` param (same `chrome-extension://` origin), and the org host is gated by the `isAllowedSfHost()` Salesforce-domain allowlist before use.

## Deliberately deferred (not in this PR)
- `rollupStatus` error-vs-fail ordering (`vscode/snapshots.ts`) — a severity-ranking judgment call, not a bug.
- Scratch-pool alias collision and the 5 pagination-truncation gaps — all already raised and deferred during #132's own review (advisory checks; the `checkMfa` semi-join was verified-rejected by Salesforce). Can be a separate hardening pass if desired.

## Verification
- [x] `npm test` — 2034/2034 (added skipped-query + structured-error tests)
- [x] `npm run lint` clean