### PR TITLE
fix(vscode): emit .cjs bundle so the extension activates (v0.1.2)

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to the **SFDT for Salesforce** VS Code extension (`sfdt.sfdt
 
 ## [Unreleased]
 
+## [0.1.2] - 2026-06-26
+
+### Fixed
+- **The Org Health sidebar and all `SFDT:` commands now work.** The extension bundle is now emitted as CommonJS (`dist/extension.cjs`) instead of `dist/extension.js`. Because the manifest declares `"type": "module"`, VS Code parsed the old `.js` bundle as an ES module and failed to load it, so `activate()` never ran — the sidebar showed *"There is no data provider registered that can provide view data"* and commands failed with *"command 'sfdt.refresh' not found"*. A `.cjs` bundle is always loaded as CommonJS, so the extension activates correctly. No functional code changed — only the build output format.
+
 ## [0.1.1] - 2026-06-26
 
 ### Changed

--- a/vscode/README.md
+++ b/vscode/README.md
@@ -46,7 +46,7 @@ your PATH.
 
 ```bash
 npm install            # from the repo root (workspaces)
-npm run build:vscode   # build flow-core + bundle to dist/extension.js
+npm run build:vscode   # build flow-core + bundle to dist/extension.cjs
 npm run test:vscode    # unit tests (vitest)
 ```
 

--- a/vscode/esbuild.mjs
+++ b/vscode/esbuild.mjs
@@ -8,7 +8,11 @@ import { build, context } from 'esbuild';
 const options = {
   entryPoints: ['src/extension.ts'],
   bundle: true,
-  outfile: 'dist/extension.js',
+  // Emit a .cjs file so VS Code can require() the CommonJS bundle even though
+  // package.json declares "type": "module" (a bare .js would be parsed as ESM
+  // and fail to load, leaving activate() — and thus the views/commands —
+  // unregistered).
+  outfile: 'dist/extension.cjs',
   external: ['vscode'],
   format: 'cjs',
   platform: 'node',

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "sfdt-devtools",
   "displayName": "SFDT for Salesforce",
   "description": "Drive the sfdt CLI from VS Code: deploy, preflight, org monitoring & audit, docs, and the sfdt dashboard — all from the command palette and a dedicated Org Health sidebar.",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "type": "module",
   "publisher": "sfdt",
@@ -23,7 +23,7 @@
   "categories": ["Other", "Linters", "SCM Providers"],
   "keywords": ["salesforce", "devops", "sfdx", "deployment", "monitoring"],
   "activationEvents": [],
-  "main": "./dist/extension.js",
+  "main": "./dist/extension.cjs",
   "scripts": {
     "build": "node esbuild.mjs",
     "watch": "node esbuild.mjs --watch",


### PR DESCRIPTION
## Summary

Fixes the dead **Org Health** sidebar and all `SFDT:` commands in the VS Code extension. Bumps to **v0.1.2**.

### Root cause
`vscode/package.json` declares `"type": "module"`, but `esbuild.mjs` bundles the extension as **CommonJS**. Node therefore treats the output `dist/extension.js` as ESM, so VS Code's `require('./dist/extension.js')` throws at load time and **`activate()` never runs**. The view container is a static `package.json` contribution so the sidebar still *appears*, but the `registerTreeDataProvider` and every `registerCommand` call never execute — producing both symptoms at once:
- *"There is no data provider registered that can provide view data"*
- *"command 'sfdt.refresh' not found"*

Confirmed present in the shipped 0.1.1 vsix.

### Fix
Emit the bundle as **`dist/extension.cjs`** and point `main` at it. A `.cjs` file is always loaded as CommonJS regardless of `"type": "module"`, so VS Code can `require()` it. No functional code changed — only the build output format.

### Verification
- `head -1 dist/extension.cjs` → `"use strict";` (CommonJS)
- A `require()` smoke test with a stubbed `vscode` module loads the bundle cleanly and returns `typeof activate === 'function'` (the exact call that previously threw)
- `npm run test:vscode` (17 pass), `npm run lint -w vscode` clean, `npm run build:vscode` clean
- Packaged `sfdt-devtools-0.1.2.vsix` ships `dist/extension.cjs` (no stale `.js`); installed locally via `code --install-extension`

## Routing
Merging to **develop** first; a follow-up **develop→main** release PR triggers `vscode-release.yml` to publish 0.1.2 to the Marketplace + Open VSX.

## Files
- `vscode/esbuild.mjs` — outfile → `dist/extension.cjs`
- `vscode/package.json` — `main` → `./dist/extension.cjs`; version `0.1.1` → `0.1.2`
- `vscode/CHANGELOG.md` — 0.1.2 entry
- `vscode/README.md` — dev-command comment now references `extension.cjs`

https://claude.ai/code/session_01YFBeAD33fANRyNKjjvkjp5