### PR TITLE
chore: release vscode v0.1.2 (fix dead sidebar) → main

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -61,9 +61,18 @@
 
 ---
 
-## In Progress
+## Next Session
 
-- **Plugin registry & scaffolding** — `sfdt plugin create` scaffold to bootstrap a new `sfdt-plugin-*` package with example `register(program)` wiring
+Consolidated, actionable queue from the v0.14.0 release cycle (2026-06-26):
+
+- **`sfdt plugin create`** — plugin registry & scaffolding to bootstrap a new `sfdt-plugin-*` package with example `register(program)` wiring. *(Was in progress — top of the queue.)*
+- **Triage the 3 parked specs** in `docs/superpowers/specs/` — for each, decide build / defer / discard:
+  - `2026-05-07-sfdt-mcp-parking-and-skills-design.md` — feeds the "Expose sfdt as MCP Server" planned item below
+  - `2026-05-09-remaining-items-design.md`
+  - `2026-05-09-scan-page-design.md`
+- **Automate the Homebrew tap bump** — add a step to the CLI publish path that computes the new tarball `sha256` and pushes `Formula/sfdt.rb` to the `scoobydrew83/homebrew-sfdt` tap. Needs a PAT with push access to that repo (the default `GITHUB_TOKEN` can't reach it). Currently a manual step in [RELEASING.md](RELEASING.md) Step 9.
+- **Fix the always-failing `integration` CI job** — it red-X's every release PR (DevHub org-auth; no org secrets available in PR context). Either wire the auth, restrict it to non-PR runs, or mark it non-required so release PRs stop showing a false failure.
+- **Refresh the "Shipped" section below** — it predates v0.14.0. Not yet reflected: the generic **`http` AI provider** (OpenAI-compatible: Ollama / OpenRouter / MiniMax), the new **install methods** (`install.sh`, Homebrew tap, **public GHCR Docker image**), and the **VS Code extension** (`sfdt.sfdt-devtools`, live on Marketplace + Open VSX at 0.1.1). The Docker line still says "Node 20" (now built from the published npm package on Node 22).
 
 ---
 

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to the **SFDT for Salesforce** VS Code extension (`sfdt.sfdt
 
 ## [Unreleased]
 
+## [0.1.2] - 2026-06-26
+
+### Fixed
+- **The Org Health sidebar and all `SFDT:` commands now work.** The extension bundle is now emitted as CommonJS (`dist/extension.cjs`) instead of `dist/extension.js`. Because the manifest declares `"type": "module"`, VS Code parsed the old `.js` bundle as an ES module and failed to load it, so `activate()` never ran — the sidebar showed *"There is no data provider registered that can provide view data"* and commands failed with *"command 'sfdt.refresh' not found"*. A `.cjs` bundle is always loaded as CommonJS, so the extension activates correctly. No functional code changed — only the build output format.
+
 ## [0.1.1] - 2026-06-26
 
 ### Changed

--- a/vscode/README.md
+++ b/vscode/README.md
@@ -46,7 +46,7 @@ your PATH.
 
 ```bash
 npm install            # from the repo root (workspaces)
-npm run build:vscode   # build flow-core + bundle to dist/extension.js
+npm run build:vscode   # build flow-core + bundle to dist/extension.cjs
 npm run test:vscode    # unit tests (vitest)
 ```
 

--- a/vscode/esbuild.mjs
+++ b/vscode/esbuild.mjs
@@ -8,7 +8,11 @@ import { build, context } from 'esbuild';
 const options = {
   entryPoints: ['src/extension.ts'],
   bundle: true,
-  outfile: 'dist/extension.js',
+  // Emit a .cjs file so VS Code can require() the CommonJS bundle even though
+  // package.json declares "type": "module" (a bare .js would be parsed as ESM
+  // and fail to load, leaving activate() — and thus the views/commands —
+  // unregistered).
+  outfile: 'dist/extension.cjs',
   external: ['vscode'],
   format: 'cjs',
   platform: 'node',

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "sfdt-devtools",
   "displayName": "SFDT for Salesforce",
   "description": "Drive the sfdt CLI from VS Code: deploy, preflight, org monitoring & audit, docs, and the sfdt dashboard — all from the command palette and a dedicated Org Health sidebar.",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "type": "module",
   "publisher": "sfdt",
@@ -23,7 +23,7 @@
   "categories": ["Other", "Linters", "SCM Providers"],
   "keywords": ["salesforce", "devops", "sfdx", "deployment", "monitoring"],
   "activationEvents": [],
-  "main": "./dist/extension.js",
+  "main": "./dist/extension.cjs",
   "scripts": {
     "build": "node esbuild.mjs",
     "watch": "node esbuild.mjs --watch",


### PR DESCRIPTION
Promotes `develop` → `main` to publish **VS Code extension v0.1.2**.

## What ships
- **fix(vscode): emit `.cjs` bundle so the extension activates (v0.1.2)** (#145)
  - The Org Health sidebar and all `SFDT:` commands were dead because the CommonJS bundle was named `dist/extension.js` under a `"type": "module"` manifest, so VS Code's `require()` parsed it as ESM and `activate()` never ran. Now emitted as `dist/extension.cjs`. No functional code changed.
- **docs(roadmap):** consolidate next-session queue from the v0.14.0 cycle (already on develop)

## On merge
`.github/workflows/vscode-release.yml` detects the `vscode/package.json` bump on `main` → `vsce publish` (Marketplace) + `ovsx publish` (Open VSX), tags `vscode-v0.1.2`, and attaches the `.vsix` to a GitHub Release. Both `VSCE_PAT` and `OVSX_PAT` secrets are set.

> Merge method: **merge commit** (not squash) to keep `develop` fast-forwardable with `main` and avoid branch drift.

## Verification
- `npm run test:vscode` (17 pass), `npm run lint -w vscode`, `npm run build:vscode` — all green
- `require()` smoke test (stubbed `vscode`) loads `dist/extension.cjs` and returns `typeof activate === 'function'`
- `sfdt-devtools-0.1.2.vsix` installed locally via `code --install-extension`

https://claude.ai/code/session_01YFBeAD33fANRyNKjjvkjp5