### PR TITLE
chore: release vscode v0.1.1 (Marketplace listing refresh)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15025,7 +15025,7 @@
     },
     "vscode": {
       "name": "sfdt-devtools",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@sfdt/flow-core": "^0.9.0"

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to the **SFDT for Salesforce** VS Code extension (`sfdt.sfdt
 
 ## [Unreleased]
 
+## [0.1.1] - 2026-06-26
+
+### Changed
+- **Marketplace listing refresh** — the README rendered on the Marketplace now shows the correct title ("SFDT for Salesforce"), version/install badges, and `code --install-extension` instructions. The 0.1.0 listing rendered an earlier draft README that was baked into that build. No functional changes to the extension.
+- First automated publish via `.github/workflows/vscode-release.yml` (Marketplace + Open VSX).
+
 ## [0.1.0] - 2026-06-24
 
 Initial version of the SFDT VS Code extension — a thin UI over the `sfdt` CLI. It spawns the `sfdt` binary and reads the same JSON snapshots the CLI writes; it reimplements no logic of its own.

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "sfdt-devtools",
   "displayName": "SFDT for Salesforce",
   "description": "Drive the sfdt CLI from VS Code: deploy, preflight, org monitoring & audit, docs, and the sfdt dashboard — all from the command palette and a dedicated Org Health sidebar.",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "publisher": "sfdt",


### PR DESCRIPTION
First automated VS Code extension release. Bumps `vscode/package.json` `0.1.0 → 0.1.1`.

## What ships
- **Marketplace listing refresh** — the README rendered on the Marketplace will now show the correct title ("SFDT for Salesforce"), version/install badges, and `code --install-extension` instructions. The 0.1.0 listing rendered an earlier draft README baked into that manual build. **No functional extension changes.**

## On merge
`.github/workflows/vscode-release.yml` (trigger: `vscode/package.json` version bump on `main`) will:
1. `vsce publish` → VS Code Marketplace (`sfdt.sfdt-devtools`)
2. `ovsx publish` → Open VSX (both `VSCE_PAT` and `OVSX_PAT` are configured)
3. Tag `vscode-v0.1.1` + attach the `.vsix` to a GitHub Release

## Verified locally
- `npm run lint -w vscode`, `npm run test:vscode` (17 pass), `npm run build:vscode` — all green
- `npm run package:vscode` → `vscode/sfdt-devtools-0.1.1.vsix` built cleanly

> Gotcha to watch on the run: a `401` on the publish step means the `VSCE_PAT`'s Organization scope wasn't "All accessible organizations".
