### PR TITLE
fix(deploy): stop deploy/ + deployed/ artifacts clogging the deploy picker & Release Hub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Preflight safety flags are now editable from the GUI Settings page.** `deployment.preflight.*` was previously API-locked (read-only in the dashboard, 403 on write); it's now writable via `PATCH /api/config` with an inline safety caution instead of a hard lock. `defaultOrg`, `plugins`, and `mcp.salesforce.*` remain locked.
+
+### Fixed
+
+- **Deploy picker & Release Hub no longer list `manifest/release/deploy/` and `deployed/` artifacts.** Under `manifestLayout: "subpath"`, the manifest scan swept every `rl-*-package.xml` one level deep into the picker, ballooning it past the expected choices; because the CLI captured results in an unquoted array, a project path containing a space also word-split the list and broke `select`. Both the CLI (`deployment-assistant.sh`) and the GUI (`/api/manifests`) now exclude the `deploy/` and `deployed/` subfolders, and the CLI reads results newline-delimited. Rollbacks are unaffected (the post-deploy flow and Rollback step read `deployed/` on their own).
+
 ## [0.15.0] - 2026-06-29
 
 A large feature release completing the sfdx-hardis parity effort: a multi-channel notifier, smart delta deployments with an optional coding-agent auto-fix loop, CI/CD pipeline templates, PR decoration and cross-org retrofit, two new analysis commands, and a brand-new Salesforce CLI plugin — all sharing one org-health rulebook in `@sfdt/flow-core`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,9 @@ Dockerfile      Official Docker image definition
 | `SFDT_PREFLIGHT_ENFORCE_GIT_CLEAN` | `"true"` (default) unless `config.deployment.preflight.enforceGitClean` is `false`; gates git-clean check |
 | `SFDT_PREFLIGHT_ENFORCE_SFDX_PROJECT` | `"true"` (default) unless `config.deployment.preflight.enforceSfdxProject` is `false`; gates sfdx-project.json check |
 | `SFDT_PREFLIGHT_ENFORCE_UNTRACKED` | `"true"` when `config.deployment.preflight.enforceUntrackedFiles` is set; gates untracked-files check in force-app/ |
-| `SFDT_PREFLIGHT_STRICT` | `"true"` when `config.deployment.preflight.strict` is set; promotes all WARNs to FAILs |
+| `SFDT_PREFLIGHT_STRICT` | `"true"` when `config.deployment.preflight.strict` is set; promotes all WARNs to FAILs (**overrides the per-check flags** — a check left as a WARN by `enforceX: false` is still promoted to a failure under strict) |
+
+> Note: for the opt-in enforce flags (`enforceTests`, `enforceBranchNaming`, `enforceChangelog`, `enforceUntrackedFiles`), "is set" means **truthy** — `false` is indistinguishable from omitting the key, and both leave the check as a non-fatal WARN (they never actively suppress it). Only `enforceGitClean`/`enforceSfdxProject` are default-on (`!== false`). All preflight flags are editable from the GUI Settings page (an inline caution is shown; they are no longer API-locked).
 | `SFDT_FEATURE_*` | Flattened from `config.features` |
 | `SFDT_DEFAULT_ENV` | `config.environments.default` |
 | `SFDT_ENV_ORGS` | Comma-joined org aliases from `config.environments.orgs` |

