### PR TITLE
feat(vscode): full command center (v0.2.0)

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -6,6 +6,45 @@ All notable changes to the **SFDT for Salesforce** VS Code extension (`sfdt.sfdt
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-06-26
+
+A ground-up expansion from a single Org Health viewer into a full command center
+for the sfdt CLI. The extension stays a thin UI over the CLI — it spawns `sfdt`
+and reads the same JSON snapshots — but it now surfaces the *entire* command
+surface and the live state of your org and project.
+
+### Added
+- **Commands view** — a grouped tree of the full sfdt command surface (30+
+  commands / 50+ subcommands) across six categories: Deploy & Release, Org
+  Health, Quality & Analysis, Documentation, Data & Scratch Orgs, and Project &
+  Tools. Click any command to run it; subcommands nest under their parent.
+- **Integrated-terminal execution** — commands now run in a dedicated **SFDT**
+  terminal with live, colored, streaming output and support for interactive
+  prompts, instead of a hidden output channel. Destructive commands (deploy,
+  rollback, backup, data delete, scratch delete) confirm first.
+- **Status view** — the active target org (alias, instance URL, connection),
+  the git branch, an Org Health rollup, and the installed `sfdt`/`sf` versions
+  with an "update available" hint.
+- **Org picker** — select the target org from `sf org list` (or type an alias)
+  right from the Status view title bar; it updates `sfdt.defaultOrg`.
+- **Welcome / onboarding** — when the `sfdt` CLI isn't found or the project
+  isn't initialized, the views offer one-click install docs and `sfdt init`.
+- **Command search** — `SFDT: Run Command…` is now a searchable quick-pick over
+  every command (matches on label, detail, and argv).
+- **Context menus & docs links** — right-click any command to Run, Copy the
+  exact `sfdt …` invocation, or Open the matching page on https://sfdt.dev/.
+- **Per-org window theming** (`sfdt.orgColor`, on by default) — tints the window
+  by org type (production = red, sandbox = orange, scratch/developer = green) to
+  prevent wrong-org mistakes.
+- **Org Health** now also surfaces `scan` (metadata inventory) and `drift`
+  sections alongside audit and monitor, and all views auto-refresh whenever a
+  `logs/*-latest.json` snapshot changes.
+
+### Fixed
+- **The embedded dashboard no longer 401s.** It now captures the one-time launch
+  token printed by `sfdt ui` and passes it to the webview (and can deep-link to
+  a specific dashboard page), so the in-editor dashboard authenticates correctly.
+
 ## [0.1.2] - 2026-06-26
 
 ### Fixed

--- a/vscode/README.md
+++ b/vscode/README.md
@@ -16,17 +16,34 @@ your PATH.
 
 ## Features
 
-- **Org Health sidebar** — a tree view that reads the latest `sfdt audit` and
-  `sfdt monitor` snapshots (`logs/audit-latest.json`, `logs/monitor-latest.json`)
-  and shows each check's status, summary, and findings. Click any check to
-  re-run just that check.
-- **Command palette** — `SFDT: Run Command…` lists the common operations
-  (preflight, audit, monitor, backup, drift, scan, quality, docs, deploy).
-  Dedicated commands exist for the most-used ones.
-- **Embedded dashboard** — `SFDT: Open Dashboard` spawns `sfdt ui` and shows the
-  full web dashboard in an editor tab.
-- **Status bar** — shows the active org and the worst monitor/audit status; click
-  to open the dashboard.
+The SFDT activity-bar container holds three views plus a status bar:
+
+- **Commands** — a grouped tree of the *entire* sfdt command surface (30+
+  commands / 50+ subcommands) across six categories: **Deploy & Release**,
+  **Org Health**, **Quality & Analysis**, **Documentation**, **Data & Scratch
+  Orgs**, and **Project & Tools**. Click a command to run it in a dedicated
+  **SFDT** integrated terminal — live, colored, streaming output, with
+  interactive prompts supported. Destructive commands confirm first. Right-click
+  any command to **Run**, **Copy** the exact `sfdt …` invocation, or **Open
+  docs** on [sfdt.dev](https://sfdt.dev/). `SFDT: Run Command…` is a searchable
+  quick-pick over everything.
+- **Status** — the active target org (alias, instance URL, connection), the git
+  branch, an Org Health rollup, and the installed `sfdt`/`sf` versions with an
+  "update available" hint. Use the title-bar **Select Org** button to switch the
+  target org from `sf org list`.
+- **Org Health** — reads the latest `audit`, `monitor`, `scan`, and `drift`
+  snapshots and shows each check's status, summary, and findings; click a check
+  to re-run it. All views auto-refresh when a `logs/*-latest.json` snapshot
+  changes.
+- **Embedded dashboard** — `SFDT: Open Dashboard` runs `sfdt ui` and shows the
+  full web dashboard in an editor tab (authenticated via the CLI's launch token).
+- **Per-org window theming** — tints the window by org type (production = red,
+  sandbox = orange, scratch/developer = green) to prevent wrong-org mistakes
+  (toggle with `sfdt.orgColor`).
+- **Status bar** — shows the active org and the worst monitor/audit status.
+
+New here? When the `sfdt` CLI isn't found or the project isn't initialized, the
+views offer a one-click **Run sfdt init** and links to the install docs.
 
 ## Requirements
 
@@ -41,6 +58,7 @@ your PATH.
 | `sfdt.cliPath` | `sfdt` | Path to the sfdt binary. |
 | `sfdt.defaultOrg` | `""` | Org alias passed as `--org`; empty uses the project default. |
 | `sfdt.dashboardPort` | `7654` | Port the `sfdt ui` server listens on. |
+| `sfdt.orgColor` | `true` | Tint the window by org type (prod/sandbox/scratch) to prevent wrong-org mistakes. |
 
 ## Development
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1,8 +1,8 @@
 {
   "name": "sfdt-devtools",
   "displayName": "SFDT for Salesforce",
-  "description": "Drive the sfdt CLI from VS Code: deploy, preflight, org monitoring & audit, docs, and the sfdt dashboard — all from the command palette and a dedicated Org Health sidebar.",
-  "version": "0.1.2",
+  "description": "A full command center for the sfdt CLI in VS Code: a grouped Commands tree for every sfdt command, a live Status panel (org, branch, versions), the Org Health view, an org picker, the embedded dashboard, and per-org window theming.",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "publisher": "sfdt",
@@ -44,28 +44,60 @@
     },
     "views": {
       "sfdt": [
-        {
-          "id": "sfdtOrgHealth",
-          "name": "Org Health"
-        }
+        { "id": "sfdtCommands", "name": "Commands" },
+        { "id": "sfdtStatus", "name": "Status" },
+        { "id": "sfdtOrgHealth", "name": "Org Health" }
       ]
     },
+    "viewsWelcome": [
+      {
+        "view": "sfdtCommands",
+        "when": "!sfdt:hasSfdt",
+        "contents": "The sfdt CLI was not found on your PATH.\n[Install sfdt](https://sfdt.dev/getting-started)\nAfter installing, reload the window.\n[Reload Window](command:workbench.action.reloadWindow)"
+      },
+      {
+        "view": "sfdtStatus",
+        "when": "sfdt:hasSfdt && !sfdt:ready",
+        "contents": "This project isn't initialized yet.\n[Run sfdt init](command:sfdt.init)\n[Open the docs](https://sfdt.dev/getting-started)"
+      }
+    ],
     "commands": [
-      { "command": "sfdt.refresh", "title": "SFDT: Refresh Org Health", "icon": "$(refresh)" },
-      { "command": "sfdt.setOrg", "title": "SFDT: Set Default Org" },
+      { "command": "sfdt.refresh", "title": "SFDT: Refresh", "icon": "$(refresh)" },
+      { "command": "sfdt.searchCommands", "title": "SFDT: Run Command…", "icon": "$(search)" },
       { "command": "sfdt.openDashboard", "title": "SFDT: Open Dashboard", "icon": "$(dashboard)" },
+      { "command": "sfdt.pickOrg", "title": "SFDT: Select Org", "icon": "$(account)" },
+      { "command": "sfdt.setOrg", "title": "SFDT: Set Default Org" },
+      { "command": "sfdt.init", "title": "SFDT: Initialize Project" },
+      { "command": "sfdt.runEntry", "title": "SFDT: Run", "icon": "$(play)" },
+      { "command": "sfdt.runArgs", "title": "SFDT: Run Command (args)" },
+      { "command": "sfdt.copyCommand", "title": "SFDT: Copy Command", "icon": "$(copy)" },
+      { "command": "sfdt.openCommandDocs", "title": "SFDT: Open Docs", "icon": "$(book)" },
       { "command": "sfdt.audit", "title": "SFDT: Run Org Audit" },
       { "command": "sfdt.monitor", "title": "SFDT: Run Org Monitor" },
       { "command": "sfdt.backup", "title": "SFDT: Backup Org Metadata" },
       { "command": "sfdt.preflight", "title": "SFDT: Run Preflight Checks" },
       { "command": "sfdt.deploy", "title": "SFDT: Deploy" },
-      { "command": "sfdt.docs", "title": "SFDT: Generate Documentation" },
-      { "command": "sfdt.runCommand", "title": "SFDT: Run Command…" }
+      { "command": "sfdt.docs", "title": "SFDT: Generate Documentation" }
     ],
     "menus": {
+      "commandPalette": [
+        { "command": "sfdt.runEntry", "when": "false" },
+        { "command": "sfdt.runArgs", "when": "false" },
+        { "command": "sfdt.copyCommand", "when": "false" },
+        { "command": "sfdt.openCommandDocs", "when": "false" }
+      ],
       "view/title": [
-        { "command": "sfdt.refresh", "when": "view == sfdtOrgHealth", "group": "navigation" },
-        { "command": "sfdt.openDashboard", "when": "view == sfdtOrgHealth", "group": "navigation" }
+        { "command": "sfdt.searchCommands", "when": "view == sfdtCommands", "group": "navigation@1" },
+        { "command": "sfdt.refresh", "when": "view == sfdtCommands", "group": "navigation@2" },
+        { "command": "sfdt.pickOrg", "when": "view == sfdtStatus", "group": "navigation@1" },
+        { "command": "sfdt.refresh", "when": "view == sfdtStatus", "group": "navigation@2" },
+        { "command": "sfdt.refresh", "when": "view == sfdtOrgHealth", "group": "navigation@1" },
+        { "command": "sfdt.openDashboard", "when": "view == sfdtOrgHealth", "group": "navigation@2" }
+      ],
+      "view/item/context": [
+        { "command": "sfdt.runEntry", "when": "view == sfdtCommands && viewItem =~ /^sfdtCommand/", "group": "inline@1" },
+        { "command": "sfdt.copyCommand", "when": "view == sfdtCommands && viewItem =~ /^sfdtCommand/", "group": "1_run@1" },
+        { "command": "sfdt.openCommandDocs", "when": "view == sfdtCommands && viewItem =~ /^sfdt(Command|Group|Parent)/", "group": "2_docs@1" }
       ]
     },
     "configuration": {
@@ -85,6 +117,11 @@
           "type": "number",
           "default": 7654,
           "description": "Port the `sfdt ui` dashboard server listens on."
+        },
+        "sfdt.orgColor": {
+          "type": "boolean",
+          "default": true,
+          "description": "Tint the VS Code window by org type (production = red, sandbox = orange, scratch/developer = green) to prevent wrong-org mistakes."
         }
       }
     }

--- a/vscode/src/commandsTree.ts
+++ b/vscode/src/commandsTree.ts
@@ -1,0 +1,62 @@
+import * as vscode from 'vscode';
+import { COMMAND_GROUPS, type CommandEntry, type CommandGroup } from './lib/commands.js';
+
+/**
+ * Tree data provider for the "Commands" view — the full sfdt command surface,
+ * grouped into categories. Group → entries → (optional) subcommands. Leaf nodes
+ * carry a `sfdt.runEntry` command so a click runs them in the integrated
+ * terminal. Pure presentation; all execution lives in the extension wiring.
+ */
+
+export type CmdNode =
+  | { kind: 'group'; group: CommandGroup }
+  | { kind: 'entry'; entry: CommandEntry };
+
+export class CommandsProvider implements vscode.TreeDataProvider<CmdNode> {
+  private readonly _onDidChange = new vscode.EventEmitter<CmdNode | undefined | void>();
+  readonly onDidChangeTreeData = this._onDidChange.event;
+
+  refresh(): void {
+    this._onDidChange.fire();
+  }
+
+  getTreeItem(node: CmdNode): vscode.TreeItem {
+    if (node.kind === 'group') {
+      const item = new vscode.TreeItem(node.group.label, vscode.TreeItemCollapsibleState.Collapsed);
+      item.iconPath = new vscode.ThemeIcon(node.group.icon);
+      item.contextValue = 'sfdtGroup';
+      return item;
+    }
+
+    const { entry } = node;
+    const hasChildren = !!entry.children && entry.children.length > 0;
+    const item = new vscode.TreeItem(
+      entry.label,
+      hasChildren ? vscode.TreeItemCollapsibleState.Collapsed : vscode.TreeItemCollapsibleState.None,
+    );
+    item.id = `cmd.${entry.id}`;
+    item.description = entry.detail;
+    item.tooltip = entry.args ? `Run: sfdt ${entry.args.join(' ')}` : entry.detail;
+    if (entry.icon) item.iconPath = new vscode.ThemeIcon(entry.icon);
+
+    if (!hasChildren) {
+      item.command = { command: 'sfdt.runEntry', title: 'Run', arguments: [entry] };
+      // contextValue drives the right-click menu (Run / Copy / Docs); a
+      // destructive flag lets the menu warn before running.
+      item.contextValue = entry.destructive ? 'sfdtCommandDestructive' : 'sfdtCommand';
+    } else {
+      item.contextValue = 'sfdtParent';
+    }
+    return item;
+  }
+
+  getChildren(node?: CmdNode): CmdNode[] {
+    if (!node) {
+      return COMMAND_GROUPS.map((group) => ({ kind: 'group', group }));
+    }
+    if (node.kind === 'group') {
+      return node.group.entries.map((entry) => ({ kind: 'entry', entry }));
+    }
+    return (node.entry.children ?? []).map((entry) => ({ kind: 'entry', entry }));
+  }
+}

--- a/vscode/src/dashboard.ts
+++ b/vscode/src/dashboard.ts
@@ -1,15 +1,19 @@
 import * as vscode from 'vscode';
 import { spawn, type ChildProcess } from 'node:child_process';
 import * as http from 'node:http';
+import { parseLaunchToken, dashboardPageUrl } from './lib/dashboard-url.js';
 
 /**
- * Manages the embedded sfdt dashboard. Spawns `sfdt ui` once (reusing the
- * existing web GUI) and shows it inside a webview panel pointed at the local
- * server, so the whole dashboard is reachable without leaving the editor.
+ * Manages the embedded sfdt dashboard. Spawns `sfdt ui --no-open` once (reusing
+ * the existing web GUI) and shows it inside a webview panel pointed at the local
+ * server. The GUI authenticates with a one-time launch token printed on the
+ * `sfdt ui` stdout — we capture it and pass it in the iframe URL, otherwise the
+ * dashboard would 401 on every API call.
  */
 export class DashboardController {
   private server: ChildProcess | undefined;
   private panel: vscode.WebviewPanel | undefined;
+  private launchToken: string | undefined;
 
   constructor(
     private readonly cliPath: () => string,
@@ -17,10 +21,13 @@ export class DashboardController {
     private readonly port: () => number,
   ) {}
 
-  async open(): Promise<void> {
+  /** Open the dashboard, optionally deep-linked to a GUI page (e.g. "audit"). */
+  async open(page?: string): Promise<void> {
     const port = this.port();
     await this.ensureServer();
+    const url = this.pageUrl(port, page);
     if (this.panel) {
+      this.panel.webview.html = iframeHtml(url);
       this.panel.reveal();
       return;
     }
@@ -30,14 +37,18 @@ export class DashboardController {
       vscode.ViewColumn.Active,
       { enableScripts: true, retainContextWhenHidden: true },
     );
-    const url = `http://localhost:${port}`;
     this.panel.webview.html = iframeHtml(url);
     this.panel.onDidDispose(() => (this.panel = undefined));
   }
 
+  private pageUrl(port: number, page?: string): string {
+    return dashboardPageUrl(port, page, this.launchToken);
+  }
+
   private async ensureServer(): Promise<void> {
     if (this.server && !this.server.killed) return;
-    this.server = spawn(this.cliPath(), ['ui'], {
+    // --no-open: we render the GUI in the webview, not an external browser.
+    this.server = spawn(this.cliPath(), ['ui', '--no-open'], {
       cwd: this.cwd(),
       env: { ...process.env },
       shell: false,
@@ -46,8 +57,11 @@ export class DashboardController {
     this.server.on('error', (err) => {
       vscode.window.showErrorMessage(`Failed to start sfdt ui: ${err.message}`);
     });
-    // Poll the health endpoint until the server is actually listening rather
-    // than racing a fixed delay (which fails on slow machines or busy ports).
+    // Capture the launch token from the "Dashboard running at …?token=…" line.
+    this.server.stdout?.on('data', (d) => {
+      const token = parseLaunchToken(d.toString());
+      if (token) this.launchToken = token;
+    });
     await this.waitForServer(this.port());
   }
 
@@ -69,11 +83,13 @@ export class DashboardController {
       });
     return (async () => {
       while (Date.now() < deadline) {
-        if (await attempt()) return;
+        if (await attempt()) {
+          // Give stdout a beat to surface the token line after health is up.
+          if (!this.launchToken) await new Promise((r) => setTimeout(r, 300));
+          return;
+        }
         await new Promise((r) => setTimeout(r, 200));
       }
-      // Fall through after the timeout — let the webview load and surface its
-      // own connection error if the server never came up.
     })();
   }
 
@@ -84,11 +100,12 @@ export class DashboardController {
 }
 
 function iframeHtml(url: string): string {
+  const origin = url.replace(/(https?:\/\/[^/]+).*/, '$1');
   return `<!DOCTYPE html>
 <html>
   <head>
     <meta charset="utf-8" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; frame-src ${url}; style-src 'unsafe-inline';" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; frame-src ${origin}; style-src 'unsafe-inline';" />
     <style>html,body,iframe{margin:0;padding:0;height:100%;width:100%;border:0;}</style>
   </head>
   <body>

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -1,7 +1,16 @@
 import * as vscode from 'vscode';
-import { runSfdt } from './lib/cli.js';
-import { COMMAND_CATALOG, findCommand, type CommandEntry } from './lib/commands.js';
+import { spawn } from 'node:child_process';
+import * as path from 'node:path';
+import * as fs from 'node:fs';
+import { COMMAND_GROUPS, flattenCommands, findCommand, docsUrlFor, type CommandEntry } from './lib/commands.js';
+import { buildTerminalCommand } from './lib/terminal.js';
+import { buildStatusTree } from './lib/status.js';
+import { evaluatePrereqs } from './lib/prereqs.js';
+import { classifyOrg, colorForOrg } from './lib/org-color.js';
+import { readSnapshots } from './lib/io.js';
 import { OrgHealthProvider } from './tree.js';
+import { CommandsProvider } from './commandsTree.js';
+import { StatusProvider } from './statusTree.js';
 import { DashboardController } from './dashboard.js';
 import { StatusBar } from './statusBar.js';
 
@@ -17,94 +26,259 @@ function defaultOrg(): string | undefined {
 function dashboardPort(): number {
   return cfg().get<number>('dashboardPort') || 7654;
 }
+function orgColorEnabled(): boolean {
+  return cfg().get<boolean>('orgColor') !== false;
+}
 function workspaceRoot(): string | undefined {
   return vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
 }
 
+/** Capture stdout from an arbitrary command (sf, git, npm). Never throws. */
+function capture(cmd: string, args: string[], cwd?: string, timeoutMs = 8000): Promise<string> {
+  return new Promise((resolve) => {
+    let out = '';
+    let done = false;
+    const finish = (v: string) => { if (!done) { done = true; resolve(v); } };
+    try {
+      const child = spawn(cmd, args, { cwd, env: { ...process.env }, shell: false });
+      const timer = setTimeout(() => { child.kill(); finish(''); }, timeoutMs);
+      child.stdout?.on('data', (d) => (out += d.toString()));
+      child.on('error', () => { clearTimeout(timer); finish(''); });
+      child.on('close', () => { clearTimeout(timer); finish(out); });
+    } catch {
+      finish('');
+    }
+  });
+}
+
 export function activate(context: vscode.ExtensionContext): void {
   const output = vscode.window.createOutputChannel('SFDT');
-  const tree = new OrgHealthProvider(workspaceRoot);
+  let latestSfdtVersion: string | undefined;
+
+  // ── Status gatherer (org / git / versions / health) ──
+  const gatherStatus = async () => {
+    const root = workspaceRoot();
+    const org = defaultOrg();
+    const [orgJson, sfVer, sfdtVer, branch] = await Promise.all([
+      capture('sf', ['org', 'display', '--json', ...(org ? ['--target-org', org] : [])], root),
+      capture('sf', ['--version'], root, 5000),
+      capture(cliPath(), ['--version'], root, 5000),
+      capture('git', ['rev-parse', '--abbrev-ref', 'HEAD'], root, 4000),
+    ]);
+    let instanceUrl: string | undefined;
+    let connected: boolean | undefined;
+    let orgAlias = org;
+    try {
+      const parsed = JSON.parse(orgJson);
+      const r = parsed.result ?? {};
+      instanceUrl = r.instanceUrl;
+      connected = r.connectedStatus ? /connected/i.test(r.connectedStatus) : undefined;
+      orgAlias = org ?? r.alias ?? r.username;
+    } catch { /* no org / sf unavailable */ }
+    const { audit, monitor } = root ? await readSnapshots(root) : { audit: null, monitor: null };
+    return buildStatusTree({
+      orgAlias,
+      instanceUrl,
+      connected,
+      gitBranch: branch.trim() || undefined,
+      audit,
+      monitor,
+      sfdtVersion: (sfdtVer.trim().split('\n')[0] || undefined),
+      sfVersion: (sfVer.trim().split('\n')[0] || undefined),
+      latestSfdtVersion,
+    });
+  };
+
+  // ── Providers ──
+  const commands = new CommandsProvider();
+  const health = new OrgHealthProvider(workspaceRoot);
+  const status = new StatusProvider(gatherStatus);
   const dashboard = new DashboardController(cliPath, workspaceRoot, dashboardPort);
   const statusBar = new StatusBar(workspaceRoot);
 
   context.subscriptions.push(
-    vscode.window.registerTreeDataProvider('sfdtOrgHealth', tree),
+    vscode.window.registerTreeDataProvider('sfdtCommands', commands),
+    vscode.window.registerTreeDataProvider('sfdtOrgHealth', health),
+    vscode.window.registerTreeDataProvider('sfdtStatus', status),
     output,
     statusBar,
     { dispose: () => dashboard.dispose() },
   );
 
-  const refreshAll = async () => {
-    await Promise.all([tree.refresh(), statusBar.refresh(defaultOrg())]);
+  // ── Integrated terminal execution ──
+  let terminal: vscode.Terminal | undefined;
+  const sfdtTerminal = (): vscode.Terminal => {
+    if (!terminal || terminal.exitStatus !== undefined) {
+      terminal = vscode.window.createTerminal({ name: 'SFDT', cwd: workspaceRoot() });
+    }
+    return terminal;
   };
+  context.subscriptions.push(
+    vscode.window.onDidCloseTerminal((t) => { if (t === terminal) terminal = undefined; }),
+  );
 
-  /** Run an sfdt command with progress, stream output, then refresh views. */
-  const run = async (args: string[], label: string) => {
-    output.show(true);
-    output.appendLine(`\n$ sfdt ${args.join(' ')}`);
-    await vscode.window.withProgress(
-      { location: vscode.ProgressLocation.Notification, title: `SFDT: ${label}…`, cancellable: false },
-      async () => {
-        try {
-          const res = await runSfdt(args, { cliPath: cliPath(), cwd: workspaceRoot(), org: defaultOrg() });
-          if (res.stdout) output.append(res.stdout);
-          if (res.stderr) output.append(res.stderr);
-          if (res.code === 0) {
-            vscode.window.showInformationMessage(`SFDT: ${label} complete`);
-          } else {
-            vscode.window.showWarningMessage(`SFDT: ${label} exited with code ${res.code}`);
-          }
-        } catch (err) {
-          vscode.window.showErrorMessage(`SFDT: ${label} failed — ${(err as Error).message}`);
-        }
-      },
-    );
-    await refreshAll();
+  const runInTerminal = (args: string[]) => {
+    const term = sfdtTerminal();
+    term.show(true);
+    term.sendText(buildTerminalCommand(args, { cliPath: cliPath(), org: defaultOrg() }));
   };
 
   const runEntry = async (entry: CommandEntry) => {
+    if (entry.action === 'dashboard') return dashboard.open();
+    if (!entry.args) return;
     if (entry.destructive) {
       const ok = await vscode.window.showWarningMessage(
-        `Run "sfdt ${entry.args.join(' ')}"? This can modify the org.`,
+        `Run "sfdt ${entry.args.join(' ')}"? This can modify the org or your project.`,
         { modal: true },
         'Run',
       );
       if (ok !== 'Run') return;
     }
-    await run(entry.args, entry.label);
+    runInTerminal(entry.args);
   };
 
+  // ── Refresh (snapshots feed Org Health + Status + status bar) ──
+  const refreshViews = async () => {
+    await Promise.all([health.refresh(), status.refresh(), statusBar.refresh(defaultOrg())]);
+    await applyOrgColor();
+  };
+
+  // Auto-refresh when any snapshot file changes, regardless of how it was run.
+  const root = workspaceRoot();
+  if (root) {
+    const watcher = vscode.workspace.createFileSystemWatcher(
+      new vscode.RelativePattern(root, 'logs/*-latest.json'),
+    );
+    watcher.onDidCreate(() => void refreshViews());
+    watcher.onDidChange(() => void refreshViews());
+    context.subscriptions.push(watcher);
+  }
+
+  // ── Per-org window tint ──
+  async function applyOrgColor(): Promise<void> {
+    if (!orgColorEnabled()) return;
+    const org = defaultOrg();
+    const orgJson = await capture('sf', ['org', 'display', '--json', ...(org ? ['--target-org', org] : [])], workspaceRoot());
+    let customizations: Record<string, string> | null = null;
+    try {
+      const r = JSON.parse(orgJson).result ?? {};
+      customizations = colorForOrg(classifyOrg({
+        instanceUrl: r.instanceUrl,
+        isSandbox: r.isSandbox,
+        isScratch: r.isScratchOrg,
+        isDevEdition: typeof r.edition === 'string' && /developer/i.test(r.edition),
+      }));
+    } catch { /* leave untinted */ }
+    try {
+      await cfg().update('orgColorCustomizations', undefined, vscode.ConfigurationTarget.Workspace).then(undefined, () => {});
+      const workbench = vscode.workspace.getConfiguration('workbench');
+      await workbench.update('colorCustomizations', customizations ?? {}, vscode.ConfigurationTarget.Workspace);
+    } catch { /* color update is best-effort */ }
+  }
+
+  // ── Prerequisite / welcome context ──
+  const refreshPrereqs = async () => {
+    const r = workspaceRoot();
+    const hasSf = (await capture('sf', ['--version'], r, 5000)).trim().length > 0;
+    const hasSfdt = (await capture(cliPath(), ['--version'], r, 5000)).trim().length > 0;
+    const hasConfig = !!r && fs.existsSync(path.join(r, '.sfdt', 'config.json'));
+    const state = evaluatePrereqs({ hasSf, hasSfdt, hasConfig });
+    await vscode.commands.executeCommand('setContext', 'sfdt:ready', state.ready);
+    await vscode.commands.executeCommand('setContext', 'sfdt:hasSfdt', hasSfdt);
+  };
+
+  // ── Refresh latest-version hint without blocking ──
+  const refreshLatestVersion = () => {
+    void capture('npm', ['view', '@sfdt/cli', 'version'], workspaceRoot(), 6000).then((v) => {
+      const trimmed = v.trim();
+      if (trimmed) { latestSfdtVersion = trimmed; void status.refresh(); }
+    });
+  };
+
+  // ── Commands ──
   context.subscriptions.push(
-    vscode.commands.registerCommand('sfdt.refresh', refreshAll),
-    vscode.commands.registerCommand('sfdt.openDashboard', () => dashboard.open()),
-    vscode.commands.registerCommand('sfdt.audit', () => runEntry(findCommand('audit')!)),
-    vscode.commands.registerCommand('sfdt.monitor', () => runEntry(findCommand('monitor')!)),
-    vscode.commands.registerCommand('sfdt.backup', () => runEntry(findCommand('backup')!)),
-    vscode.commands.registerCommand('sfdt.preflight', () => runEntry(findCommand('preflight')!)),
-    vscode.commands.registerCommand('sfdt.deploy', () => runEntry(findCommand('deploy')!)),
-    vscode.commands.registerCommand('sfdt.docs', () => runEntry(findCommand('docs')!)),
-    // Invoked from tree nodes with a concrete argv.
-    vscode.commands.registerCommand('sfdt.runArgs', (args: string[]) => run(args, args.join(' '))),
-    vscode.commands.registerCommand('sfdt.setOrg', async () => {
-      const value = await vscode.window.showInputBox({
-        prompt: 'Org alias for sfdt commands (--org). Leave blank to use the project default.',
-        value: defaultOrg() ?? '',
-      });
-      if (value !== undefined) {
-        await cfg().update('defaultOrg', value, vscode.ConfigurationTarget.Workspace);
-        await refreshAll();
-      }
+    vscode.commands.registerCommand('sfdt.runEntry', (arg: CommandEntry | { entry: CommandEntry }) => {
+      // Leaf click passes a CommandEntry; the context menu passes the CmdNode.
+      const entry = arg && 'entry' in arg ? arg.entry : (arg as CommandEntry);
+      return runEntry(entry);
     }),
-    vscode.commands.registerCommand('sfdt.runCommand', async () => {
+    vscode.commands.registerCommand('sfdt.runArgs', (args: string[]) => runInTerminal(args)),
+    vscode.commands.registerCommand('sfdt.refresh', () => { refreshLatestVersion(); return refreshViews(); }),
+    vscode.commands.registerCommand('sfdt.openDashboard', () => dashboard.open()),
+
+    vscode.commands.registerCommand('sfdt.searchCommands', async () => {
       const pick = await vscode.window.showQuickPick(
-        COMMAND_CATALOG.map((c) => ({ label: c.label, detail: c.detail, entry: c })),
-        { placeHolder: 'Select an sfdt command to run' },
+        flattenCommands().map((e) => ({ label: e.label, detail: e.detail, description: e.args?.join(' '), entry: e })),
+        { placeHolder: 'Run an sfdt command…', matchOnDetail: true, matchOnDescription: true },
       );
       if (pick) await runEntry(pick.entry);
     }),
+
+    vscode.commands.registerCommand('sfdt.copyCommand', async (node?: { entry?: CommandEntry }) => {
+      const entry = node?.entry;
+      if (!entry?.args) return;
+      await vscode.env.clipboard.writeText(buildTerminalCommand(entry.args, { cliPath: cliPath(), org: defaultOrg() }));
+      vscode.window.showInformationMessage('Command copied to clipboard');
+    }),
+
+    vscode.commands.registerCommand('sfdt.openCommandDocs', async (node?: { entry?: CommandEntry }) => {
+      const url = node?.entry ? docsUrlFor(node.entry.id) : 'https://sfdt.dev/cli/commands';
+      if (url) await vscode.env.openExternal(vscode.Uri.parse(url));
+    }),
+
+    vscode.commands.registerCommand('sfdt.pickOrg', async () => {
+      const json = await capture('sf', ['org', 'list', '--json'], workspaceRoot());
+      let aliases: Array<{ label: string; description?: string }> = [];
+      try {
+        const r = JSON.parse(json).result ?? {};
+        const orgs = [...(r.nonScratchOrgs ?? []), ...(r.scratchOrgs ?? [])];
+        aliases = orgs.map((o: Record<string, unknown>) => ({
+          label: String(o.alias || o.username),
+          description: String(o.username ?? ''),
+        }));
+      } catch { /* fall through to manual input */ }
+      let chosen: string | undefined;
+      if (aliases.length > 0) {
+        const pick = await vscode.window.showQuickPick(aliases, { placeHolder: 'Select the target org' });
+        chosen = pick?.label;
+      } else {
+        chosen = await vscode.window.showInputBox({ prompt: 'Org alias for sfdt (--org)', value: defaultOrg() ?? '' });
+      }
+      if (chosen !== undefined) {
+        await cfg().update('defaultOrg', chosen, vscode.ConfigurationTarget.Workspace);
+        await refreshViews();
+      }
+    }),
+
+    vscode.commands.registerCommand('sfdt.setOrg', () => vscode.commands.executeCommand('sfdt.pickOrg')),
+    vscode.commands.registerCommand('sfdt.init', () => runInTerminal(['init'])),
+
+    // Dedicated palette shortcuts to common commands (back-compat + discoverability).
+    ...(['audit', 'monitor', 'deploy', 'preflight', 'backup', 'docs-generate'].map((id) =>
+      vscode.commands.registerCommand(`sfdt.${id.replace('-generate', '')}`, () => {
+        const entry = findCommand(id);
+        if (entry) return runEntry(entry);
+      }),
+    )),
   );
 
-  void refreshAll();
+  // Initial population.
+  void refreshPrereqs();
+  refreshLatestVersion();
+  void refreshViews();
+
+  // React to config changes (org / color toggle).
+  context.subscriptions.push(
+    vscode.workspace.onDidChangeConfiguration((e) => {
+      if (e.affectsConfiguration('sfdt.defaultOrg') || e.affectsConfiguration('sfdt.orgColor')) {
+        void refreshViews();
+      }
+      if (e.affectsConfiguration('sfdt.cliPath')) void refreshPrereqs();
+    }),
+  );
+
+  // Keep COMMAND_GROUPS referenced so tree-shaking never drops it (defensive).
+  void COMMAND_GROUPS.length;
 }
 
 export function deactivate(): void {

--- a/vscode/src/lib/commands.ts
+++ b/vscode/src/lib/commands.ts
@@ -1,30 +1,235 @@
 /**
- * Catalog of sfdt commands surfaced through the "SFDT: Run Command…" quick
- * pick. Pure data so it can be asserted in tests and reused by the palette.
+ * Catalog of sfdt commands surfaced in the extension. Pure data so it can be
+ * asserted in tests, rendered by the Commands tree, and searched by the palette
+ * quick-pick. The extension layer maps each entry to a terminal invocation.
+ *
+ * Deliberately free of any `vscode` import — unit-testable in isolation.
  */
+
+/** A doc category on https://sfdt.dev that a command group links to. */
+const DOCS = {
+  core: 'https://sfdt.dev/cli/commands/core',
+  orgHealth: 'https://sfdt.dev/cli/commands/org-health',
+  testing: 'https://sfdt.dev/cli/commands/testing-quality',
+  ai: 'https://sfdt.dev/cli/commands/ai',
+  metadata: 'https://sfdt.dev/cli/commands/metadata',
+  configUtils: 'https://sfdt.dev/cli/commands/config-utils',
+} as const;
 
 export interface CommandEntry {
   id: string;
   label: string;
   detail: string;
-  /** argv passed to the sfdt CLI. */
-  args: string[];
-  /** When true, the command mutates the org and should confirm first. */
+  /** argv passed to the sfdt CLI. Omitted for non-CLI actions (see `action`). */
+  args?: string[];
+  /** When true, the command mutates the org/repo and should confirm first. */
   destructive?: boolean;
+  /** When set, refresh the matching snapshot view after the command completes. */
+  refreshes?: 'audit' | 'monitor' | 'scan' | 'drift';
+  /** Non-terminal action handled by the extension (e.g. open the dashboard). */
+  action?: 'dashboard';
+  /** Docs page opened by "Open docs". Inherited from the group when unset. */
+  docsUrl?: string;
+  /** VS Code ThemeIcon id for the tree leaf. */
+  icon?: string;
+  /** Nested subcommands (each itself runnable). */
+  children?: CommandEntry[];
 }
 
-export const COMMAND_CATALOG: CommandEntry[] = [
-  { id: 'preflight', label: 'Preflight', detail: 'Run pre-deployment validation checks', args: ['preflight'] },
-  { id: 'audit', label: 'Org Audit', detail: 'Diagnose org health (read-only)', args: ['audit', 'all'] },
-  { id: 'monitor', label: 'Org Monitor', detail: 'Limits, Apex failures, security score', args: ['monitor', 'all'] },
-  { id: 'backup', label: 'Backup Metadata', detail: 'Retrieve a full metadata backup', args: ['monitor', 'backup'] },
-  { id: 'drift', label: 'Detect Drift', detail: 'Compare local source against the org', args: ['drift'] },
-  { id: 'scan', label: 'Scan Inventory', detail: 'Fetch the org metadata inventory', args: ['scan'] },
-  { id: 'quality', label: 'Quality Analysis', detail: 'Analyze Apex test quality', args: ['quality'] },
-  { id: 'docs', label: 'Generate Docs', detail: 'Generate project documentation', args: ['docs', 'generate'] },
-  { id: 'deploy', label: 'Deploy', detail: 'Deploy metadata to the org', args: ['deploy'], destructive: true },
+export interface CommandGroup {
+  id: string;
+  label: string;
+  icon: string;
+  docsUrl: string;
+  entries: CommandEntry[];
+}
+
+export const COMMAND_GROUPS: CommandGroup[] = [
+  {
+    id: 'deploy-release',
+    label: 'Deploy & Release',
+    icon: 'rocket',
+    docsUrl: DOCS.core,
+    entries: [
+      { id: 'deploy', label: 'Deploy', detail: 'Deploy metadata to the org', args: ['deploy'], destructive: true, icon: 'cloud-upload' },
+      { id: 'preflight', label: 'Preflight', detail: 'Run pre-deployment validation checks', args: ['preflight'], icon: 'checklist' },
+      { id: 'rollback', label: 'Rollback', detail: 'Roll back the last deployment', args: ['rollback'], destructive: true, icon: 'discard' },
+      { id: 'release', label: 'Release', detail: 'Build a release (manifest + notes)', args: ['release'], icon: 'tag' },
+      { id: 'manifest', label: 'Manifest', detail: 'Generate package.xml from a git diff', args: ['manifest'], icon: 'list-tree' },
+      { id: 'pr-description', label: 'PR Description', detail: 'Generate a pull-request description', args: ['pr-description'], icon: 'git-pull-request' },
+      {
+        id: 'changelog', label: 'Changelog', detail: 'Manage the CHANGELOG', icon: 'history',
+        children: [
+          { id: 'changelog-generate', label: 'Generate', detail: 'Generate changelog entries from git', args: ['changelog', 'generate'] },
+          { id: 'changelog-release', label: 'Release', detail: 'Cut a changelog release section', args: ['changelog', 'release'] },
+          { id: 'changelog-check', label: 'Check', detail: 'Verify the changelog is current', args: ['changelog', 'check'] },
+        ],
+      },
+      { id: 'smoke', label: 'Smoke Test', detail: 'Run post-deploy smoke checks', args: ['smoke'], icon: 'flame' },
+    ],
+  },
+  {
+    id: 'org-health',
+    label: 'Org Health',
+    icon: 'pulse',
+    docsUrl: DOCS.orgHealth,
+    entries: [
+      {
+        id: 'audit', label: 'Org Audit', detail: 'Diagnose org health (read-only)', args: ['audit', 'all'], refreshes: 'audit', icon: 'shield',
+        children: [
+          { id: 'audit-all', label: 'All Checks', detail: 'Run every audit check', args: ['audit', 'all'], refreshes: 'audit' },
+          { id: 'audit-audittrail', label: 'Setup Audit Trail', detail: 'Suspicious setup activity', args: ['audit', 'audittrail'], refreshes: 'audit' },
+          { id: 'audit-licenses', label: 'License Usage', detail: 'Licenses near their limit', args: ['audit', 'licenses'], refreshes: 'audit' },
+          { id: 'audit-mfa', label: 'MFA Coverage', detail: 'Users without MFA', args: ['audit', 'mfa'], refreshes: 'audit' },
+          { id: 'audit-unused-apex', label: 'Unused Apex', detail: 'Apex classes with no coverage', args: ['audit', 'unused-apex'], refreshes: 'audit' },
+          { id: 'audit-inactive-users', label: 'Inactive Users', detail: 'Users with no recent login', args: ['audit', 'inactive-users'], refreshes: 'audit' },
+          { id: 'audit-api-versions', label: 'API Versions', detail: 'Deprecated metadata API versions', args: ['audit', 'api-versions'], refreshes: 'audit' },
+        ],
+      },
+      {
+        id: 'monitor', label: 'Org Monitor', detail: 'Limits, Apex failures, security score', args: ['monitor', 'all'], refreshes: 'monitor', icon: 'graph',
+        children: [
+          { id: 'monitor-all', label: 'All Checks', detail: 'Run every monitoring check', args: ['monitor', 'all'], refreshes: 'monitor' },
+          { id: 'monitor-limits', label: 'Org Limits', detail: 'Org limits near threshold', args: ['monitor', 'limits'], refreshes: 'monitor' },
+          { id: 'monitor-errors', label: 'Apex Job Failures', detail: 'Recent failed async Apex jobs', args: ['monitor', 'errors'], refreshes: 'monitor' },
+          { id: 'monitor-health', label: 'Security Health Score', detail: 'Security Health Check score', args: ['monitor', 'health'], refreshes: 'monitor' },
+        ],
+      },
+      { id: 'backup', label: 'Backup Metadata', detail: 'Retrieve a full metadata backup', args: ['monitor', 'backup'], destructive: true, icon: 'archive' },
+      { id: 'scan', label: 'Scan Inventory', detail: 'Fetch the org metadata inventory', args: ['scan'], refreshes: 'scan', icon: 'search' },
+      { id: 'drift', label: 'Detect Drift', detail: 'Compare local source against the org', args: ['drift'], refreshes: 'drift', icon: 'git-compare' },
+      { id: 'doctor', label: 'Doctor', detail: 'Diagnose the sfdt/sf setup', args: ['doctor'], icon: 'verified' },
+    ],
+  },
+  {
+    id: 'quality',
+    label: 'Quality & Analysis',
+    icon: 'beaker',
+    docsUrl: DOCS.testing,
+    entries: [
+      { id: 'quality', label: 'Quality Analysis', detail: 'Analyze Apex test quality', args: ['quality'], icon: 'beaker' },
+      { id: 'test', label: 'Run Tests', detail: 'Run Apex tests', args: ['test'], icon: 'beaker' },
+      { id: 'review', label: 'Code Review', detail: 'AI review of the current diff', args: ['review'], icon: 'comment-discussion' },
+      {
+        id: 'flow', label: 'Flow Analysis', detail: 'Analyze Flows', icon: 'type-hierarchy',
+        children: [
+          { id: 'flow-scan', label: 'Scan', detail: 'Score Flow health', args: ['flow', 'scan'] },
+          { id: 'flow-conflicts', label: 'Conflicts', detail: 'Find conflicting Flows per object', args: ['flow', 'conflicts'] },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'documentation',
+    label: 'Documentation',
+    icon: 'book',
+    docsUrl: DOCS.ai,
+    entries: [
+      {
+        id: 'docs', label: 'Generate Docs', detail: 'Generate project documentation', icon: 'book',
+        children: [
+          { id: 'docs-generate', label: 'Generate', detail: 'Build the MkDocs documentation site', args: ['docs', 'generate'] },
+          { id: 'docs-diagram', label: 'ER Diagram', detail: 'Build a Mermaid ER diagram', args: ['docs', 'diagram'] },
+        ],
+      },
+      { id: 'explain', label: 'Explain', detail: 'Explain a class or flow (AI)', args: ['explain'], icon: 'lightbulb' },
+      { id: 'compare', label: 'Compare', detail: 'Diff two orgs or org vs local', args: ['compare'], icon: 'diff' },
+    ],
+  },
+  {
+    id: 'data-scratch',
+    label: 'Data & Scratch Orgs',
+    icon: 'database',
+    docsUrl: DOCS.configUtils,
+    entries: [
+      {
+        id: 'data', label: 'Data Sets', detail: 'Manage data sets', icon: 'database',
+        children: [
+          { id: 'data-list', label: 'List', detail: 'List configured data sets', args: ['data', 'list'] },
+          { id: 'data-export', label: 'Export', detail: 'Export a data set from the org', args: ['data', 'export'] },
+          { id: 'data-import', label: 'Import', detail: 'Import a data set into the org', args: ['data', 'import'] },
+          { id: 'data-delete', label: 'Delete', detail: 'Bulk-delete a data set in the org', args: ['data', 'delete'], destructive: true },
+        ],
+      },
+      {
+        id: 'scratch', label: 'Scratch Orgs', detail: 'Scratch-org lifecycle & pool', icon: 'server-environment',
+        children: [
+          { id: 'scratch-create', label: 'Create', detail: 'Create a scratch org', args: ['scratch', 'create'] },
+          { id: 'scratch-list', label: 'List', detail: 'List scratch orgs', args: ['scratch', 'list'] },
+          { id: 'scratch-delete', label: 'Delete', detail: 'Delete a scratch org', args: ['scratch', 'delete'], destructive: true },
+          { id: 'scratch-pool-status', label: 'Pool: Status', detail: 'Show the scratch-org pool', args: ['scratch', 'pool', 'status'] },
+          { id: 'scratch-pool-fill', label: 'Pool: Fill', detail: 'Top up the scratch-org pool', args: ['scratch', 'pool', 'fill'] },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'project-tools',
+    label: 'Project & Tools',
+    icon: 'tools',
+    docsUrl: DOCS.configUtils,
+    entries: [
+      { id: 'init', label: 'Initialize Project', detail: 'Create .sfdt config (sfdt init)', args: ['init'], icon: 'rocket' },
+      { id: 'config', label: 'Show Config', detail: 'Print the resolved configuration', args: ['config'], icon: 'settings-gear' },
+      { id: 'pull', label: 'Pull Metadata', detail: 'Retrieve metadata into the project', args: ['pull'], icon: 'cloud-download' },
+      { id: 'dashboard', label: 'Open Dashboard', detail: 'Open the embedded sfdt dashboard', action: 'dashboard', icon: 'dashboard', docsUrl: 'https://sfdt.dev/cli/dashboard' },
+      { id: 'mcp', label: 'Start MCP Server', detail: 'Start the stdio MCP server', args: ['mcp', 'start'], icon: 'server-process', docsUrl: 'https://sfdt.dev/cli/mcp' },
+      {
+        id: 'extension', label: 'Browser Extension', detail: 'Native messaging host & telemetry', icon: 'extensions',
+        children: [
+          { id: 'extension-status', label: 'Status', detail: 'Show native-host status', args: ['extension', 'status'] },
+          { id: 'extension-stats', label: 'Stats', detail: 'Show extension telemetry', args: ['extension', 'stats'] },
+        ],
+      },
+      { id: 'update', label: 'Check for Updates', detail: 'Check for a newer sfdt CLI', args: ['update'], icon: 'sync' },
+    ],
+  },
 ];
 
-export function findCommand(id: string): CommandEntry | undefined {
-  return COMMAND_CATALOG.find((c) => c.id === id);
+/** All runnable leaf entries (entries without children, plus all children). */
+export function flattenCommands(groups: CommandGroup[] = COMMAND_GROUPS): CommandEntry[] {
+  const out: CommandEntry[] = [];
+  const walk = (entry: CommandEntry) => {
+    if (entry.children && entry.children.length > 0) {
+      entry.children.forEach(walk);
+    } else {
+      out.push(entry);
+    }
+  };
+  groups.forEach((g) => g.entries.forEach(walk));
+  return out;
 }
+
+/** Find any entry (group entry or nested child) by id. */
+export function findCommand(id: string, groups: CommandGroup[] = COMMAND_GROUPS): CommandEntry | undefined {
+  const search = (entry: CommandEntry): CommandEntry | undefined => {
+    if (entry.id === id) return entry;
+    for (const child of entry.children ?? []) {
+      const hit = search(child);
+      if (hit) return hit;
+    }
+    return undefined;
+  };
+  for (const group of groups) {
+    for (const entry of group.entries) {
+      const hit = search(entry);
+      if (hit) return hit;
+    }
+  }
+  return undefined;
+}
+
+/** Resolve the docs URL for an entry, inheriting from its group when unset. */
+export function docsUrlFor(id: string, groups: CommandGroup[] = COMMAND_GROUPS): string | undefined {
+  for (const group of groups) {
+    const inGroup = (entry: CommandEntry): boolean =>
+      entry.id === id || (entry.children ?? []).some(inGroup);
+    if (group.entries.some(inGroup)) {
+      return findCommand(id, groups)?.docsUrl ?? group.docsUrl;
+    }
+  }
+  return undefined;
+}
+
+/** Backward-compatible flat list (used by the palette quick-pick). */
+export const COMMAND_CATALOG: CommandEntry[] = flattenCommands();

--- a/vscode/src/lib/dashboard-url.ts
+++ b/vscode/src/lib/dashboard-url.ts
@@ -1,0 +1,18 @@
+/**
+ * Pure helpers for the embedded dashboard: extract the one-time launch token
+ * from `sfdt ui` stdout, and build a deep-linked, tokened GUI URL. Free of any
+ * `vscode` import so it is unit-testable.
+ */
+
+/** Pull the launch token out of an `sfdt ui` stdout chunk (ANSI-tolerant). */
+export function parseLaunchToken(text: string): string | undefined {
+  const match = text.match(/[?&]token=([A-Za-z0-9_-]+)/);
+  return match ? match[1] : undefined;
+}
+
+/** Build the embedded GUI URL for a page, appending the token when known. */
+export function dashboardPageUrl(port: number, page?: string, token?: string): string {
+  const path = page ? `/${page.replace(/^\/+/, '')}` : '/';
+  const query = token ? `?token=${encodeURIComponent(token)}` : '';
+  return `http://localhost:${port}${path}${query}`;
+}

--- a/vscode/src/lib/io.ts
+++ b/vscode/src/lib/io.ts
@@ -1,6 +1,6 @@
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
-import type { Snapshot } from './snapshots.js';
+import type { Snapshot, ScanSnapshot, DriftSnapshot } from './snapshots.js';
 
 /** Read and parse a JSON file, returning null if it is missing or invalid. */
 export async function readJsonIfExists<T>(filePath: string): Promise<T | null> {
@@ -27,4 +27,16 @@ export async function readSnapshots(
     readJsonIfExists<Snapshot>(path.join(dir, 'monitor-latest.json')),
   ]);
   return { audit, monitor };
+}
+
+/** Read the latest scan + drift snapshots (Org Health's secondary sections). */
+export async function readScanDrift(
+  projectRoot: string,
+): Promise<{ scan: ScanSnapshot | null; drift: DriftSnapshot | null }> {
+  const dir = logsDir(projectRoot);
+  const [scan, drift] = await Promise.all([
+    readJsonIfExists<ScanSnapshot>(path.join(dir, 'scan-latest.json')),
+    readJsonIfExists<DriftSnapshot>(path.join(dir, 'drift-latest.json')),
+  ]);
+  return { scan, drift };
 }

--- a/vscode/src/lib/org-color.ts
+++ b/vscode/src/lib/org-color.ts
@@ -1,0 +1,52 @@
+/**
+ * Pure org-classification + window-tint mapping. Tinting the VS Code window by
+ * org type (prod=red, sandbox=orange, scratch/dev=green) prevents wrong-org
+ * mistakes. The extension applies the returned customizations via
+ * `workbench.colorCustomizations`; this module holds the pure mapping.
+ */
+
+export type OrgType = 'production' | 'sandbox' | 'scratch' | 'developer' | 'other';
+
+export interface OrgFacts {
+  instanceUrl?: string;
+  isSandbox?: boolean;
+  isScratch?: boolean;
+  /** Trial / Developer Edition org. */
+  isDevEdition?: boolean;
+}
+
+/** Classify an org from the facts `sf org display --json` exposes. */
+export function classifyOrg(facts: OrgFacts): OrgType {
+  if (facts.isScratch) return 'scratch';
+  if (facts.isSandbox) return 'sandbox';
+  if (facts.isDevEdition) return 'developer';
+  const url = facts.instanceUrl ?? '';
+  if (/\.sandbox\.|\.cs\d+\.|--/.test(url)) return 'sandbox';
+  if (/\.develop\.|scratch/.test(url)) return 'scratch';
+  if (url) return 'production';
+  return 'other';
+}
+
+const TINT: Record<OrgType, string | null> = {
+  production: '#8b1a1a', // red — be careful
+  sandbox: '#a8580f', // orange
+  scratch: '#1f7a3d', // green
+  developer: '#1f7a3d', // green
+  other: null,
+};
+
+/**
+ * Color customizations to merge into `workbench.colorCustomizations`, or null
+ * when the org type should not be tinted (`other`).
+ */
+export function colorForOrg(type: OrgType): Record<string, string> | null {
+  const base = TINT[type];
+  if (!base) return null;
+  return {
+    'activityBar.background': base,
+    'titleBar.activeBackground': base,
+    'statusBar.background': base,
+    'titleBar.activeForeground': '#ffffff',
+    'statusBar.foreground': '#ffffff',
+  };
+}

--- a/vscode/src/lib/prereqs.ts
+++ b/vscode/src/lib/prereqs.ts
@@ -1,0 +1,33 @@
+/**
+ * Pure prerequisite evaluation for the welcome/onboarding flow. The extension
+ * probes the environment (sf/sfdt on PATH, .sfdt/config.json present) and passes
+ * the booleans here; this module decides what (if anything) is missing and what
+ * the welcome view should offer. Free of any `vscode` import.
+ */
+
+export interface PrereqProbe {
+  hasSf: boolean;
+  hasSfdt: boolean;
+  hasConfig: boolean;
+}
+
+export interface PrereqAction {
+  id: string;
+  label: string;
+}
+
+export interface PrereqState {
+  /** True when everything needed to use the extension is present. */
+  ready: boolean;
+  /** Missing prerequisites, in the order they should be resolved. */
+  missing: PrereqAction[];
+}
+
+export function evaluatePrereqs(probe: PrereqProbe): PrereqState {
+  const missing: PrereqAction[] = [];
+  if (!probe.hasSf) missing.push({ id: 'install-sf', label: 'Install the Salesforce CLI (sf)' });
+  if (!probe.hasSfdt) missing.push({ id: 'install-sfdt', label: 'Install the sfdt CLI' });
+  // Config only matters once the CLI exists.
+  if (probe.hasSfdt && !probe.hasConfig) missing.push({ id: 'init', label: 'Run sfdt init' });
+  return { ready: missing.length === 0, missing };
+}

--- a/vscode/src/lib/snapshots.ts
+++ b/vscode/src/lib/snapshots.ts
@@ -82,15 +82,61 @@ function sectionFromSnapshot(id: string, label: string, snap: Snapshot | null, r
   };
 }
 
+export interface ScanSnapshot {
+  org?: string;
+  summary?: { totalTypes?: number; totalMembers?: number };
+}
+
+export interface DriftSnapshot {
+  org?: string;
+  driftStatus?: string;
+  components?: unknown[];
+}
+
+function scanNode(scan: ScanSnapshot | null): TreeNode {
+  if (!scan) return { id: 'scan', label: 'Metadata Inventory', description: 'not run yet', command: ['scan'] };
+  const s = scan.summary ?? {};
+  const org = scan.org ? ` · ${scan.org}` : '';
+  return {
+    id: 'scan',
+    label: 'Metadata Inventory',
+    description: `${s.totalTypes ?? '?'} types · ${s.totalMembers ?? '?'} members${org}`,
+    status: 'ok',
+    command: ['scan'],
+  };
+}
+
+function driftNode(drift: DriftSnapshot | null): TreeNode {
+  if (!drift) return { id: 'drift', label: 'Drift', description: 'not run yet', command: ['drift'] };
+  const count = Array.isArray(drift.components) ? drift.components.length : 0;
+  const clean = (drift.driftStatus ?? '').toUpperCase() === 'PASS' || count === 0;
+  return {
+    id: 'drift',
+    label: 'Drift',
+    description: clean ? 'in sync' : `${count} drifted component(s)`,
+    status: clean ? 'ok' : 'warn',
+    command: ['drift'],
+  };
+}
+
 /**
- * Build the full Org Health tree from the latest audit and monitor snapshots
- * (either may be null when not yet run).
+ * Build the full Org Health tree from the latest snapshots. `audit`/`monitor`
+ * are always rendered; `scan`/`drift` sections are appended only when those
+ * arguments are supplied (kept optional for back-compat with existing callers).
  */
-export function buildHealthTree(audit: Snapshot | null, monitor: Snapshot | null): TreeNode[] {
-  return [
+export function buildHealthTree(
+  audit: Snapshot | null,
+  monitor: Snapshot | null,
+  scan?: ScanSnapshot | null,
+  drift?: DriftSnapshot | null,
+): TreeNode[] {
+  const nodes: TreeNode[] = [
     sectionFromSnapshot('diagnostics', 'Diagnostics & Audit', audit, ['audit', 'all']),
     sectionFromSnapshot('monitoring', 'Monitoring', monitor, ['monitor', 'all']),
   ];
+  if (scan !== undefined) nodes.push(scanNode(scan));
+  if (drift !== undefined) nodes.push(driftNode(drift));
+  return nodes;
 }
 
 // describeFinding is the canonical renderer from @sfdt/flow-core (imported at

--- a/vscode/src/lib/status.ts
+++ b/vscode/src/lib/status.ts
@@ -1,0 +1,112 @@
+/**
+ * Pure helpers that turn org / git / version / snapshot facts into the Status
+ * view's tree of plain node descriptors. Free of any `vscode` import.
+ */
+
+import { rollupStatus, type CheckStatus, type Snapshot, type TreeNode } from './snapshots.js';
+
+export interface StatusInput {
+  orgAlias?: string;
+  instanceUrl?: string;
+  connected?: boolean;
+  gitBranch?: string;
+  audit: Snapshot | null;
+  monitor: Snapshot | null;
+  sfdtVersion?: string;
+  sfVersion?: string;
+  /** Latest sfdt version known (from `sfdt update`/registry); enables an "update" hint. */
+  latestSfdtVersion?: string;
+}
+
+/** Compare two semver-ish strings; true when `current` is behind `latest`. */
+export function isOutdated(current?: string, latest?: string): boolean {
+  if (!current || !latest) return false;
+  const norm = (v: string) => v.replace(/^v/, '').split('-')[0].split('.').map((n) => parseInt(n, 10) || 0);
+  const a = norm(current);
+  const b = norm(latest);
+  for (let i = 0; i < Math.max(a.length, b.length); i++) {
+    const x = a[i] ?? 0;
+    const y = b[i] ?? 0;
+    if (x < y) return true;
+    if (x > y) return false;
+  }
+  return false;
+}
+
+/** Worst status across the audit + monitor snapshots, or null when neither ran. */
+export function overallHealth(audit: Snapshot | null, monitor: Snapshot | null): CheckStatus | null {
+  const checks = [...(audit?.checks ?? []), ...(monitor?.checks ?? [])];
+  if (checks.length === 0) return null;
+  return rollupStatus(checks);
+}
+
+/** Build the Status view tree. */
+export function buildStatusTree(input: StatusInput): TreeNode[] {
+  const nodes: TreeNode[] = [];
+
+  // ── Org ──
+  const orgChildren: TreeNode[] = [];
+  if (input.instanceUrl) orgChildren.push({ id: 'status.org.url', label: input.instanceUrl });
+  orgChildren.push({
+    id: 'status.org.conn',
+    label: input.connected === false ? 'Not connected' : input.orgAlias ? 'Connected' : 'No default org',
+    status: input.connected === false ? 'fail' : input.orgAlias ? 'ok' : 'warn',
+  });
+  nodes.push({
+    id: 'status.org',
+    label: 'Org',
+    description: input.orgAlias ?? 'click to select…',
+    status: input.orgAlias ? (input.connected === false ? 'fail' : 'ok') : 'warn',
+    command: ['__pickOrg'],
+    children: orgChildren,
+  });
+
+  // ── Git ──
+  nodes.push({
+    id: 'status.git',
+    label: 'Branch',
+    description: input.gitBranch ?? 'no git repo',
+  });
+
+  // ── Health rollup ──
+  const ran = input.audit !== null || input.monitor !== null;
+  const health = overallHealth(input.audit, input.monitor);
+  const issues = ['warn', 'fail', 'error'].reduce((sum, k) => {
+    const key = k as 'warn' | 'fail' | 'error';
+    return sum + (input.audit?.summary[key] ?? 0) + (input.monitor?.summary[key] ?? 0);
+  }, 0);
+  nodes.push({
+    id: 'status.health',
+    label: 'Org Health',
+    description: !ran ? 'not run yet' : issues === 0 ? 'all clear' : `${issues} issue(s)`,
+    status: health ?? undefined,
+    command: ['audit', 'all'],
+  });
+
+  // ── Versions ──
+  const versionChildren: TreeNode[] = [];
+  const outdated = isOutdated(input.sfdtVersion, input.latestSfdtVersion);
+  if (input.sfdtVersion) {
+    versionChildren.push({
+      id: 'status.ver.sfdt',
+      label: `sfdt ${input.sfdtVersion}`,
+      description: outdated ? `update available → ${input.latestSfdtVersion}` : undefined,
+      status: outdated ? 'warn' : 'ok',
+      command: outdated ? ['update'] : undefined,
+    });
+  }
+  if (input.sfVersion) {
+    versionChildren.push({ id: 'status.ver.sf', label: input.sfVersion });
+  }
+  if (versionChildren.length > 0) {
+    nodes.push({
+      id: 'status.versions',
+      label: 'Versions',
+      description: outdated ? 'update available' : undefined,
+      status: outdated ? 'warn' : undefined,
+      children: versionChildren,
+    });
+  }
+
+  return nodes;
+}

--- a/vscode/src/lib/terminal.ts
+++ b/vscode/src/lib/terminal.ts
@@ -1,0 +1,32 @@
+/**
+ * Pure helpers for building the shell command that the extension sends to a VS
+ * Code integrated terminal. Free of any `vscode` import so it can be unit-tested.
+ * The terminal itself (creation, sendText) lives in the extension wiring layer.
+ */
+
+import { buildArgs } from './cli.js';
+
+/** Quote a single argv token for a POSIX-ish shell if it needs it. */
+export function shellQuote(token: string): string {
+  if (token.length > 0 && /^[A-Za-z0-9_./:=@-]+$/.test(token)) return token;
+  // Wrap in single quotes, escaping any embedded single quote.
+  return `'${token.replace(/'/g, `'\\''`)}'`;
+}
+
+export interface TerminalCommandOptions {
+  /** Path to the sfdt binary (defaults to "sfdt" on PATH). */
+  cliPath?: string;
+  /** Org alias appended as `--org <alias>` when set and not already present. */
+  org?: string;
+}
+
+/**
+ * Build the full shell command line for an sfdt invocation, e.g.
+ * `sfdt audit all --org "My Org"`. Reuses buildArgs() so the `--org` rule
+ * matches the output-channel runner exactly.
+ */
+export function buildTerminalCommand(args: string[], options: TerminalCommandOptions = {}): string {
+  const { cliPath = 'sfdt', org } = options;
+  const argv = buildArgs(args, org);
+  return [cliPath, ...argv].map(shellQuote).join(' ');
+}

--- a/vscode/src/statusTree.ts
+++ b/vscode/src/statusTree.ts
@@ -1,0 +1,49 @@
+import * as vscode from 'vscode';
+import { statusIcon, type TreeNode } from './lib/snapshots.js';
+
+/**
+ * Tree data provider for the "Status" view. The node descriptors are produced by
+ * a gatherer the extension supplies (org / git / versions / health), keeping
+ * this layer a thin TreeNode → TreeItem mapper. Nodes whose `command` is set
+ * become clickable (e.g. the org node opens the org picker).
+ */
+export class StatusProvider implements vscode.TreeDataProvider<TreeNode> {
+  private readonly _onDidChange = new vscode.EventEmitter<TreeNode | undefined | void>();
+  readonly onDidChangeTreeData = this._onDidChange.event;
+
+  private roots: TreeNode[] = [];
+
+  constructor(private readonly gather: () => Promise<TreeNode[]>) {}
+
+  async refresh(): Promise<void> {
+    try {
+      this.roots = await this.gather();
+    } catch {
+      this.roots = [];
+    }
+    this._onDidChange.fire();
+  }
+
+  getTreeItem(node: TreeNode): vscode.TreeItem {
+    const collapsible = node.children && node.children.length > 0
+      ? vscode.TreeItemCollapsibleState.Expanded
+      : vscode.TreeItemCollapsibleState.None;
+    const item = new vscode.TreeItem(node.label, collapsible);
+    item.description = node.description;
+    item.id = node.id;
+    if (node.status) item.iconPath = new vscode.ThemeIcon(statusIcon(node.status));
+    if (node.command) {
+      // A special sentinel routes to the org picker; anything else runs as argv.
+      if (node.command[0] === '__pickOrg') {
+        item.command = { command: 'sfdt.pickOrg', title: 'Select Org', arguments: [] };
+      } else {
+        item.command = { command: 'sfdt.runArgs', title: 'Run', arguments: [node.command] };
+      }
+    }
+    return item;
+  }
+
+  getChildren(node?: TreeNode): TreeNode[] {
+    return node ? node.children ?? [] : this.roots;
+  }
+}

--- a/vscode/src/tree.ts
+++ b/vscode/src/tree.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { buildHealthTree, statusIcon, type TreeNode } from './lib/snapshots.js';
-import { readSnapshots } from './lib/io.js';
+import { readSnapshots, readScanDrift } from './lib/io.js';
 
 /**
  * Tree data provider for the "Org Health" view. Reads the latest audit/monitor
@@ -20,8 +20,11 @@ export class OrgHealthProvider implements vscode.TreeDataProvider<TreeNode> {
     if (!root) {
       this.roots = [];
     } else {
-      const { audit, monitor } = await readSnapshots(root);
-      this.roots = buildHealthTree(audit, monitor);
+      const [{ audit, monitor }, { scan, drift }] = await Promise.all([
+        readSnapshots(root),
+        readScanDrift(root),
+      ]);
+      this.roots = buildHealthTree(audit, monitor, scan, drift);
     }
     this._onDidChange.fire();
   }

--- a/vscode/test/commands.test.ts
+++ b/vscode/test/commands.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import {
+  COMMAND_GROUPS,
+  COMMAND_CATALOG,
+  flattenCommands,
+  findCommand,
+  docsUrlFor,
+  type CommandEntry,
+} from '../src/lib/commands.js';
+
+function allEntries(): CommandEntry[] {
+  const out: CommandEntry[] = [];
+  const walk = (e: CommandEntry) => {
+    out.push(e);
+    (e.children ?? []).forEach(walk);
+  };
+  COMMAND_GROUPS.forEach((g) => g.entries.forEach(walk));
+  return out;
+}
+
+describe('COMMAND_GROUPS', () => {
+  it('exposes the six top-level groups', () => {
+    expect(COMMAND_GROUPS.map((g) => g.id)).toEqual([
+      'deploy-release',
+      'org-health',
+      'quality',
+      'documentation',
+      'data-scratch',
+      'project-tools',
+    ]);
+  });
+
+  it('every group has a docsUrl on sfdt.dev and an icon', () => {
+    for (const g of COMMAND_GROUPS) {
+      expect(g.docsUrl).toMatch(/^https:\/\/sfdt\.dev\//);
+      expect(g.icon).toBeTruthy();
+    }
+  });
+
+  it('has unique ids across all entries and children', () => {
+    const ids = allEntries().map((e) => e.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('every runnable leaf has either args or a non-terminal action', () => {
+    for (const leaf of flattenCommands()) {
+      const runnable = (leaf.args && leaf.args.length > 0) || Boolean(leaf.action);
+      expect(runnable, `${leaf.id} must be runnable`).toBe(true);
+    }
+  });
+
+  it('surfaces the full CLI breadth (>= 30 runnable leaves)', () => {
+    expect(flattenCommands().length).toBeGreaterThanOrEqual(30);
+  });
+
+  it('marks org/repo-mutating commands destructive', () => {
+    for (const id of ['deploy', 'rollback', 'backup', 'data-delete', 'scratch-delete']) {
+      expect(findCommand(id)?.destructive, `${id} should be destructive`).toBe(true);
+    }
+  });
+
+  it('flags snapshot-backed commands so the views refresh', () => {
+    expect(findCommand('audit')?.refreshes).toBe('audit');
+    expect(findCommand('monitor-limits')?.refreshes).toBe('monitor');
+    expect(findCommand('scan')?.refreshes).toBe('scan');
+    expect(findCommand('drift')?.refreshes).toBe('drift');
+  });
+});
+
+describe('findCommand', () => {
+  it('finds top-level and nested entries', () => {
+    expect(findCommand('deploy')?.args).toEqual(['deploy']);
+    expect(findCommand('audit-mfa')?.args).toEqual(['audit', 'mfa']);
+    expect(findCommand('scratch-pool-fill')?.args).toEqual(['scratch', 'pool', 'fill']);
+  });
+  it('returns undefined for unknown ids', () => {
+    expect(findCommand('nope')).toBeUndefined();
+  });
+});
+
+describe('docsUrlFor', () => {
+  it('inherits the group docs url when the entry has none', () => {
+    expect(docsUrlFor('audit')).toBe('https://sfdt.dev/cli/commands/org-health');
+  });
+  it('uses an entry-specific docs url when present', () => {
+    expect(docsUrlFor('dashboard')).toBe('https://sfdt.dev/cli/dashboard');
+  });
+});
+
+describe('COMMAND_CATALOG (flattened)', () => {
+  it('equals flattenCommands output', () => {
+    expect(COMMAND_CATALOG).toEqual(flattenCommands());
+  });
+});

--- a/vscode/test/dashboard-url.test.ts
+++ b/vscode/test/dashboard-url.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { parseLaunchToken, dashboardPageUrl } from '../src/lib/dashboard-url.js';
+
+describe('parseLaunchToken', () => {
+  it('extracts the token from an sfdt ui line', () => {
+    expect(parseLaunchToken('Dashboard running at http://localhost:7654?token=abc123_XY-Z')).toBe('abc123_XY-Z');
+  });
+  it('tolerates ANSI color codes and surrounding text', () => {
+    const line = '[32m  Dashboard running at http://localhost:7654?token=TOK3N[39m\n';
+    expect(parseLaunchToken(line)).toBe('TOK3N');
+  });
+  it('returns undefined when there is no token', () => {
+    expect(parseLaunchToken('Press Ctrl+C to stop.')).toBeUndefined();
+  });
+});
+
+describe('dashboardPageUrl', () => {
+  it('builds the root url with a token', () => {
+    expect(dashboardPageUrl(7654, undefined, 'TOK')).toBe('http://localhost:7654/?token=TOK');
+  });
+  it('deep-links to a page with the token', () => {
+    expect(dashboardPageUrl(7654, 'audit', 'TOK')).toBe('http://localhost:7654/audit?token=TOK');
+  });
+  it('normalizes a leading slash on the page', () => {
+    expect(dashboardPageUrl(8080, '/monitor', 'T')).toBe('http://localhost:8080/monitor?token=T');
+  });
+  it('omits the query when no token is known', () => {
+    expect(dashboardPageUrl(7654, 'scan')).toBe('http://localhost:7654/scan');
+  });
+});

--- a/vscode/test/org-color.test.ts
+++ b/vscode/test/org-color.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { classifyOrg, colorForOrg } from '../src/lib/org-color.js';
+
+describe('classifyOrg', () => {
+  it('prioritizes explicit scratch/sandbox flags', () => {
+    expect(classifyOrg({ isScratch: true })).toBe('scratch');
+    expect(classifyOrg({ isSandbox: true })).toBe('sandbox');
+    expect(classifyOrg({ isDevEdition: true })).toBe('developer');
+  });
+  it('treats a plain my.salesforce.com URL as production', () => {
+    expect(classifyOrg({ instanceUrl: 'https://acme.my.salesforce.com' })).toBe('production');
+  });
+  it('detects sandbox-style URLs', () => {
+    expect(classifyOrg({ instanceUrl: 'https://acme--dev.sandbox.my.salesforce.com' })).toBe('sandbox');
+  });
+  it('returns other when nothing is known', () => {
+    expect(classifyOrg({})).toBe('other');
+  });
+});
+
+describe('colorForOrg', () => {
+  it('returns a red-ish tint for production', () => {
+    const c = colorForOrg('production')!;
+    expect(c['activityBar.background']).toBe('#8b1a1a');
+    expect(c['statusBar.background']).toBe('#8b1a1a');
+  });
+  it('returns green for scratch and developer', () => {
+    expect(colorForOrg('scratch')!['activityBar.background']).toBe('#1f7a3d');
+    expect(colorForOrg('developer')!['activityBar.background']).toBe('#1f7a3d');
+  });
+  it('returns null for an unclassified org', () => {
+    expect(colorForOrg('other')).toBeNull();
+  });
+});

--- a/vscode/test/prereqs.test.ts
+++ b/vscode/test/prereqs.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { evaluatePrereqs } from '../src/lib/prereqs.js';
+
+describe('evaluatePrereqs', () => {
+  it('is ready when sf, sfdt, and config are all present', () => {
+    const state = evaluatePrereqs({ hasSf: true, hasSfdt: true, hasConfig: true });
+    expect(state.ready).toBe(true);
+    expect(state.missing).toEqual([]);
+  });
+
+  it('reports missing sf and sfdt first', () => {
+    const state = evaluatePrereqs({ hasSf: false, hasSfdt: false, hasConfig: false });
+    expect(state.ready).toBe(false);
+    expect(state.missing.map((m) => m.id)).toEqual(['install-sf', 'install-sfdt']);
+  });
+
+  it('only prompts for init once sfdt exists', () => {
+    const withoutSfdt = evaluatePrereqs({ hasSf: true, hasSfdt: false, hasConfig: false });
+    expect(withoutSfdt.missing.map((m) => m.id)).not.toContain('init');
+
+    const withSfdt = evaluatePrereqs({ hasSf: true, hasSfdt: true, hasConfig: false });
+    expect(withSfdt.missing.map((m) => m.id)).toEqual(['init']);
+  });
+});

--- a/vscode/test/snapshots.test.ts
+++ b/vscode/test/snapshots.test.ts
@@ -6,7 +6,6 @@ import {
   describeFinding,
   type Snapshot,
 } from '../src/lib/snapshots.js';
-import { COMMAND_CATALOG, findCommand } from '../src/lib/commands.js';
 
 function snap(overrides: Partial<Snapshot> = {}): Snapshot {
   return {
@@ -67,15 +66,5 @@ describe('describeFinding', () => {
   });
   it('renders a limit finding', () => {
     expect(describeFinding({ name: 'DailyApiRequests', used: 95, max: 100 })).toBe('DailyApiRequests: 95/100');
-  });
-});
-
-describe('COMMAND_CATALOG', () => {
-  it('marks deploy as destructive and audit as not', () => {
-    expect(findCommand('deploy')?.destructive).toBe(true);
-    expect(findCommand('audit')?.destructive).toBeFalsy();
-  });
-  it('every entry has args', () => {
-    for (const c of COMMAND_CATALOG) expect(c.args.length).toBeGreaterThan(0);
   });
 });

--- a/vscode/test/status.test.ts
+++ b/vscode/test/status.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { isOutdated, overallHealth, buildStatusTree, type StatusInput } from '../src/lib/status.js';
+import type { Snapshot } from '../src/lib/snapshots.js';
+
+function snap(partial: Partial<Snapshot>): Snapshot {
+  return {
+    timestamp: '2026-06-26T00:00:00Z',
+    org: 'dev',
+    checks: [],
+    summary: { total: 0, ok: 0, warn: 0, fail: 0, error: 0 },
+    ...partial,
+  };
+}
+
+describe('isOutdated', () => {
+  it('detects an older current version', () => {
+    expect(isOutdated('0.14.0', '0.14.1')).toBe(true);
+    expect(isOutdated('0.13.5', '0.14.0')).toBe(true);
+  });
+  it('returns false when current is equal or newer', () => {
+    expect(isOutdated('0.14.1', '0.14.1')).toBe(false);
+    expect(isOutdated('0.15.0', '0.14.1')).toBe(false);
+  });
+  it('ignores a leading v and prerelease suffix', () => {
+    expect(isOutdated('v0.14.0', '0.14.1-beta.1')).toBe(true);
+  });
+  it('returns false when either version is missing', () => {
+    expect(isOutdated(undefined, '0.14.1')).toBe(false);
+    expect(isOutdated('0.14.0', undefined)).toBe(false);
+  });
+});
+
+describe('overallHealth', () => {
+  it('returns null when nothing has run', () => {
+    expect(overallHealth(null, null)).toBeNull();
+  });
+  it('rolls up the worst status across audit + monitor', () => {
+    const audit = snap({ checks: [{ id: 'a', title: 'A', status: 'warn', summary: '', findings: [] }] });
+    const monitor = snap({ checks: [{ id: 'm', title: 'M', status: 'fail', summary: '', findings: [] }] });
+    expect(overallHealth(audit, monitor)).toBe('fail');
+  });
+});
+
+describe('buildStatusTree', () => {
+  const base: StatusInput = { audit: null, monitor: null };
+
+  it('shows an org picker prompt when no org is set', () => {
+    const tree = buildStatusTree(base);
+    const org = tree.find((n) => n.id === 'status.org')!;
+    expect(org.description).toMatch(/select/i);
+    expect(org.command).toEqual(['__pickOrg']);
+    expect(org.status).toBe('warn');
+  });
+
+  it('reflects a connected org', () => {
+    const tree = buildStatusTree({ ...base, orgAlias: 'DevHub', connected: true, instanceUrl: 'https://x.my.salesforce.com' });
+    const org = tree.find((n) => n.id === 'status.org')!;
+    expect(org.description).toBe('DevHub');
+    expect(org.status).toBe('ok');
+    expect(org.children?.some((c) => c.label === 'https://x.my.salesforce.com')).toBe(true);
+  });
+
+  it('surfaces an update hint when the CLI is outdated', () => {
+    const tree = buildStatusTree({ ...base, sfdtVersion: '0.14.0', latestSfdtVersion: '0.14.1' });
+    const versions = tree.find((n) => n.id === 'status.versions')!;
+    expect(versions.status).toBe('warn');
+    const sfdt = (versions.children ?? []).find((c) => c.id === 'status.ver.sfdt');
+    expect(sfdt?.command).toEqual(['update']);
+    expect(sfdt?.description).toMatch(/update available/);
+  });
+
+  it('counts issues from both snapshots in the health node', () => {
+    const audit = snap({ summary: { total: 3, ok: 1, warn: 2, fail: 0, error: 0 } });
+    const monitor = snap({ summary: { total: 2, ok: 1, warn: 0, fail: 1, error: 0 } });
+    const tree = buildStatusTree({ ...base, audit, monitor });
+    const health = tree.find((n) => n.id === 'status.health')!;
+    expect(health.description).toBe('3 issue(s)');
+  });
+});

--- a/vscode/test/terminal.test.ts
+++ b/vscode/test/terminal.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { shellQuote, buildTerminalCommand } from '../src/lib/terminal.js';
+
+describe('shellQuote', () => {
+  it('leaves safe tokens unquoted', () => {
+    expect(shellQuote('audit')).toBe('audit');
+    expect(shellQuote('--org')).toBe('--org');
+    expect(shellQuote('DevHub')).toBe('DevHub');
+    expect(shellQuote('a/b-c.d:e=f')).toBe('a/b-c.d:e=f');
+  });
+  it('quotes tokens with spaces or specials', () => {
+    expect(shellQuote('My Org')).toBe(`'My Org'`);
+    expect(shellQuote('a;b')).toBe(`'a;b'`);
+  });
+  it('escapes embedded single quotes', () => {
+    expect(shellQuote("it's")).toBe(`'it'\\''s'`);
+  });
+  it('quotes the empty string', () => {
+    expect(shellQuote('')).toBe(`''`);
+  });
+});
+
+describe('buildTerminalCommand', () => {
+  it('builds a plain command', () => {
+    expect(buildTerminalCommand(['audit', 'all'])).toBe('sfdt audit all');
+  });
+  it('appends --org when given', () => {
+    expect(buildTerminalCommand(['audit', 'all'], { org: 'dev' })).toBe('sfdt audit all --org dev');
+  });
+  it('quotes an org alias with spaces', () => {
+    expect(buildTerminalCommand(['monitor', 'all'], { org: 'My Org' })).toBe(`sfdt monitor all --org 'My Org'`);
+  });
+  it('honors a custom cli path', () => {
+    expect(buildTerminalCommand(['deploy'], { cliPath: '/usr/local/bin/sfdt' })).toBe('/usr/local/bin/sfdt deploy');
+  });
+  it('does not duplicate an existing --org', () => {
+    expect(buildTerminalCommand(['audit', '--org', 'x'], { org: 'dev' })).toBe('sfdt audit --org x');
+  });
+});


### PR DESCRIPTION
## Summary
Rebuilds the VS Code extension from a single Org Health snapshot viewer into a full **command center** over the sfdt CLI — staying a thin UI (spawn `sfdt`, read the same JSON snapshots, reimplement no logic). Bumps to **v0.2.0**.

### Added
- **Commands view** — grouped tree of the entire CLI surface (30+ commands / 50+ subcommands) across six categories; click to run, nested subcommands.
- **Integrated-terminal execution** — live colored/streaming output, interactive prompts; destructive commands confirm first.
- **Status view** — active org (alias/url/connection), git branch, Org Health rollup, `sfdt`/`sf` versions + update hint; **org picker** from `sf org list`.
- **Welcome/onboarding** when sfdt is missing or the project isn't initialized.
- **Command search** quick-pick, **context menus** (Run / Copy / Open docs), per-command sfdt.dev links.
- **Per-org window theming** (`sfdt.orgColor`); **Org Health** now also shows `scan`/`drift`; all views auto-refresh on `logs/*-latest.json` changes.

### Fixed
- Embedded dashboard **401** — captures the `sfdt ui` launch token and passes it to the webview (and supports deep-linking).

## Architecture
Pure logic in `vscode/src/lib/*` (vscode-free) with **63 vitest tests**; the `vscode`-importing tree/provider/extension layers stay thin, per CLAUDE.md.

## Verification
- `npm run test:vscode` (63 pass), `lint -w vscode`, `tsc --noEmit`, `build:vscode` — all green.
- `activate()` smoke-tested under a stubbed `vscode` (registers 25 disposables cleanly).
- Packaged + installed `sfdt-devtools-0.2.0.vsix`; verified the three views in VS Code.

## Routing
Merging to **develop**, then a develop→main PR triggers `vscode-release.yml` (Marketplace + Open VSX).

https://claude.ai/code/session_01YFBeAD33fANRyNKjjvkjp5