### PR TITLE
fix(ui): print the tokened dashboard URL (avoid 401)

### DIFF
--- a/src/commands/ui.js
+++ b/src/commands/ui.js
@@ -44,9 +44,15 @@ export function registerUiCommand(program) {
         return;
       }
 
+      // The dashboard authenticates with a one-time launch token generated fresh
+      // on every start. The browser must load the *tokened* URL — opening the
+      // bare http://localhost:<port> (a bookmark, history, or a tab left over
+      // from a previous launch) sends no/stale token and 401s on /api/csrf-token.
+      // So print the full tokened URL, not the bare host, to keep a working,
+      // copy-pasteable link available even when auto-open misfires.
       const url = `http://localhost:${port}?token=${server.launchToken}`;
-      const printUrl = `http://localhost:${port}`;
-      print.success(`Dashboard running at ${printUrl}`);
+      print.success(`Dashboard running at ${url}`);
+      print.info('Open the URL above — it includes a one-time auth token (regenerated each launch).');
       print.info('Press Ctrl+C to stop.');
 
       // Open browser unless suppressed
@@ -56,7 +62,7 @@ export function registerUiCommand(program) {
           await open(url);
         } catch {
           // `open` is optional — non-fatal if unavailable
-          print.info(`Open ${printUrl} in your browser.`);
+          print.info(`Open ${url} in your browser.`);
         }
       }
 

--- a/test/commands/ui.test.js
+++ b/test/commands/ui.test.js
@@ -68,6 +68,15 @@ describe('ui command', () => {
     expect(print.success).toHaveBeenCalledWith(expect.stringContaining('localhost:7654'));
   });
 
+  it('prints the launch URL with the auth token so it is copy-pasteable', async () => {
+    await createProgram().parseAsync(['node', 'sfdt', 'ui', '--no-open']);
+
+    // Must include the tokened URL — printing the bare host would 401 when used.
+    expect(print.success).toHaveBeenCalledWith(
+      expect.stringContaining('localhost:7654?token=test-launch-token'),
+    );
+  });
+
   it('starts the GUI server on a custom port with --port', async () => {
     await createProgram().parseAsync(['node', 'sfdt', 'ui', '--port', '9000', '--no-open']);
 


### PR DESCRIPTION
## Summary
`sfdt ui` was prone to a **401** on the dashboard. Each launch generates a fresh random launch token (`security.js` → `crypto.randomBytes(32)`), and the dashboard authenticates by loading the page with `?token=…`, caching it in `sessionStorage`, and sending it as `Authorization: Bearer` to `/api/csrf-token`. The command auto-opened the browser with the tokened URL but **printed only the bare host** (`http://localhost:<port>`), so any of these 401'd:
- opening the printed URL / a bookmark / history autocomplete (no token)
- relaunching `sfdt ui` while an old tab held a stale token
- auto-open misfiring

## Fix
Print the **full tokened URL** (with a note that it carries a one-time token), and use it in the open-failed fallback too — so there's always a working, copy-pasteable link.

## Verification
- `test/commands/ui.test.js`: added an assertion that the success line contains `…?token=…`; all 13 ui tests pass.
- Full suite green (2077), lint clean.

No server/auth behavior changed — only the console output. Rides the next release.

https://claude.ai/code/session_01YFBeAD33fANRyNKjjvkjp5