### PR TITLE
ci: make Homebrew tap-bump step non-blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,7 +272,11 @@ jobs:
         # (scoobydrew83/homebrew-sfdt). The default GITHUB_TOKEN can't write to
         # another repo, so this needs a fine-grained PAT (contents:write on the
         # tap) stored as HOMEBREW_TAP_TOKEN. Skips cleanly if the secret is unset.
+        # continue-on-error: a cosmetic tap bump must never fail the release job
+        # (npm/GHCR already published by this point) or block the downstream
+        # `docker` job — a bad/expired PAT surfaces as a yellow step, not a red run.
         if: steps.version.outputs.changed == 'true'
+        continue-on-error: true
         env:
           TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           VERSION: ${{ steps.version.outputs.version }}


### PR DESCRIPTION
## Why

Verifying the newly-added `HOMEBREW_TAP_TOKEN` secret surfaced a real failure mode: the "Bump Homebrew tap" step runs with `bash -e`, so if the PAT is wrong or expired, the `git push` to the tap fails → the whole `publish` job fails → the downstream `docker` job (`needs: publish`) is **skipped**.

By that point npm + GHCR are already published, so a cosmetic tap bump failing must not redden the release or block the Docker autobuild.

## Change

Add `continue-on-error: true` to the tap-bump step. A credential problem now surfaces as a **yellow step** (tap stays stale until the PAT is fixed) instead of a red run that blocks Docker.

## Notes
- No behavior change when the token is valid (or absent — it still skips cleanly).
- First real exercise is the next release (0.15.2); worst case is now a harmless warning.