### PR TITLE
fix(config): allow mcp.parking block in config schema

### DIFF
--- a/src/lib/config-schema.json
+++ b/src/lib/config-schema.json
@@ -81,6 +81,16 @@
             "command": { "type": "string" },
             "args": { "type": "array", "items": { "type": "string" } }
           }
+        },
+        "parking": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "thresholdBytes": { "type": "integer", "minimum": 0 },
+            "ttlSeconds": { "type": "integer", "minimum": 0 },
+            "cacheScope": { "type": "string" }
+          }
         }
       }
     },

--- a/test/lib/config.test.js
+++ b/test/lib/config.test.js
@@ -189,6 +189,25 @@ describe('validateConfig', () => {
     expect(() => validateConfig({ defaultOrg: 'dev', features: {}, logRetention: 'lots' }))
       .toThrow(ConfigError);
   });
+
+  it('accepts the mcp.parking block written by `sfdt init`', () => {
+    // The config template (src/templates/sfdt.config.json) ships mcp.parking and
+    // src/lib/mcp-parking.js consumes it — the schema must allow it.
+    const config = {
+      ...VALID_CONFIG,
+      mcp: {
+        enabled: true,
+        salesforce: { transport: 'stdio', command: 'sf', args: ['mcp', 'start'] },
+        parking: { enabled: true, thresholdBytes: 51200, ttlSeconds: 86400, cacheScope: 'session' },
+      },
+    };
+    expect(() => validateConfig(config)).not.toThrow();
+  });
+
+  it('still rejects an unknown key under mcp.parking', () => {
+    const config = { ...VALID_CONFIG, mcp: { parking: { enabled: true, bogusKey: 1 } } };
+    expect(() => validateConfig(config)).toThrow(/"mcp\.parking" contains unknown key "bogusKey"/);
+  });
 });
 
 describe('getConfigDir', () => {


### PR DESCRIPTION
## Summary
`sfdt audit` (and any command that calls `validateConfig`) failed with:

> Invalid configuration: "mcp" contains unknown key "parking".

### Root cause
`src/templates/sfdt.config.json` ships an `mcp.parking` block and `src/lib/mcp-parking.js` consumes it, but `src/lib/config-schema.json` never listed `parking` under the `mcp` object — and `mcp` has `additionalProperties: false`. So any config generated by `sfdt init` from the current template fails strict validation.

### Fix
Add the `parking` sub-schema (`enabled`, `thresholdBytes`, `ttlSeconds`, `cacheScope`) mirroring the template and the keys `mcp-parking.js` reads. Strictness is preserved — unknown keys under `parking` are still rejected (`"mcp.parking" contains unknown key "…"`).

### Verification
- Proven through the real `validateConfig` code path: a real project config + `mcp.parking` now validates; a typo under `parking` is still caught.
- Added regression tests (valid block + typo case).
- Full suite: **2076 tests pass**, lint clean.

## Notes
- Discovered while testing the VS Code extension's **Run Org Audit** after the v0.1.2 activation fix — the extension activates correctly now and surfaced this CLI-side validation bug.
- Reaches published npm/Homebrew/Docker users only via a CLI release; local `npm link` setups get it immediately.

https://claude.ai/code/session_01YFBeAD33fANRyNKjjvkjp5