--- a/gui/src/pages/Settings.jsx
+++ b/gui/src/pages/Settings.jsx
@@ -64,7 +64,7 @@ function getNestedValue(obj, key) {
 // are rejected by PATCH /api/config (org hijack / disabling safety checks /
 // code execution), so we render them read-only with a reason instead of letting
 // a save fail with an opaque error.
-const PROTECTED_PREFIXES = ['defaultOrg', 'deployment.preflight', 'plugins', 'mcp.salesforce.command', 'mcp.salesforce.args'];
+const PROTECTED_PREFIXES = ['defaultOrg', 'plugins', 'mcp.salesforce.command', 'mcp.salesforce.args'];
 
 function isProtectedKey(dotKey) {
   return PROTECTED_PREFIXES.some((p) => dotKey === p || dotKey.startsWith(`${p}.`));
@@ -72,8 +72,13 @@ function isProtectedKey(dotKey) {
 
 function protectedReason(dotKey) {
   if (dotKey === 'defaultOrg') return 'Set via the org switcher or “sfdt init” — the dashboard can’t change the target org.';
-  if (dotKey.startsWith('deployment.preflight')) return 'Safety check — edit in .sfdt/config.json, not from the dashboard.';
   return 'Protected — edit in .sfdt/config.json.';
+}
+
+// Preflight flags are editable but gate deploy safety, so warn (don't lock).
+function cautionReason(dotKey) {
+  if (dotKey.startsWith('deployment.preflight')) return 'Safety check — disabling this reduces deploy safety.';
+  return null;
 }
 
 function FieldRow({ dotKey, label, type, options, rawConfig, onSave }) {
@@ -177,6 +182,9 @@ function FieldRow({ dotKey, label, type, options, rawConfig, onSave }) {
       </div>
       {locked && (
         <div style={{ fontSize: 11, color: 'var(--fg-muted)', marginTop: 4 }}>{protectedReason(dotKey)}</div>
+      )}
+      {!locked && cautionReason(dotKey) && (
+        <div style={{ fontSize: 11, color: 'var(--fg-muted)', marginTop: 4 }}>⚠ {cautionReason(dotKey)}</div>
       )}
       {errMsg && !locked && (
         <div style={{ fontSize: 11, color: 'var(--status-conflict-fg, #c0392b)', marginTop: 4 }}>{errMsg}</div>

--- a/scripts/core/deployment-assistant.sh
+++ b/scripts/core/deployment-assistant.sh
@@ -175,17 +175,28 @@ select_manifest() {
     local include_deployed=${1:-false}
     print_step "Finding release manifests in ${MANIFEST_BASE_DIR}/..."
 
-    # Find manifests in main release folder
+    # Find manifests in main release folder. In subpath layout we descend one
+    # level into package subdirs, but must NOT sweep in the deploy/ (in-flight
+    # artifacts) or deployed/ (post-deploy snapshots — reached via the post-deploy
+    # flow below and the rollback command) subfolders, or the picker balloons and
+    # its numbered choices become unusable. Read newline-delimited so paths that
+    # contain spaces (e.g. a project root with a space) don't word-split the array.
     local max_depth=1
     if [[ "${SFDT_MANIFEST_LAYOUT:-flat}" == "subpath" ]]; then max_depth=2; fi
-    local manifests=( $(find "${MANIFEST_BASE_DIR}/" -maxdepth "$max_depth" -name "rl-*-package.xml" 2>/dev/null | sort -V) )
+    local manifests=()
+    while IFS= read -r m; do
+        [[ -n "$m" ]] && manifests+=("$m")
+    done < <(find "${MANIFEST_BASE_DIR}/" -maxdepth "$max_depth" -name "rl-*-package.xml" \
+        -not -path '*/deploy/*' -not -path '*/deployed/*' 2>/dev/null | sort -V)
 
     # Also include deployed manifests when called from post-deployment flow (last 3 only)
     if [ "$include_deployed" == "true" ] && [ ${#manifests[@]} -eq 0 ]; then
         print_warning "No undeployed manifests found. Showing recent deployed manifests..."
         local fallback_depth=1
         if [[ "${SFDT_MANIFEST_LAYOUT:-flat}" == "subpath" ]]; then fallback_depth=2; fi
-        manifests=( $(find "${MANIFEST_BASE_DIR}/deployed/" -maxdepth $fallback_depth -name "*.xml" 2>/dev/null | sort -V | tail -3) )
+        while IFS= read -r m; do
+            [[ -n "$m" ]] && manifests+=("$m")
+        done < <(find "${MANIFEST_BASE_DIR}/deployed/" -maxdepth "$fallback_depth" -name "*.xml" 2>/dev/null | sort -V | tail -3)
     fi
 
     if [ ${#manifests[@]} -eq 0 ]; then
@@ -1387,10 +1398,14 @@ if [[ "${SFDT_NON_INTERACTIVE:-}" == "true" ]]; then
     if [[ -z "$MANIFEST_PATH" ]]; then
         _auto_max_depth=1
         if [[ "${SFDT_MANIFEST_LAYOUT:-flat}" == "subpath" ]]; then _auto_max_depth=2; fi
-        MANIFEST_PATH=$(find "${MANIFEST_BASE_DIR}/" -maxdepth "$_auto_max_depth" -name "rl-*-package.xml" 2>/dev/null | sort -V | tail -1)
+        # Exclude deploy/ (in-flight) and deployed/ (already-deployed snapshots) so
+        # auto-select picks an active release manifest, not a stale artifact.
+        MANIFEST_PATH=$(find "${MANIFEST_BASE_DIR}/" -maxdepth "$_auto_max_depth" -name "rl-*-package.xml" \
+            -not -path '*/deploy/*' -not -path '*/deployed/*' 2>/dev/null | sort -V | tail -1)
         # Fall back to any package.xml if no versioned manifest found
         if [[ -z "$MANIFEST_PATH" ]]; then
-            MANIFEST_PATH=$(find "${MANIFEST_BASE_DIR}/" -maxdepth "$_auto_max_depth" -name "package.xml" 2>/dev/null | head -1)
+            MANIFEST_PATH=$(find "${MANIFEST_BASE_DIR}/" -maxdepth "$_auto_max_depth" -name "package.xml" \
+                -not -path '*/deploy/*' -not -path '*/deployed/*' 2>/dev/null | head -1)
         fi
         if [[ -z "$MANIFEST_PATH" ]]; then
             print_error "No manifests found in ${MANIFEST_BASE_DIR}/ and SFDT_MANIFEST_PATH not set"

--- a/src/lib/gui-server/index.js
+++ b/src/lib/gui-server/index.js
@@ -192,15 +192,15 @@ export function createGuiApp(config, version, port = 7654) {
     }
   });
 
-  // Keys that must not be API-writable. Three categories:
+  // Keys that must not be API-writable. Two categories:
   //   - Shell-command keys whose values would execute as commands.
   //   - `defaultOrg`: flows into `--target-org` for every sf invocation; the
   //     dashboard's intended path is POST /api/session/org which validates the
   //     alias against a strict regex. PATCH-ing it directly would let a write
   //     coerce sf to point at an attacker-controlled org.
-  //   - `deployment.preflight.*`: silently flipping enforcement flags off
-  //     (e.g. enforceGitClean) would let a subsequent deploy bypass the
-  //     safety check that the operator deliberately enabled.
+  //
+  // Note: `deployment.preflight.*` is intentionally NOT blocked — those safety
+  // flags are editable from the Settings page, which renders an inline caution.
   //
   // The match check below is `key === prefix || key.startsWith(`${prefix}.`)`
   // — exact match OR a dot-bounded prefix. That means:
@@ -208,13 +208,10 @@ export function createGuiApp(config, version, port = 7654) {
   //     shape — defaultOrg is a string, not a nested object).
   //   - `defaultOrgFoo` is NOT blocked (different key entirely; the dot
   //     boundary prevents over-broad matching).
-  //   - `deployment.preflight` blocks every nested enforcement flag like
-  //     `deployment.preflight.enforceGitClean` and `deployment.preflight.strict`.
   const BLOCKED_CONFIG_KEY_PREFIXES = [
     'mcp.salesforce.command',
     'mcp.salesforce.args',
     'defaultOrg',
-    'deployment.preflight',
     // `plugins` entries are dynamically import()ed at CLI startup, so allowing
     // the API to set them would be an arbitrary-code-execution path.
     'plugins',
@@ -1579,7 +1576,6 @@ export function createGuiApp(config, version, port = 7654) {
       const projectRoot = config._projectRoot ?? process.cwd();
       const relManifestDir = config.manifestDir ?? 'manifest/release';
       const manifestReleaseDir = path.join(projectRoot, relManifestDir);
-      const deployedDir = path.join(manifestReleaseDir, 'deployed');
       const manifests = [];
 
       const logFiles = await safeReaddir(logDir);
@@ -1603,7 +1599,9 @@ export function createGuiApp(config, version, port = 7654) {
         for (const subdir of subdirs) {
           const subdirPath = path.join(manifestReleaseDir, subdir);
           const subdirStat = await fs.stat(subdirPath).catch(() => null);
-          if (!subdirStat?.isDirectory() || subdir === 'deployed') continue;
+          // Skip deploy/ (in-flight artifacts) and deployed/ (post-deploy
+          // snapshots — surfaced via the Rollback step, not the manifest list).
+          if (!subdirStat?.isDirectory() || subdir === 'deployed' || subdir === 'deploy') continue;
           const subdirFiles = await safeReaddir(subdirPath);
           for (const file of subdirFiles.filter((f) => f.endsWith('.xml')).sort().reverse()) {
             const filePath = path.join(subdirPath, file);
@@ -1613,13 +1611,8 @@ export function createGuiApp(config, version, port = 7654) {
         }
       }
 
-      // Scan deployed manifests
-      const deployedFiles = await safeReaddir(deployedDir);
-      for (const file of deployedFiles.filter((f) => f.endsWith('.xml')).sort().reverse()) {
-        const filePath = path.join(deployedDir, file);
-        const stat = await fs.stat(filePath).catch(() => null);
-        if (stat) manifests.push({ name: file, source: 'deployed', date: stat.mtime.toISOString(), size: stat.size, relPath: `${relManifestDir}/deployed/${file}` });
-      }
+      // deployed/ snapshots are intentionally omitted here — they are surfaced
+      // through the Rollback step (log-based deployHistory), not the deploy list.
 
       res.json({ manifests });
     } catch (err) {

--- a/test/lib/gui-server-routes.test.js
+++ b/test/lib/gui-server-routes.test.js
@@ -1137,12 +1137,17 @@ describe('PATCH /api/config — success path', () => {
     expect(res.status).toBe(403);
   });
 
-  it('returns 403 when key targets a deployment.preflight.* enforcement flag', async () => {
+  it('allows writing a deployment.preflight.* enforcement flag (editable, not locked)', async () => {
+    const { default: fsMock } = await import('fs-extra');
+    fsMock.readJson.mockResolvedValueOnce({ deployment: { preflight: { enforceGitClean: true } } });
+
     const res = await request(app)
       .patch('/api/config')
       .set('X-SFDT-CSRF', csrf)
       .send({ key: 'deployment.preflight.enforceGitClean', value: 'false' });
-    expect(res.status).toBe(403);
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.key).toBe('deployment.preflight.enforceGitClean');
   });
 });
 

--- a/test/lib/gui-server-routes3.test.js
+++ b/test/lib/gui-server-routes3.test.js
@@ -426,11 +426,10 @@ describe('GET /api/manifests with files present', () => {
 
   it('returns manifests list when XML files are present', async () => {
     const { default: fsMock } = await import('fs-extra');
-    // logDir readdir: no compare files
+    // flat layout → readdir called twice: logDir (compare files), then release dir
     fsMock.readdir
       .mockResolvedValueOnce([]) // log files
-      .mockResolvedValueOnce(['rl-1.0.0-package.xml', 'rl-0.9.0-package.xml']) // release manifests
-      .mockResolvedValueOnce([]); // deployed
+      .mockResolvedValueOnce(['rl-1.0.0-package.xml', 'rl-0.9.0-package.xml']); // release manifests
 
     fsMock.stat.mockResolvedValue({ mtime: new Date('2026-05-01'), size: 1024, isDirectory: () => false });
 
@@ -439,6 +438,38 @@ describe('GET /api/manifests with files present', () => {
     expect(Array.isArray(res.body.manifests)).toBe(true);
     expect(res.body.manifests.length).toBeGreaterThan(0);
     expect(res.body.manifests[0].name).toBe('rl-1.0.0-package.xml');
+  });
+});
+
+// ─── GET /api/manifests — subpath layout excludes deploy/ and deployed/ ───────
+
+describe('GET /api/manifests — subpath excludes deploy/ and deployed/', () => {
+  let app;
+
+  beforeAll(() => {
+    app = createGuiApp({ ...MOCK_CONFIG, manifestLayout: 'subpath' }, VERSION, PORT);
+  });
+
+  afterAll(async () => {
+    await app.cleanup?.();
+  });
+
+  it('lists only real package subdirs, not deploy/ or deployed/ artifacts', async () => {
+    const { default: fsMock } = await import('fs-extra');
+    fsMock.readdir
+      .mockResolvedValueOnce([]) // logDir compare files
+      .mockResolvedValueOnce([]) // release dir top-level xml
+      .mockResolvedValueOnce(['all', 'deploy', 'deployed']) // subdirs
+      .mockResolvedValueOnce(['rl-1.0.0-package.xml']); // files inside 'all' (deploy/deployed skipped, never read)
+
+    // Every stat resolves as a directory; file entries just use mtime/size.
+    fsMock.stat.mockResolvedValue({ mtime: new Date('2026-05-01'), size: 1024, isDirectory: () => true });
+
+    const res = await request(app).get('/api/manifests');
+    expect(res.status).toBe(200);
+    const names = res.body.manifests.map((m) => m.name);
+    expect(names).toEqual(['all/rl-1.0.0-package.xml']);
+    expect(names.some((n) => n.startsWith('deploy/') || n.startsWith('deployed/'))).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Why

A user with `manifestLayout: "subpath"` reported the `sfdt deploy` menu filling up with unexpected entries until it "stops working." Root cause: the subpath manifest scan swept **every** `rl-*-package.xml` one level under `manifest/release/` into the deploy picker — including in-flight `manifest/release/deploy/*` and post-deploy `manifest/release/deployed/*` snapshots.

Two compounding failures:
1. The list ballooned well past the expected ~6 choices.
2. The CLI results were captured in an **unquoted array**, so a project path containing a space word-split the array and broke `select` (the "stops working" symptom).

Their preflight config (`strict: false`, `enforceBranchNaming: false`) was **never** the cause — that check only ever WARNs and exits 0. But they also wanted the UI-locked preflight flags made editable, which is included here.

## Changes

**Deploy picker leak + breakage**
- `scripts/core/deployment-assistant.sh`: exclude `*/deploy/*` and `*/deployed/*` from the picker and auto-detect globs; read newline-delimited so a space in the project path no longer breaks `select`. The `include_deployed` fallback (only reached by the "Post-Deployment Tasks Only" flow, which legitimately needs `deployed/`) is preserved — just its word-splitting is fixed.
- `src/lib/gui-server/index.js` (`GET /api/manifests`): skip `deploy/` as well as `deployed/` in the subpath scan and drop the separate `deployed/` scan block. Rollbacks are unaffected (they come from the log-based Rollback step, not this list).

**Preflight settings editable in the UI**
- Removed `deployment.preflight` from the API deny-list and the client `PROTECTED_PREFIXES`. Fields now save via `PATCH /api/config` with an inline `⚠ Safety check — disabling this reduces deploy safety.` caution instead of a hard lock. `defaultOrg`, `plugins`, `mcp.salesforce.*` stay locked.

**Docs**
- `CLAUDE.md`: clarified that `strict` overrides per-check flags, that `false` == unset for opt-in preflight flags, and that these are now UI-editable.

## Testing
- `npm run lint` clean; **2999/2999 tests pass**. Flipped the preflight-block route test to assert it's now writable; added a subpath `deploy/`+`deployed/` exclusion test.
- `bash -n` clean; sandbox check confirmed both folders excluded and space-in-path handled (only active manifests returned).
- `npm run build:gui` rebuilt `dist/`.

## Follow-up
- Mirror "preflight editable in dashboard" + strict semantics to `sfdt-site` (separate repo).