### PR TITLE
Sprint 2: VS Code uplift — native results, diagnostics, smart-deploy preview, onboarding

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -35,7 +35,12 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          claude_args: "--allowedTools 'mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr list:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*),Bash(gh api:*),Bash(git diff:*),Bash(git log:*),Read,Glob,Grep'"
+          # Broad `gh pr:*` / comment-tool coverage on purpose: the code-review
+          # plugin is installed unpinned from the marketplace on every run, and
+          # a narrower list drifted out from under it — the reviewer ran but all
+          # posting calls were permission-denied (50 denials, "No buffered
+          # inline comments"), so reviews silently stopped appearing on PRs.
+          claude_args: "--allowedTools 'mcp__github_inline_comment__create_inline_comment,mcp__github_comment__update_claude_comment,Bash(gh pr:*),Bash(gh issue:*),Bash(gh search:*),Bash(gh api:*),Bash(git diff:*),Bash(git log:*),Read,Glob,Grep'"
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: |

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -35,12 +35,16 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          # Broad `gh pr:*` / comment-tool coverage on purpose: the code-review
-          # plugin is installed unpinned from the marketplace on every run, and
-          # a narrower list drifted out from under it — the reviewer ran but all
-          # posting calls were permission-denied (50 denials, "No buffered
-          # inline comments"), so reviews silently stopped appearing on PRs.
-          claude_args: "--allowedTools 'mcp__github_inline_comment__create_inline_comment,mcp__github_comment__update_claude_comment,Bash(gh pr:*),Bash(gh issue:*),Bash(gh search:*),Bash(gh api:*),Bash(git diff:*),Bash(git log:*),Read,Glob,Grep'"
+          # The code-review plugin is installed unpinned from the marketplace on
+          # every run, and its posting path once drifted out from under this
+          # allowlist (the reviewer ran but every posting call was
+          # permission-denied — 50 denials, "No buffered inline comments" — so
+          # reviews silently stopped appearing while the job reported success).
+          # Keep BOTH comment MCP tools listed, and if reviews go silent again,
+          # rerun once with `show_full_output: true` to see what's being denied.
+          # Deliberately least-privilege: enumerated read/comment subcommands,
+          # not `gh pr:*` (which would also grant merge/close/edit).
+          claude_args: "--allowedTools 'mcp__github_inline_comment__create_inline_comment,mcp__github_comment__update_claude_comment,Bash(gh pr comment:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr list:*),Bash(gh pr checks:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*),Bash(gh api:*),Bash(git diff:*),Bash(git log:*),Read,Glob,Grep'"
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -72,15 +72,13 @@
 
 ## Next Session
 
-Full detail for every item lives in [docs/plans/2026-07-03-gap-remediation-and-release-research.md](docs/plans/2026-07-03-gap-remediation-and-release-research.md). Priority queue:
+Live status + full queue: [docs/plans/2026-07-03-gap-remediation-and-release-research.md](docs/plans/2026-07-03-gap-remediation-and-release-research.md) (see its **Status** section). Snapshot as of 2026-07-04:
 
-- **Fix `sfdt smoke` config wiring** — `smoke.sh` reads a config filename that doesn't exist (`.sfdt/sfdt.config.json`) and `smoke.js` never sets `SFDT_SMOKE_TESTS`; configured smoke tests currently never run (plan 1.1)
-- **Deploy flags for tag / PR / notify** — `SFDT_TAG_RELEASE`/`SFDT_CREATE_PR`/`SFDT_NOTIFY_SLACK` are honoured by the deploy script but only settable from the GUI; add `--tag`/`--create-pr`/`--notify` to `sfdt deploy` (plan 1.3)
-- **Make `docs.roleGuides` / `docs.ai` / `docs.diagrams` config keys real** — today only CLI flags enable those features; config values are dead or can only disable (plan 1.4)
-- **Label the code-analyzer stub result as skipped** so a missing scanner can't read as a passing scan (plan 1.5)
-- **sf CLI credential-redaction sweep** — since sf CLI 2.136.8, tokens are redacted from `sf org display --json`; migrate any scraping to `sf org auth show-access-token` (plan 4.2)
+- ✅ **Sprint 1 shipped** (PR #171 → develop): smoke config wiring, deploy `--tag/--create-pr/--notify`, live `docs.*` config keys, skipped-scan labelling, Google Chat channel, credential-redaction sweep, formatter/middleware tests.
+- ✅ **Sprint 2 complete on the working branch** (PR pending): VS Code native results, Problems-pane diagnostics, Smart Deploy preview/execute + Quick Deploy, onboarding walkthrough, catalog completeness.
+- **Up next:** PR sprint 2 → develop; VS Code test/coverage integration (plan 3.4); then Sprint 3 (API v67 readiness check, MFA/deprecation/limits/release-channel checks, RunRelevantTests follow-through, GUI run-from-dashboard).
 - **Fix the always-failing `integration` CI job** — it red-X's every release PR (DevHub org-auth; no org secrets in PR context). Wire the auth, restrict to non-PR runs, or mark non-required.
-- ~~**Automate the Homebrew tap bump**~~ — ✅ Done (PR #167); activates once `HOMEBREW_TAP_TOKEN` is added. The in-repo `Formula/sfdt.rb` mirror is redundant and slated for removal.
+- **sfdt-site docs pass** covering both sprints (needs the `scoobydrew83/sfdt-site` repo added to the session).
 
 ---
 

--- a/docs/plans/2026-07-03-gap-remediation-and-release-research.md
+++ b/docs/plans/2026-07-03-gap-remediation-and-release-research.md
@@ -6,9 +6,27 @@ Each item lists: what's wrong / what's new, the fix approach, files to touch, an
 
 ---
 
+## Status — updated 2026-07-04 (read this first, next session)
+
+**Sprint 1 — SHIPPED.** Merged to `develop` via [PR #171](https://github.com/scoobydrew83/sfdt/pull/171): items 1.1–1.7, 2.5, 4.2, 4.8, plus the `docs.*` config keys and all adversarial-review follow-ups (deploy-flag semantics in both interactive/CI modes, env-over-config precedence for the new tunables, SKIPPED quality snapshots, CI-template auth-URL guidance).
+
+**Sprint 2 — COMPLETE on branch `claude/salesforce-release-features-snsp3t`** (restarted from the merged `develop`; not yet PR'd): items 3.1, 3.2, 3.3, 3.5. The VS Code extension now has native `--json` result capture + rendering (SFDT Results output channel, tree refresh, terminal fallback), Problems-pane diagnostics from the quality snapshot, Smart Deploy validate-and-review with modal production-aware confirmation, Quick Deploy via `sf project deploy quick`, a Get Started walkthrough, catalog completeness (`ci init`, `feature-flags`, `config get/set`, `notify <event>`, `pr-description`, `ai prompt`), no-`--org` command handling, Windows `.cmd` spawn support, process-group kill on timeout, and focus-triggered prereq/context refresh. vscode CHANGELOG has the Unreleased entries.
+
+**Next session queue, in order:**
+1. **PR the sprint-2 branch to `develop`** (all verification green: vscode compile/198 tests/lint/esbuild; root suite 3239 tests).
+2. **3.4 VS Code test & coverage integration** — the one remaining Part-3 item (test-run tree + gutter coverage from snapshots; builds on run-json.ts/render-summary.ts).
+3. **Sprint 3 (release-driven, parallelizable):** 4.1 API v67 readiness check, 4.7a–e new audit/monitor checks (MFA, SOAP login retirement, Connected-Apps migration, elastic async limits, release channels), 4.3 RunRelevantTests follow-through, 2.1 GUI run-from-dashboard.
+4. Then Sprint 4/5 per the appendix.
+
+**Outstanding cross-repo work:** the sfdt-site (sfdt.dev) docs pass covering BOTH sprints — manifest any-`.xml` detection, deploy `--tag/--create-pr/--notify`, Google Chat channel, `docs.*` config semantics + `--no-ai`/`--no-diagrams`, `smokeTests.testClasses`, and the entire VS Code extension page (native results, diagnostics, smart-deploy/quick-deploy, walkthrough). Requires adding the `scoobydrew83/sfdt-site` repo to the session.
+
+**Working conventions that produced good results (keep):** parallel agents only on disjoint file sets (pre-commit shared template/schema keys first); sequential stages for the VS Code extension (`extension.ts`/`package.json` are hubs); every stage implement → compile/test/lint/build loop → adversarial reviewer → bounded fix round; orchestrator owns CHANGELOG/CLAUDE.md/ROADMAP and the final full-suite run; one commit per work item.
+
+---
+
 ## Part 1 — Bugs & broken promises (P0)
 
-### 1.1 `sfdt smoke` can never load configured smoke tests — **S**
+### 1.1 `sfdt smoke` can never load configured smoke tests — **S** — **DONE (PR #171)**
 `scripts/ops/smoke.sh:61,64,139,141` reads `${CONFIG_DIR}/sfdt.config.json`, but the per-project config file is `.sfdt/config.json` (`src/lib/config.js:15`). The keys it queries (`smokeTests.testClasses`, `deployment.keyClasses`) are also missing from the config template and schema, and `src/commands/smoke.js` never sets `SFDT_SMOKE_TESTS` from config. In CI the script silently exits 0 ("skipping smoke tests").
 
 **Fix:**
@@ -20,24 +38,24 @@ Each item lists: what's wrong / what's new, the fix approach, files to touch, an
 ### 1.2 Deploy manifest detection limited to `rl-*-package.xml` — **DONE (this branch)**
 `deployment-assistant.sh` now detects any `.xml` manifest (excluding `*-destructiveChanges.xml`, `*no-overwrite*.xml`, `deploy/`, `deployed/`); `rl-*` manifests keep first position and auto-select preference. Follow-up: mirror in the sfdt-site docs.
 
-### 1.3 CLI deploy can't tag / create PR / notify — **S**
+### 1.3 CLI deploy can't tag / create PR / notify — **S** — **DONE (PR #171)**
 `deployment-assistant.sh` honours `SFDT_TAG_RELEASE`, `SFDT_CREATE_PR`, `SFDT_NOTIFY_SLACK`, but only the GUI sets them (`src/lib/gui-server/index.js:1845-1847`).
 
 **Fix:** add `--tag`, `--create-pr`, `--notify` flags to `src/commands/deploy.js` (interactive path) that set those env vars; document in USAGE.md; tests.
 
-### 1.4 `docs.*` config keys dead or misleading — **S**
+### 1.4 `docs.*` config keys dead or misleading — **S** — **DONE (PR #171)**
 - `docs.roleGuides` (template + schema) is read by nothing — `resolveRoleOption` in `src/commands/docs.js` only honours the `--roles` flag.
 - `docs.ai` defaults to `true` in the template but can only *disable* AI (the `--ai` flag is still required to enable).
 - `docs.diagrams` unread by `docs generate`.
 
 **Fix:** make `docs generate` fall back to config: role guides on when `docs.roleGuides` is truthy (using `docs.roles` list), AI overview on when `features.ai && docs.ai` (add `--no-ai` to override), and honour `docs.diagrams` by running the ER-diagram step during `generate`. Tests for each gate.
 
-### 1.5 `code-analyzer.sh` fabricates a stub result when no scanner installed — **S**
+### 1.5 `code-analyzer.sh` fabricates a stub result when no scanner installed — **S** — **DONE (PR #171)**
 `scripts/quality/code-analyzer.sh:150` emits a stub that can read as a passing scan.
 
 **Fix:** label the stub result unmistakably (`status: "skipped", reason: "sf code-analyzer not installed"`) in output and snapshot; make `sfdt quality` print an actionable warning. (Supersedes itself if item 4.6 Code Analyzer v5 integration lands.)
 
-### 1.6 Dead script tunables — **S**
+### 1.6 Dead script tunables — **S** — **DONE (PR #171)**
 `SFDT_PARALLEL_DELAY` (`enhanced-test-runner.sh:31`) and `SFDT_DEFAULT_BRANCH` (`deployment-assistant.sh:1463`) are read by scripts but never set by any CLI code.
 
 **Fix:** add `testConfig.parallelDelay` and `defaultBranch` config keys (template + schema) flattened by `buildScriptEnv()`, or remove the script hooks. Update the CLAUDE.md env table either way.
@@ -65,7 +83,7 @@ Each item lists: what's wrong / what's new, the fix approach, files to touch, an
 ### 2.4 MCP coverage — **M**
 Missing tools for: `test`, `coverage`, `scan`, `dependencies`, `flow`, `explain`, `review`, `release`/`changelog`, `pull`, `scratch`, `data`. Add read-only ones first (`sfdt_test_results`, `sfdt_coverage`, `sfdt_scan`, `sfdt_dependencies`, `sfdt_flow_scan`); gate mutating ones (`sfdt_release`, `sfdt_scratch_create`) behind `confirmExecution` like `sfdt_deploy`/`sfdt_retrofit`.
 
-### 2.5 Test gaps — **S**
+### 2.5 Test gaps — **S** — **DONE (PR #171)**
 Direct unit tests for `src/lib/notifier-formatters.js` (Slack/Teams/Loki/markdown payload shapes) and `src/lib/bridge/middleware.js`.
 
 ---
@@ -74,19 +92,19 @@ Direct unit tests for `src/lib/notifier-formatters.js` (Slack/Teams/Loki/markdow
 
 Today the extension is a terminal launcher + 3 read-only trees + the GUI in an iframe. Sequenced plan:
 
-### 3.1 Native result capture & rendering — **M** (foundation)
+### 3.1 Native result capture & rendering — **M** (foundation) — **DONE (sprint-2 branch)**
 Run commands with `--json` via `child_process` (instead of `term.sendText`) for snapshot-producing commands; parse the sf-envelope (`status`/`result`); render audit/monitor/quality/coverage results in native views. Keep the terminal path for interactive commands (deploy picker, init).
 
-### 3.2 Problems-pane diagnostics — **M**
+### 3.2 Problems-pane diagnostics — **M** — **DONE (sprint-2 branch)**
 Map snapshot findings that carry file/line (quality, lint-access, future v67 checks) to `vscode.Diagnostic` collections so findings appear inline in editors. Builds directly on 3.1.
 
-### 3.3 Smart-deploy delta preview + execute + quick-deploy — **M**
+### 3.3 Smart-deploy delta preview + execute + quick-deploy — **M** — **DONE (sprint-2 branch)**
 A webview (or tree + confirm) showing the computed delta, chosen test level, and no-overwrite protections before deploy; add the missing `--smart` execute path (currently validate-only) and a quick-deploy action for a validated job ID (parity with GUI + MCP `sfdt_quick_deploy`).
 
 ### 3.4 Test & coverage integration — **M**
 Test-run tree from `logs/test-*-latest.json`; editor gutter coverage decoration from the coverage snapshot.
 
-### 3.5 Onboarding & catalog completeness — **S**
+### 3.5 Onboarding & catalog completeness — **S** — **DONE (sprint-2 branch)**
 A `walkthroughs` contribution (init → first audit → first smart deploy); add missing command families to the catalog (`ci init`, `feature-flags`, `config set/get`, `notify <event>`, `pr-description`, `ai prompt`); severity trends + "open in org" links in the org-health tree; one-click `--notify` dispatch.
 
 ### 3.6 Agent-test runner (later, pairs with 4.5) — **L**
@@ -101,7 +119,7 @@ CodeLens on agent test-spec files backed by `sf agent test run-eval` / `sf logic
 #### 4.1 API v67 readiness check — **M** (P1, time-sensitive)
 Summer '26 makes Apex user-mode-by-default at API 67 and `WITH SECURITY_ENFORCED` no longer compiles. New audit/quality check (`sfdt audit api67` or `sfdt quality --api67`) scanning local Apex for `WITH SECURITY_ENFORCED`, sharing-less classes, and system-mode assumptions before a `sourceApiVersion` bump. Feeds VS Code diagnostics (3.2).
 
-#### 4.2 sf CLI credential-redaction adaptation — **S** (P0-adjacent)
+#### 4.2 sf CLI credential-redaction adaptation — **S** (P0-adjacent) — **DONE (PR #171)**
 Since sf CLI 2.136.8 (May 2026), tokens are redacted from `sf org display --json` / `org list --json`. Audit our scripts/libs for token scraping and switch to `sf org auth show-access-token` where needed (sfdx-hardis already shipped this).
 
 #### 4.3 RunRelevantTests follow-through — **M**
@@ -123,7 +141,7 @@ Run `sf code-analyzer` (PMD 7, `--include-fixes`) inside `sfdt quality`; merge f
 - **Elastic async limits**: read `DailyAsyncApexElasticExecutions` / `DailyAsyncApexProcessed` from OrgLimits and warn on overflow capacity.
 - **Release channel awareness**: report the org's Release Manager channel + preview/non-preview instance in `monitor org-info`; `retrofit`/`compare` warn when source and target run different release versions.
 
-#### 4.8 Google Chat notifier channel — **S**
+#### 4.8 Google Chat notifier channel — **S** — **DONE (PR #171)**
 Cheap parity with sfdx-hardis: add a `googlechat` provider to `notifier.js`/`notifier-formatters.js` (webhook-based, `webhookUrlEnv` pattern).
 
 #### 4.9 Agent-skills publishing — **M**
@@ -163,7 +181,7 @@ Every user-facing change must be mirrored to the docs site (`sfdt-site`) in the 
 
 Execution model: each sprint runs as a wave of parallel agents on **disjoint file sets** (shared files — config template, schema, CHANGELOG, CLAUDE.md — are edited once, up front or at consolidation, never concurrently). Every agent runs its own verification loop (implement → targeted vitest → eslint → fix until green); every wave ends with a full-suite run plus one **adversarial reviewer per item** whose job is to refute the change; confirmed findings loop back into a fix round before commit. One commit per work item.
 
-### Sprint 1 — bugs & quick wins *(in progress on this branch)*
+### Sprint 1 — bugs & quick wins — ✅ SHIPPED (PR #171)
 | Order | Item | Files (ownership) | Depends on |
 |---|---|---|---|
 | 0 | Pre-work: config keys (`defaultBranch`, `smokeTests`, `deployment.keyClasses`, `googlechat` enum) | template + schema | — |
@@ -175,7 +193,7 @@ Execution model: each sprint runs as a wave of parallel agents on **disjoint fil
 | 1f | 4.2 credential-redaction sweep | scripts/src minus 1a–1e files | — |
 | 2 | Consolidation: CHANGELOG, CLAUDE.md env table, docs-site staleness list | shared docs | 1a–1f |
 
-### Sprint 2 — VS Code uplift (order matters: each builds on the previous)
+### Sprint 2 — VS Code uplift — ✅ COMPLETE except 3.4 (on sprint-2 branch, PR pending)
 1. **3.1 native `--json` capture** (foundation; `vscode/src/lib/` runner module + result types)
 2. **3.2 Problems-pane diagnostics** (consumes 3.1's parsed results)
 3. **3.3 smart-deploy preview / execute / quick-deploy** (uses 3.1 runner; new webview)

--- a/docs/plans/2026-07-03-gap-remediation-and-release-research.md
+++ b/docs/plans/2026-07-03-gap-remediation-and-release-research.md
@@ -102,7 +102,7 @@ Map snapshot findings that carry file/line (quality, lint-access, future v67 che
 A webview (or tree + confirm) showing the computed delta, chosen test level, and no-overwrite protections before deploy; add the missing `--smart` execute path (currently validate-only) and a quick-deploy action for a validated job ID (parity with GUI + MCP `sfdt_quick_deploy`).
 
 ### 3.4 Test & coverage integration — **M**
-Test-run tree from `logs/test-*-latest.json`; editor gutter coverage decoration from the coverage snapshot.
+Test-run tree from `logs/test-*-latest.json`; editor gutter coverage decoration from the coverage snapshot. Also fold in the deferred PR #172 review finding: consolidate `vscode/src/lib/run-json.ts`'s spawn/envelope path with `cli.ts`'s `runSfdt`/`runSfdtJson` so the extension has one "run sfdt and read JSON" implementation (move the timeout/AbortSignal/Windows-shell/process-group-kill improvements into the shared module).
 
 ### 3.5 Onboarding & catalog completeness — **S** — **DONE (sprint-2 branch)**
 A `walkthroughs` contribution (init → first audit → first smart deploy); add missing command families to the catalog (`ci init`, `feature-flags`, `config set/get`, `notify <event>`, `pr-description`, `ai prompt`); severity trends + "open in org" links in the org-health tree; one-click `--notify` dispatch.

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -6,6 +6,20 @@ All notable changes to the **SFDT for Salesforce** VS Code extension (`sfdt.sfdt
 
 ## [Unreleased]
 
+### Added
+
+- **Native result rendering.** Audit, monitor, coverage, quality, and preflight now run with captured `--json` output under a progress notification — from every entry point (palette shortcuts, the Commands tree, and command search) — refreshing the SFDT trees and rendering a readable summary to the new **SFDT Results** output channel, with a "Run in Terminal" fallback on any failure. Interactive commands (deploy picker, init) keep the terminal.
+- **Problems-pane diagnostics.** Quality violations from the CLI's snapshot map to native VS Code diagnostics (severity 1 → Error, 2 → Warning, 3+ → Info) that open the offending file; a skipped scan (scanner not installed) produces no false-clean diagnostics. **SFDT: Clear Diagnostics** empties the collection.
+- **Smart Deploy — Validate & Review** (`sfdt.smartDeployPreview`): captures `deploy --smart --dry-run`, shows the parsed delta (components, test level, overwrite protections), then offers Deploy now / Re-validate / Cancel behind a modal, org-named confirmation that warns extra-loudly for production orgs.
+- **Quick Deploy** (`sfdt.quickDeploy`): promote a validated deployment by `0Af…` job ID via `sf project deploy quick` in the integrated terminal, with org picker and modal confirmation.
+- **"Get started with SFDT" walkthrough** (check CLI → init → first audit → smart-deploy validate → open dashboard) and new catalog entries for `ci init`, `feature-flags`, `config get/set`, `notify <event>`, `pr-description`, and `ai prompt`.
+- **Org-health tree**: per-check tooltips with summaries and a "Send snapshot to channels" action (`notify snapshot --type audit|monitor`).
+
+### Fixed
+
+- Commands that accept no `--org` flag (`config`, `feature-flags`, `ai prompt`, `init`, …) no longer get a default org injected into their terminal command line.
+- CLI spawning works on Windows (`sfdt.cmd` shim requires a shell since Node's 2024 security patch).
+
 ## [0.3.1] - 2026-07-02
 
 ### Fixed

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -76,7 +76,11 @@
       { "command": "sfdt.monitor", "title": "SFDT: Run Org Monitor" },
       { "command": "sfdt.backup", "title": "SFDT: Backup Org Metadata" },
       { "command": "sfdt.preflight", "title": "SFDT: Run Preflight Checks" },
+      { "command": "sfdt.quality", "title": "SFDT: Run Quality Analysis" },
+      { "command": "sfdt.clearDiagnostics", "title": "SFDT: Clear Problems" },
       { "command": "sfdt.deploy", "title": "SFDT: Deploy" },
+      { "command": "sfdt.smartDeployPreview", "title": "SFDT: Smart Deploy — Validate & Review", "icon": "$(rocket)" },
+      { "command": "sfdt.quickDeploy", "title": "SFDT: Quick Deploy (validated job ID)", "icon": "$(zap)" },
       { "command": "sfdt.docs", "title": "SFDT: Generate Documentation" }
     ],
     "menus": {
@@ -89,6 +93,8 @@
       "view/title": [
         { "command": "sfdt.searchCommands", "when": "view == sfdtCommands", "group": "navigation@1" },
         { "command": "sfdt.refresh", "when": "view == sfdtCommands", "group": "navigation@2" },
+        { "command": "sfdt.smartDeployPreview", "when": "view == sfdtCommands", "group": "1_deploy@1" },
+        { "command": "sfdt.quickDeploy", "when": "view == sfdtCommands", "group": "1_deploy@2" },
         { "command": "sfdt.pickOrg", "when": "view == sfdtStatus", "group": "navigation@1" },
         { "command": "sfdt.refresh", "when": "view == sfdtStatus", "group": "navigation@2" },
         { "command": "sfdt.refresh", "when": "view == sfdtOrgHealth", "group": "navigation@1" },

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -81,14 +81,18 @@
       { "command": "sfdt.deploy", "title": "SFDT: Deploy" },
       { "command": "sfdt.smartDeployPreview", "title": "SFDT: Smart Deploy — Validate & Review", "icon": "$(rocket)" },
       { "command": "sfdt.quickDeploy", "title": "SFDT: Quick Deploy (validated job ID)", "icon": "$(zap)" },
-      { "command": "sfdt.docs", "title": "SFDT: Generate Documentation" }
+      { "command": "sfdt.docs", "title": "SFDT: Generate Documentation" },
+      { "command": "sfdt.doctor", "title": "SFDT: Run Doctor (browser-extension bridge)", "icon": "$(verified)" },
+      { "command": "sfdt.checkCli", "title": "SFDT: Check CLI Installation", "icon": "$(verified)" },
+      { "command": "sfdt.notifySnapshot", "title": "SFDT: Send Snapshot to Channels", "icon": "$(bell)" }
     ],
     "menus": {
       "commandPalette": [
         { "command": "sfdt.runEntry", "when": "false" },
         { "command": "sfdt.runArgs", "when": "false" },
         { "command": "sfdt.copyCommand", "when": "false" },
-        { "command": "sfdt.openCommandDocs", "when": "false" }
+        { "command": "sfdt.openCommandDocs", "when": "false" },
+        { "command": "sfdt.notifySnapshot", "when": "false" }
       ],
       "view/title": [
         { "command": "sfdt.searchCommands", "when": "view == sfdtCommands", "group": "navigation@1" },
@@ -103,9 +107,55 @@
       "view/item/context": [
         { "command": "sfdt.runEntry", "when": "view == sfdtCommands && viewItem =~ /^sfdtCommand/", "group": "inline@1" },
         { "command": "sfdt.copyCommand", "when": "view == sfdtCommands && viewItem =~ /^sfdtCommand/", "group": "1_run@1" },
-        { "command": "sfdt.openCommandDocs", "when": "view == sfdtCommands && viewItem =~ /^sfdt(Command|Group|Parent)/", "group": "2_docs@1" }
+        { "command": "sfdt.openCommandDocs", "when": "view == sfdtCommands && viewItem =~ /^sfdt(Command|Group|Parent)/", "group": "2_docs@1" },
+        { "command": "sfdt.notifySnapshot", "when": "view == sfdtOrgHealth && viewItem =~ /^sfdtHealthSnapshot/", "group": "inline@1" },
+        { "command": "sfdt.notifySnapshot", "when": "view == sfdtOrgHealth && viewItem =~ /^sfdtHealthSnapshot/", "group": "1_notify@1" }
       ]
     },
+    "walkthroughs": [
+      {
+        "id": "sfdt.gettingStarted",
+        "title": "Get started with SFDT",
+        "description": "Install the sfdt CLI, initialize your project, run your first org health checks, and validate a smart deploy.",
+        "steps": [
+          {
+            "id": "sfdt.walkthrough.installCli",
+            "title": "Install & check the sfdt CLI",
+            "description": "The extension is a thin UI over the sfdt CLI — it must be on your PATH, alongside the Salesforce ``sf`` CLI.\nInstall it with ``npm install -g @sfdt/cli``, or follow the [install guide](https://sfdt.dev/getting-started).\n[Check My Setup (sfdt --version)](command:sfdt.checkCli)",
+            "media": { "svg": "media/sfdt.svg", "altText": "SFDT logo" },
+            "completionEvents": ["onCommand:sfdt.checkCli", "onContext:sfdt:hasSfdt"]
+          },
+          {
+            "id": "sfdt.walkthrough.init",
+            "title": "Initialize your project",
+            "description": "Create ``.sfdt/config.json`` for this workspace. ``sfdt init`` asks a few questions in the integrated terminal and derives the rest from ``sfdx-project.json``.\n[Run sfdt init](command:sfdt.init)",
+            "media": { "svg": "media/sfdt.svg", "altText": "SFDT logo" },
+            "completionEvents": ["onCommand:sfdt.init", "onContext:sfdt:ready"]
+          },
+          {
+            "id": "sfdt.walkthrough.audit",
+            "title": "Run your first org audit",
+            "description": "Diagnose org health with ~25 read-only checks (MFA coverage, licenses, unused metadata, field access, …). Results land in the Org Health view and the SFDT Results channel.\n[Run Org Audit](command:sfdt.audit)",
+            "media": { "svg": "media/sfdt.svg", "altText": "SFDT logo" },
+            "completionEvents": ["onCommand:sfdt.audit"]
+          },
+          {
+            "id": "sfdt.walkthrough.smartDeploy",
+            "title": "Validate a smart deploy",
+            "description": "Compute the git delta, pick the minimal safe test level, and validate against the org without deploying anything. Review the outcome, then promote it when you're ready.\n[Smart Deploy — Validate & Review](command:sfdt.smartDeployPreview)",
+            "media": { "svg": "media/sfdt.svg", "altText": "SFDT logo" },
+            "completionEvents": ["onCommand:sfdt.smartDeployPreview"]
+          },
+          {
+            "id": "sfdt.walkthrough.dashboard",
+            "title": "Open the dashboard",
+            "description": "The embedded web dashboard (``sfdt ui``) brings audits, monitoring, releases, and settings together in one place.\n[Open the SFDT Dashboard](command:sfdt.openDashboard)",
+            "media": { "svg": "media/sfdt.svg", "altText": "SFDT logo" },
+            "completionEvents": ["onCommand:sfdt.openDashboard"]
+          }
+        ]
+      }
+    ],
     "configuration": {
       "title": "SFDT",
       "properties": {
@@ -128,6 +178,12 @@
           "type": "boolean",
           "default": true,
           "description": "Tint the VS Code window by org type (production = red, sandbox = orange, scratch/developer = green) to prevent wrong-org mistakes."
+        },
+        "sfdt.smartDeployTimeoutMinutes": {
+          "type": "number",
+          "default": 0,
+          "minimum": 0,
+          "description": "Maximum minutes to wait for the Smart Deploy — Validate & Review validation (`sfdt deploy --smart --dry-run`). 0 (default) means no limit — the progress notification stays cancellable either way. Production validations run the full local test suite and often exceed 10 minutes."
         }
       }
     }

--- a/vscode/src/commandsTree.ts
+++ b/vscode/src/commandsTree.ts
@@ -4,8 +4,9 @@ import { COMMAND_GROUPS, type CommandEntry, type CommandGroup } from './lib/comm
 /**
  * Tree data provider for the "Commands" view — the full sfdt command surface,
  * grouped into categories. Group → entries → (optional) subcommands. Leaf nodes
- * carry a `sfdt.runEntry` command so a click runs them in the integrated
- * terminal. Pure presentation; all execution lives in the extension wiring.
+ * carry a `sfdt.runEntry` command so a click runs them (natively with rendered
+ * results for snapshot-producing commands, otherwise in the integrated
+ * terminal). Pure presentation; all execution lives in the extension wiring.
  */
 
 export type CmdNode =

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -448,12 +448,14 @@ export function activate(context: vscode.ExtensionContext): void {
   }
 
   // ── Prerequisite / welcome context ──
+  let prereqsReady = false;
   const refreshPrereqs = async () => {
     const r = workspaceRoot();
     const hasSf = (await capture('sf', ['--version'], r, 5000)).trim().length > 0;
     const hasSfdt = (await capture(cliPath(), ['--version'], r, 5000)).trim().length > 0;
     const hasConfig = !!r && fs.existsSync(path.join(r, '.sfdt', 'config.json'));
     const state = evaluatePrereqs({ hasSf, hasSfdt, hasConfig });
+    prereqsReady = state.ready;
     await vscode.commands.executeCommand('setContext', 'sfdt:ready', state.ready);
     await vscode.commands.executeCommand('setContext', 'sfdt:hasSfdt', hasSfdt);
   };
@@ -563,6 +565,17 @@ export function activate(context: vscode.ExtensionContext): void {
         void refreshViews();
       }
       if (e.affectsConfiguration('sfdt.cliPath')) void refreshPrereqs();
+    }),
+  );
+
+  // Re-check prerequisites when the window regains focus while setup is still
+  // incomplete — users install the CLI or run `sfdt init` in an external
+  // terminal, and the walkthrough/welcome context keys would otherwise stay
+  // stale until a reload. Only transitions from not-ready are interesting, so
+  // a ready state never re-spawns the version probes on focus.
+  context.subscriptions.push(
+    vscode.window.onDidChangeWindowState((ws) => {
+      if (ws.focused && !prereqsReady) void refreshPrereqs();
     }),
   );
 

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -33,6 +33,10 @@ function dashboardPort(): number {
 function orgColorEnabled(): boolean {
   return cfg().get<boolean>('orgColor') !== false;
 }
+function smartDeployTimeoutMinutes(): number {
+  const v = cfg().get<number>('smartDeployTimeoutMinutes');
+  return typeof v === 'number' && Number.isFinite(v) && v > 0 ? v : 0;
+}
 function workspaceRoot(): string | undefined {
   return vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
 }
@@ -153,14 +157,24 @@ export function activate(context: vscode.ExtensionContext): void {
     vscode.window.onDidCloseTerminal((t) => { if (t === terminal) terminal = undefined; }),
   );
 
-  const sendToTerminal = (commandLine: string) => {
+  const sendToTerminal = (commandLine: string, execute = true) => {
     const term = sfdtTerminal();
     term.show(true);
-    term.sendText(commandLine);
+    term.sendText(commandLine, execute);
   };
 
-  const runInTerminal = (args: string[]) => {
-    sendToTerminal(buildTerminalCommand(args, { cliPath: cliPath(), org: defaultOrg() }));
+  // `incomplete` types the command without executing it (trailing space) so
+  // the user can append required positional args (e.g. `config get <key>`).
+  // --org is not injected on that path: the user finishes the line, and most
+  // of these commands (config, feature-flags, ai prompt) take no --org flag.
+  // `noOrg` also skips --org injection: some CLI commands (doctor, init,
+  // feature-flags) accept no --org flag and would exit 1 on the unknown option.
+  const runInTerminal = (args: string[], opts: { incomplete?: boolean; noOrg?: boolean } = {}) => {
+    if (opts.incomplete) {
+      sendToTerminal(`${buildTerminalCommand(args, { cliPath: cliPath() })} `, false);
+      return;
+    }
+    sendToTerminal(buildTerminalCommand(args, { cliPath: cliPath(), org: opts.noOrg ? undefined : defaultOrg() }));
   };
 
   // ── Org picker (shared by sfdt.pickOrg and one-shot flows like Quick Deploy) ──
@@ -204,13 +218,28 @@ export function activate(context: vscode.ExtensionContext): void {
 
   const smartDeployPreview = async (): Promise<void> => {
     const args = ['deploy', '--smart', '--dry-run'];
+    // Production validations always run the full local test suite and
+    // routinely exceed run-json's 10-minute default, so the timeout is
+    // user-configurable (0 = unlimited) and the progress notification is
+    // cancellable — cancelling kills the child CLI process.
+    const timeoutMinutes = smartDeployTimeoutMinutes();
+    const abort = new AbortController();
     const cap = await vscode.window.withProgress(
       {
         location: vscode.ProgressLocation.Notification,
         title: 'SFDT: computing delta and validating (sfdt deploy --smart --dry-run)…',
-        cancellable: false,
+        cancellable: true,
       },
-      () => captureSfdt(args, { cliPath: cliPath(), cwd: workspaceRoot(), org: defaultOrg() }),
+      (_progress, token) => {
+        token.onCancellationRequested(() => abort.abort());
+        return captureSfdt(args, {
+          cliPath: cliPath(),
+          cwd: workspaceRoot(),
+          org: defaultOrg(),
+          timeoutMs: timeoutMinutes * 60_000,
+          signal: abort.signal,
+        });
+      },
     );
     const raw = [cap.stdout, cap.stderr].filter((s) => s && s.trim()).join('\n');
     results.appendLine('');
@@ -221,8 +250,16 @@ export function activate(context: vscode.ExtensionContext): void {
       vscode.window.showErrorMessage(`Could not run the sfdt CLI: ${cap.spawnError}`);
       return;
     }
+    if (cap.cancelled) {
+      vscode.window.showInformationMessage(
+        'Smart-deploy validation cancelled. A validation already submitted to the org keeps running there.',
+      );
+      return;
+    }
     if (cap.timedOut) {
-      vscode.window.showErrorMessage('Smart-deploy validation timed out — see the SFDT Results channel.');
+      vscode.window.showErrorMessage(
+        `Smart-deploy validation timed out after ${timeoutMinutes} minute(s) — raise "sfdt.smartDeployTimeoutMinutes" (0 = no limit). See the SFDT Results channel.`,
+      );
       return;
     }
     const summary = parseSmartDeployOutput(raw);
@@ -255,10 +292,9 @@ export function activate(context: vscode.ExtensionContext): void {
   };
 
   // ── Quick Deploy: promote a previously validated job (0Af…) ──
-  // The CLI's quick-deploy path is deployment-assistant.sh's non-interactive
-  // branch, driven by SFDT_VALIDATION_JOB_ID; the built command env-prefixes
-  // the vars and redirects stdin from /dev/null so the CLI's script runner
-  // flags the run non-interactive while output streams in the terminal.
+  // Runs `sf project deploy quick` directly in the integrated terminal. The
+  // sfdt CLI's quick-deploy path (deployment-assistant.sh) can't promote a
+  // smart-deploy validation job — see buildQuickDeployCommand for why.
   const quickDeploy = async (): Promise<void> => {
     const jobId = (
       await vscode.window.showInputBox({
@@ -281,12 +317,7 @@ export function activate(context: vscode.ExtensionContext): void {
       'Quick Deploy',
     );
     if (picked !== 'Quick Deploy') return;
-    if (process.platform === 'win32') {
-      vscode.window.showWarningMessage(
-        'Quick Deploy sends a POSIX-style command (env prefix + /dev/null redirect) — use a bash-compatible integrated terminal (Git Bash/WSL), not PowerShell or cmd.',
-      );
-    }
-    sendToTerminal(buildQuickDeployCommand({ cliPath: cliPath(), org, jobId }));
+    sendToTerminal(buildQuickDeployCommand({ org, jobId }));
   };
 
   // ── Refresh (snapshots feed Org Health + Status + status bar) ──
@@ -367,7 +398,7 @@ export function activate(context: vscode.ExtensionContext): void {
       );
       if (ok !== 'Run') return;
     }
-    runInTerminal(entry.args);
+    runInTerminal(entry.args, { incomplete: entry.argsIncomplete, noOrg: entry.noOrg });
   };
 
   // Auto-refresh when any snapshot file changes, regardless of how it was run.
@@ -462,7 +493,9 @@ export function activate(context: vscode.ExtensionContext): void {
     vscode.commands.registerCommand('sfdt.copyCommand', async (node?: { entry?: CommandEntry }) => {
       const entry = node?.entry;
       if (!entry?.args) return;
-      await vscode.env.clipboard.writeText(buildTerminalCommand(entry.args, { cliPath: cliPath(), org: defaultOrg() }));
+      await vscode.env.clipboard.writeText(
+        buildTerminalCommand(entry.args, { cliPath: cliPath(), org: entry.noOrg ? undefined : defaultOrg() }),
+      );
       vscode.window.showInformationMessage('Command copied to clipboard');
     }),
 
@@ -480,16 +513,36 @@ export function activate(context: vscode.ExtensionContext): void {
     }),
 
     vscode.commands.registerCommand('sfdt.setOrg', () => vscode.commands.executeCommand('sfdt.pickOrg')),
+
+    // Org Health section nodes (audit/monitor snapshots) pass the TreeNode;
+    // push that snapshot through the CLI notifier in the terminal so channel
+    // config errors and delivery output stay visible.
+    vscode.commands.registerCommand('sfdt.notifySnapshot', (node?: { snapshotType?: 'audit' | 'monitor' }) => {
+      const type = node?.snapshotType;
+      if (!type) return;
+      runInTerminal(['notify', 'snapshot', '--type', type]);
+    }),
+
     vscode.commands.registerCommand('sfdt.smartDeployPreview', () => smartDeployPreview()),
     vscode.commands.registerCommand('sfdt.quickDeploy', () => quickDeploy()),
-    vscode.commands.registerCommand('sfdt.init', () => runInTerminal(['init'])),
+    vscode.commands.registerCommand('sfdt.init', () => runInTerminal(['init'], { noOrg: true })),
+
+    // Walkthrough step 1: verify the CLIs are installed. Pre-init safe —
+    // unlike `sfdt doctor` (the extension-bridge diagnostic, which needs
+    // `.sfdt/config.json` and a running `sfdt ui`), `--version` succeeds on a
+    // fresh machine, which is exactly the state onboarding starts from.
+    vscode.commands.registerCommand('sfdt.checkCli', () => {
+      sendToTerminal(buildTerminalCommand(['--version'], { cliPath: cliPath() }));
+      sendToTerminal('sf --version');
+      void refreshPrereqs();
+    }),
     vscode.commands.registerCommand('sfdt.clearDiagnostics', () => diagnostics.clear()),
 
     // Dedicated palette shortcuts to common commands (back-compat + discoverability).
     // runEntry routes snapshot-producing commands (audit/monitor/preflight/
     // quality/coverage) natively; interactive ones (deploy, backup, docs)
     // keep the terminal.
-    ...(['audit', 'monitor', 'deploy', 'preflight', 'quality', 'backup', 'docs-generate'].map((id) =>
+    ...(['audit', 'monitor', 'deploy', 'preflight', 'quality', 'backup', 'docs-generate', 'doctor'].map((id) =>
       vscode.commands.registerCommand(`sfdt.${id.replace('-generate', '')}`, () => {
         const entry = findCommand(id);
         if (!entry) return;

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -4,10 +4,14 @@ import * as path from 'node:path';
 import * as fs from 'node:fs';
 import { COMMAND_GROUPS, flattenCommands, findCommand, docsUrlFor, type CommandEntry } from './lib/commands.js';
 import { buildTerminalCommand } from './lib/terminal.js';
+import { runSfdtForResult, captureSfdt } from './lib/run-json.js';
+import { parseSmartDeployOutput, summaryLines, isValidationJobId, buildQuickDeployCommand } from './lib/smart-deploy-output.js';
+import { renderSummary, nativeSpecFor, type NativeCommandSpec, type QualityResult } from './lib/render-summary.js';
+import { qualityFromRun, qualityFromSnapshot, qualityToDiagnostics, groupByFile, type DiagnosticEntry } from './lib/diagnostics.js';
 import { buildStatusTree } from './lib/status.js';
 import { evaluatePrereqs } from './lib/prereqs.js';
 import { classifyOrg, colorForOrg } from './lib/org-color.js';
-import { readSnapshots } from './lib/io.js';
+import { readSnapshots, readQualityLog } from './lib/io.js';
 import { OrgHealthProvider } from './tree.js';
 import { CommandsProvider } from './commandsTree.js';
 import { StatusProvider } from './statusTree.js';
@@ -53,7 +57,37 @@ function capture(cmd: string, args: string[], cwd?: string, timeoutMs = 8000): P
 
 export function activate(context: vscode.ExtensionContext): void {
   const output = vscode.window.createOutputChannel('SFDT');
+  const results = vscode.window.createOutputChannel('SFDT Results');
+  const diagnostics = vscode.languages.createDiagnosticCollection('sfdt');
   let latestSfdtVersion: string | undefined;
+
+  const SEVERITY: Record<DiagnosticEntry['severity'], vscode.DiagnosticSeverity> = {
+    error: vscode.DiagnosticSeverity.Error,
+    warning: vscode.DiagnosticSeverity.Warning,
+    info: vscode.DiagnosticSeverity.Information,
+  };
+
+  /** Replace the Problems-pane contents with the given file-anchored entries. */
+  const publishDiagnostics = (entries: DiagnosticEntry[]) => {
+    diagnostics.clear();
+    for (const [file, fileEntries] of groupByFile(entries)) {
+      const uri = vscode.Uri.file(file);
+      diagnostics.set(
+        uri,
+        fileEntries.map((e) => {
+          const lineIdx = Math.max(0, e.line - 1);
+          const d = new vscode.Diagnostic(
+            new vscode.Range(lineIdx, 0, lineIdx, Number.MAX_SAFE_INTEGER),
+            e.message,
+            SEVERITY[e.severity],
+          );
+          d.source = e.source;
+          if (e.code) d.code = e.code;
+          return d;
+        }),
+      );
+    }
+  };
 
   // ── Status gatherer (org / git / versions / health) ──
   const gatherStatus = async () => {
@@ -101,6 +135,8 @@ export function activate(context: vscode.ExtensionContext): void {
     vscode.window.registerTreeDataProvider('sfdtOrgHealth', health),
     vscode.window.registerTreeDataProvider('sfdtStatus', status),
     output,
+    results,
+    diagnostics,
     statusBar,
     { dispose: () => dashboard.dispose() },
   );
@@ -117,15 +153,212 @@ export function activate(context: vscode.ExtensionContext): void {
     vscode.window.onDidCloseTerminal((t) => { if (t === terminal) terminal = undefined; }),
   );
 
-  const runInTerminal = (args: string[]) => {
+  const sendToTerminal = (commandLine: string) => {
     const term = sfdtTerminal();
     term.show(true);
-    term.sendText(buildTerminalCommand(args, { cliPath: cliPath(), org: defaultOrg() }));
+    term.sendText(commandLine);
   };
 
+  const runInTerminal = (args: string[]) => {
+    sendToTerminal(buildTerminalCommand(args, { cliPath: cliPath(), org: defaultOrg() }));
+  };
+
+  // ── Org picker (shared by sfdt.pickOrg and one-shot flows like Quick Deploy) ──
+  // Lists authenticated orgs via `sf org list --json`, falling back to a manual
+  // input box when the sf CLI is unavailable. Returns the chosen alias without
+  // persisting it — callers decide whether to save it as the default.
+  const chooseOrg = async (placeHolder: string): Promise<string | undefined> => {
+    const json = await capture('sf', ['org', 'list', '--json'], workspaceRoot());
+    let aliases: Array<{ label: string; description?: string }> = [];
+    try {
+      const r = JSON.parse(json).result ?? {};
+      const orgs = [...(r.nonScratchOrgs ?? []), ...(r.scratchOrgs ?? [])];
+      aliases = orgs.map((o: Record<string, unknown>) => ({
+        label: String(o.alias || o.username),
+        description: String(o.username ?? ''),
+      }));
+    } catch { /* fall through to manual input */ }
+    if (aliases.length > 0) {
+      const pick = await vscode.window.showQuickPick(aliases, { placeHolder });
+      return pick?.label;
+    }
+    return vscode.window.showInputBox({ prompt: 'Org alias for sfdt (--org)', value: defaultOrg() ?? '' });
+  };
+
+  // ── Smart deploy: validate & review, then optionally execute ──
+  // `sfdt deploy` has no --json, so the dry-run output is captured and parsed
+  // by the vscode-free smart-deploy-output module (thin UI: the CLI computes
+  // the delta/test level; the extension only reads what it printed).
+  const smartDeployExecute = async (production: boolean, orgName: string) => {
+    const message = production
+      ? `⚠ PRODUCTION DEPLOY — this will deploy to "${orgName}", which the validation flagged as a PRODUCTION org.`
+      : `Deploy the validated smart delta to "${orgName}"?`;
+    const detail = production
+      ? 'This immediately modifies a production Salesforce org. Local tests will run. Are you absolutely sure?'
+      : 'Runs `sfdt deploy --smart` in the integrated terminal so you can watch the deployment stream.';
+    const confirmLabel = production ? 'Deploy to PRODUCTION' : 'Deploy';
+    const picked = await vscode.window.showWarningMessage(message, { modal: true, detail }, confirmLabel);
+    if (picked !== confirmLabel) return;
+    runInTerminal(['deploy', '--smart']);
+  };
+
+  const smartDeployPreview = async (): Promise<void> => {
+    const args = ['deploy', '--smart', '--dry-run'];
+    const cap = await vscode.window.withProgress(
+      {
+        location: vscode.ProgressLocation.Notification,
+        title: 'SFDT: computing delta and validating (sfdt deploy --smart --dry-run)…',
+        cancellable: false,
+      },
+      () => captureSfdt(args, { cliPath: cliPath(), cwd: workspaceRoot(), org: defaultOrg() }),
+    );
+    const raw = [cap.stdout, cap.stderr].filter((s) => s && s.trim()).join('\n');
+    results.appendLine('');
+    results.appendLine(`═══ ${new Date().toISOString()} · sfdt ${args.join(' ')} ═══`);
+    results.appendLine(raw || '(no output)');
+    results.show(true);
+    if (cap.spawnError) {
+      vscode.window.showErrorMessage(`Could not run the sfdt CLI: ${cap.spawnError}`);
+      return;
+    }
+    if (cap.timedOut) {
+      vscode.window.showErrorMessage('Smart-deploy validation timed out — see the SFDT Results channel.');
+      return;
+    }
+    const summary = parseSmartDeployOutput(raw);
+    if (summary.noChanges) {
+      vscode.window.showInformationMessage('Smart deploy: no metadata changes detected between refs — nothing to deploy.');
+      return;
+    }
+    const lines = summaryLines(summary);
+    const orgName = summary.org ?? defaultOrg() ?? 'the default org';
+    const validated = summary.succeeded && !summary.failed && cap.code === 0;
+    const items: vscode.QuickPickItem[] = [];
+    if (validated) {
+      items.push({
+        label: summary.production ? '$(rocket) Deploy now — ⚠ PRODUCTION' : '$(rocket) Deploy now',
+        description: `sfdt deploy --smart → ${orgName}`,
+        detail: lines.join('  ·  '),
+      });
+    }
+    items.push(
+      { label: '$(refresh) Re-validate', description: 'Run the delta validation again' },
+      { label: '$(close) Cancel' },
+    );
+    const placeHolder = validated
+      ? `Validation passed · ${lines.join(' · ')}`
+      : `Validation failed${summary.failureDetail ? ` — ${summary.failureDetail}` : ''} · see SFDT Results`;
+    const pick = await vscode.window.showQuickPick(items, { placeHolder, ignoreFocusOut: true, matchOnDetail: true });
+    if (!pick) return;
+    if (pick.label.startsWith('$(rocket)')) return smartDeployExecute(summary.production, orgName);
+    if (pick.label.startsWith('$(refresh)')) return smartDeployPreview();
+  };
+
+  // ── Quick Deploy: promote a previously validated job (0Af…) ──
+  // The CLI's quick-deploy path is deployment-assistant.sh's non-interactive
+  // branch, driven by SFDT_VALIDATION_JOB_ID; the built command env-prefixes
+  // the vars and redirects stdin from /dev/null so the CLI's script runner
+  // flags the run non-interactive while output streams in the terminal.
+  const quickDeploy = async (): Promise<void> => {
+    const jobId = (
+      await vscode.window.showInputBox({
+        prompt: 'Salesforce validation job ID from a prior validate run (starts with 0Af)',
+        placeHolder: '0Af… (15 or 18 characters)',
+        validateInput: (v) =>
+          isValidationJobId(v.trim()) ? undefined : 'Enter a 15- or 18-character deploy request ID starting with "0Af"',
+      })
+    )?.trim();
+    if (!jobId) return;
+    const org = await chooseOrg('Target org for the quick deploy');
+    if (!org) return;
+    const picked = await vscode.window.showWarningMessage(
+      `Quick Deploy validation job ${jobId} to "${org}"?`,
+      {
+        modal: true,
+        detail:
+          'Promotes the already-validated deployment without re-running tests. The org must match the one the validation ran against.',
+      },
+      'Quick Deploy',
+    );
+    if (picked !== 'Quick Deploy') return;
+    if (process.platform === 'win32') {
+      vscode.window.showWarningMessage(
+        'Quick Deploy sends a POSIX-style command (env prefix + /dev/null redirect) — use a bash-compatible integrated terminal (Git Bash/WSL), not PowerShell or cmd.',
+      );
+    }
+    sendToTerminal(buildQuickDeployCommand({ cliPath: cliPath(), org, jobId }));
+  };
+
+  // ── Refresh (snapshots feed Org Health + Status + status bar) ──
+  const refreshViews = async () => {
+    await Promise.all([health.refresh(), status.refresh(), statusBar.refresh(defaultOrg())]);
+    await applyOrgColor();
+  };
+
+  // ── Native (non-terminal) execution for snapshot-producing commands ──
+  // Runs the CLI (with --json when supported) under a progress notification,
+  // refreshes the trees, and renders a markdown summary into the
+  // "SFDT Results" channel.
+  const runNative = async (args: string[], spec: NativeCommandSpec, label?: string): Promise<void> => {
+    const startedAt = new Date().toISOString();
+    const run = await vscode.window.withProgress(
+      {
+        location: vscode.ProgressLocation.Notification,
+        title: `SFDT: running \`sfdt ${args.join(' ')}\`…`,
+        cancellable: false,
+      },
+      () =>
+        runSfdtForResult(args, {
+          cliPath: cliPath(),
+          cwd: workspaceRoot(),
+          org: spec.org ? defaultOrg() : undefined,
+          json: spec.json,
+        }),
+    );
+    // Quality violations are file-anchored — surface them in the Problems
+    // pane (paths resolved against the workspace root so each entry opens the
+    // right file). Sources: the run's envelope/stdout markers, else a
+    // logs/quality-latest.json snapshot written during this run (today's CLI
+    // swallows the scanner output, so the snapshot is the only place real
+    // violation data lands). Each run replaces the previous set — a run that
+    // produced no parseable quality result clears stale entries rather than
+    // leaving them behind.
+    let quality: QualityResult | null = null;
+    if (spec.kind === 'quality') {
+      const root = workspaceRoot();
+      const snapshot = root ? await readQualityLog(root) : null;
+      quality = qualityFromRun(run, { snapshot, since: startedAt });
+      publishDiagnostics(qualityToDiagnostics(quality, root));
+    }
+    await refreshViews();
+    const summary = renderSummary(spec.kind, run, { label, quality });
+    results.appendLine('');
+    results.appendLine(`═══ ${new Date().toISOString()} · sfdt ${args.join(' ')} ═══`);
+    results.appendLine(summary.markdown);
+    results.show(true);
+    const show =
+      summary.severity === 'error'
+        ? vscode.window.showErrorMessage
+        : summary.severity === 'warn'
+          ? vscode.window.showWarningMessage
+          : vscode.window.showInformationMessage;
+    // When the CLI itself failed (couldn't run, timed out, or emitted no
+    // envelope), offer the terminal as a graceful fallback.
+    const actions = run.ok ? [] : ['Run in Terminal'];
+    const picked = await show(summary.headline, ...actions);
+    if (picked === 'Run in Terminal') runInTerminal(args);
+  };
+
+  // Single entry point for catalog entries (tree clicks, quick-pick search,
+  // palette shortcuts). Snapshot/report-producing commands (audit/monitor/
+  // preflight/quality/coverage — including audit/monitor subcommands) run
+  // natively with rendered results; interactive commands (deploy picker,
+  // init) and destructive ones keep the integrated terminal.
   const runEntry = async (entry: CommandEntry) => {
     if (entry.action === 'dashboard') return dashboard.open();
     if (!entry.args) return;
+    const spec = nativeSpecFor(entry);
+    if (spec) return runNative(entry.args, spec, entry.label);
     if (entry.destructive) {
       const ok = await vscode.window.showWarningMessage(
         `Run "sfdt ${entry.args.join(' ')}"? This can modify the org or your project.`,
@@ -137,20 +370,27 @@ export function activate(context: vscode.ExtensionContext): void {
     runInTerminal(entry.args);
   };
 
-  // ── Refresh (snapshots feed Org Health + Status + status bar) ──
-  const refreshViews = async () => {
-    await Promise.all([health.refresh(), status.refresh(), statusBar.refresh(defaultOrg())]);
-    await applyOrgColor();
-  };
-
   // Auto-refresh when any snapshot file changes, regardless of how it was run.
+  // A quality snapshot additionally feeds the Problems pane: dashboard
+  // (`sfdt ui`) quality runs write logs/quality-latest.json, so violations
+  // from those scans land here live — each snapshot replaces the previous
+  // diagnostics set.
+  const publishFromQualitySnapshot = async () => {
+    const r = workspaceRoot();
+    if (!r) return;
+    publishDiagnostics(qualityToDiagnostics(qualityFromSnapshot(await readQualityLog(r)), r));
+  };
   const root = workspaceRoot();
   if (root) {
     const watcher = vscode.workspace.createFileSystemWatcher(
       new vscode.RelativePattern(root, 'logs/*-latest.json'),
     );
-    watcher.onDidCreate(() => void refreshViews());
-    watcher.onDidChange(() => void refreshViews());
+    const onSnapshot = (uri: vscode.Uri) => {
+      void refreshViews();
+      if (path.basename(uri.fsPath) === 'quality-latest.json') void publishFromQualitySnapshot();
+    };
+    watcher.onDidCreate(onSnapshot);
+    watcher.onDidChange(onSnapshot);
     context.subscriptions.push(watcher);
   }
 
@@ -202,7 +442,12 @@ export function activate(context: vscode.ExtensionContext): void {
       const entry = arg && 'entry' in arg ? arg.entry : (arg as CommandEntry);
       return runEntry(entry);
     }),
-    vscode.commands.registerCommand('sfdt.runArgs', (args: string[]) => runInTerminal(args)),
+    vscode.commands.registerCommand('sfdt.runArgs', (args: string[]) => {
+      // Org Health / Status tree nodes pass raw argv — give audit/monitor
+      // (and friends) the same native rendering as the Commands tree.
+      const spec = nativeSpecFor({ id: args[0] ?? '', args });
+      return spec ? runNative(args, spec) : runInTerminal(args);
+    }),
     vscode.commands.registerCommand('sfdt.refresh', () => { refreshLatestVersion(); return refreshViews(); }),
     vscode.commands.registerCommand('sfdt.openDashboard', () => dashboard.open()),
 
@@ -227,23 +472,7 @@ export function activate(context: vscode.ExtensionContext): void {
     }),
 
     vscode.commands.registerCommand('sfdt.pickOrg', async () => {
-      const json = await capture('sf', ['org', 'list', '--json'], workspaceRoot());
-      let aliases: Array<{ label: string; description?: string }> = [];
-      try {
-        const r = JSON.parse(json).result ?? {};
-        const orgs = [...(r.nonScratchOrgs ?? []), ...(r.scratchOrgs ?? [])];
-        aliases = orgs.map((o: Record<string, unknown>) => ({
-          label: String(o.alias || o.username),
-          description: String(o.username ?? ''),
-        }));
-      } catch { /* fall through to manual input */ }
-      let chosen: string | undefined;
-      if (aliases.length > 0) {
-        const pick = await vscode.window.showQuickPick(aliases, { placeHolder: 'Select the target org' });
-        chosen = pick?.label;
-      } else {
-        chosen = await vscode.window.showInputBox({ prompt: 'Org alias for sfdt (--org)', value: defaultOrg() ?? '' });
-      }
+      const chosen = await chooseOrg('Select the target org');
       if (chosen !== undefined) {
         await cfg().update('defaultOrg', chosen, vscode.ConfigurationTarget.Workspace);
         await refreshViews();
@@ -251,13 +480,20 @@ export function activate(context: vscode.ExtensionContext): void {
     }),
 
     vscode.commands.registerCommand('sfdt.setOrg', () => vscode.commands.executeCommand('sfdt.pickOrg')),
+    vscode.commands.registerCommand('sfdt.smartDeployPreview', () => smartDeployPreview()),
+    vscode.commands.registerCommand('sfdt.quickDeploy', () => quickDeploy()),
     vscode.commands.registerCommand('sfdt.init', () => runInTerminal(['init'])),
+    vscode.commands.registerCommand('sfdt.clearDiagnostics', () => diagnostics.clear()),
 
     // Dedicated palette shortcuts to common commands (back-compat + discoverability).
-    ...(['audit', 'monitor', 'deploy', 'preflight', 'backup', 'docs-generate'].map((id) =>
+    // runEntry routes snapshot-producing commands (audit/monitor/preflight/
+    // quality/coverage) natively; interactive ones (deploy, backup, docs)
+    // keep the terminal.
+    ...(['audit', 'monitor', 'deploy', 'preflight', 'quality', 'backup', 'docs-generate'].map((id) =>
       vscode.commands.registerCommand(`sfdt.${id.replace('-generate', '')}`, () => {
         const entry = findCommand(id);
-        if (entry) return runEntry(entry);
+        if (!entry) return;
+        return runEntry(entry);
       }),
     )),
   );

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -48,7 +48,7 @@ function capture(cmd: string, args: string[], cwd?: string, timeoutMs = 8000): P
     let done = false;
     const finish = (v: string) => { if (!done) { done = true; resolve(v); } };
     try {
-      const child = spawn(cmd, args, { cwd, env: { ...process.env }, shell: false });
+      const child = spawn(cmd, args, { cwd, env: { ...process.env }, shell: process.platform === 'win32' });
       const timer = setTimeout(() => { child.kill(); finish(''); }, timeoutMs);
       child.stdout?.on('data', (d) => (out += d.toString()));
       child.on('error', () => { clearTimeout(timer); finish(''); });
@@ -325,6 +325,15 @@ export function activate(context: vscode.ExtensionContext): void {
     await Promise.all([health.refresh(), status.refresh(), statusBar.refresh(defaultOrg())]);
     await applyOrgColor();
   };
+  // A native run and the snapshot FileSystemWatcher both want to refresh after
+  // the same logs/*-latest.json write; debounce so one run costs one refresh
+  // (refreshViews spawns a live `sf org display` via applyOrgColor).
+  let refreshTimer: ReturnType<typeof setTimeout> | undefined;
+  const scheduleRefreshViews = () => {
+    if (refreshTimer) clearTimeout(refreshTimer);
+    refreshTimer = setTimeout(() => { refreshTimer = undefined; void refreshViews(); }, 300);
+  };
+  context.subscriptions.push({ dispose: () => { if (refreshTimer) clearTimeout(refreshTimer); } });
 
   // ── Native (non-terminal) execution for snapshot-producing commands ──
   // Runs the CLI (with --json when supported) under a progress notification,
@@ -361,7 +370,7 @@ export function activate(context: vscode.ExtensionContext): void {
       quality = qualityFromRun(run, { snapshot, since: startedAt });
       publishDiagnostics(qualityToDiagnostics(quality, root));
     }
-    await refreshViews();
+    scheduleRefreshViews();
     const summary = renderSummary(spec.kind, run, { label, quality });
     results.appendLine('');
     results.appendLine(`═══ ${new Date().toISOString()} · sfdt ${args.join(' ')} ═══`);
@@ -377,7 +386,7 @@ export function activate(context: vscode.ExtensionContext): void {
     // envelope), offer the terminal as a graceful fallback.
     const actions = run.ok ? [] : ['Run in Terminal'];
     const picked = await show(summary.headline, ...actions);
-    if (picked === 'Run in Terminal') runInTerminal(args);
+    if (picked === 'Run in Terminal') runInTerminal(args, { noOrg: !spec.org });
   };
 
   // Single entry point for catalog entries (tree clicks, quick-pick search,
@@ -417,7 +426,7 @@ export function activate(context: vscode.ExtensionContext): void {
       new vscode.RelativePattern(root, 'logs/*-latest.json'),
     );
     const onSnapshot = (uri: vscode.Uri) => {
-      void refreshViews();
+      scheduleRefreshViews();
       if (path.basename(uri.fsPath) === 'quality-latest.json') void publishFromQualitySnapshot();
     };
     watcher.onDidCreate(onSnapshot);

--- a/vscode/src/lib/commands.ts
+++ b/vscode/src/lib/commands.ts
@@ -22,8 +22,21 @@ export interface CommandEntry {
   detail: string;
   /** argv passed to the sfdt CLI. Omitted for non-CLI actions (see `action`). */
   args?: string[];
+  /**
+   * When true, `args` is a prefix the user must complete (required positional
+   * arguments, e.g. `config get <key>`). The extension types the command into
+   * the integrated terminal without executing it so the user appends the rest.
+   */
+  argsIncomplete?: boolean;
   /** When true, the command mutates the org/repo and should confirm first. */
   destructive?: boolean;
+  /**
+   * When true, the CLI command accepts no `--org` flag, so the extension must
+   * NOT append the configured `sfdt.defaultOrg` (Commander rejects unknown
+   * options with exit 1). Applies to project-local commands like `doctor`,
+   * `init`, and `feature-flags`.
+   */
+  noOrg?: boolean;
   /** When set, refresh the matching snapshot view after the command completes. */
   refreshes?: 'audit' | 'monitor' | 'scan' | 'drift';
   /** Non-terminal action handled by the extension (e.g. open the dashboard). */
@@ -112,10 +125,11 @@ export const COMMAND_GROUPS: CommandGroup[] = [
         ],
       },
       { id: 'notify-monitor', label: 'Send Org Health to Notifications', detail: 'Push the latest monitor snapshot to configured channels', args: ['notify', 'snapshot', '--type', 'monitor'], icon: 'bell' },
+      { id: 'notify', label: 'Send Notification (event)', detail: 'Send a lifecycle event to configured channels: deploy-success | deploy-failure | test-failure | release-created | snapshot', args: ['notify'], argsIncomplete: true, icon: 'bell' },
       { id: 'backup', label: 'Backup Metadata', detail: 'Retrieve a full metadata backup', args: ['monitor', 'backup'], destructive: true, icon: 'archive' },
       { id: 'scan', label: 'Scan Inventory', detail: 'Fetch the org metadata inventory', args: ['scan'], refreshes: 'scan', icon: 'search' },
       { id: 'drift', label: 'Detect Drift', detail: 'Compare local source against the org', args: ['drift'], refreshes: 'drift', icon: 'git-compare' },
-      { id: 'doctor', label: 'Doctor', detail: 'Diagnose the sfdt/sf setup', args: ['doctor'], icon: 'verified' },
+      { id: 'doctor', label: 'Doctor', detail: 'Diagnose the browser-extension bridge stack (expects `sfdt ui` to be running)', args: ['doctor'], noOrg: true, icon: 'verified' },
     ],
   },
   {
@@ -153,6 +167,7 @@ export const COMMAND_GROUPS: CommandGroup[] = [
       },
       { id: 'explain', label: 'Explain', detail: 'Explain a class or flow (AI)', args: ['explain'], icon: 'lightbulb' },
       { id: 'compare', label: 'Compare', detail: 'Diff two orgs or org vs local', args: ['compare'], icon: 'diff' },
+      { id: 'ai-prompt', label: 'AI Prompt', detail: 'Run a free-form prompt through the configured AI provider', args: ['ai', 'prompt'], argsIncomplete: true, icon: 'sparkle' },
     ],
   },
   {
@@ -188,8 +203,36 @@ export const COMMAND_GROUPS: CommandGroup[] = [
     icon: 'tools',
     docsUrl: DOCS.configUtils,
     entries: [
-      { id: 'init', label: 'Initialize Project', detail: 'Create .sfdt config (sfdt init)', args: ['init'], icon: 'rocket' },
-      { id: 'config', label: 'Show Config', detail: 'Print the resolved configuration', args: ['config'], icon: 'settings-gear' },
+      { id: 'init', label: 'Initialize Project', detail: 'Create .sfdt config (sfdt init)', args: ['init'], noOrg: true, icon: 'rocket' },
+      {
+        id: 'config', label: 'Config', detail: 'Read and write .sfdt config values', icon: 'settings-gear',
+        children: [
+          { id: 'config-get', label: 'Get', detail: 'Print a config value by dot-notation key (e.g. defaultOrg)', args: ['config', 'get'], argsIncomplete: true },
+          { id: 'config-set', label: 'Set', detail: 'Set a config value by dot-notation key (e.g. deployment.coverageThreshold 80)', args: ['config', 'set'], argsIncomplete: true },
+        ],
+      },
+      {
+        id: 'feature-flags', label: 'Feature Flags', detail: 'Kill-switch for sfdt feature ids (.sfdt/feature-flags.json)', icon: 'symbol-boolean',
+        children: [
+          { id: 'feature-flags-list', label: 'List', detail: 'List currently disabled feature ids', args: ['feature-flags', 'list'], noOrg: true },
+          { id: 'feature-flags-disable', label: 'Disable', detail: 'Add a feature id to the disabled list', args: ['feature-flags', 'disable'], argsIncomplete: true },
+          { id: 'feature-flags-enable', label: 'Enable', detail: 'Remove a feature id from the disabled list', args: ['feature-flags', 'enable'], argsIncomplete: true },
+          { id: 'feature-flags-clear', label: 'Clear', detail: 'Re-enable everything (empties the disabled list)', args: ['feature-flags', 'clear'], noOrg: true },
+        ],
+      },
+      {
+        id: 'ci', label: 'CI Templates', detail: 'Generate ready-to-use CI/CD pipeline workflows', icon: 'circuit-board',
+        children: [
+          { id: 'ci-init-github-monitor', label: 'GitHub · Monitor', detail: 'Scheduled org-monitoring workflow for GitHub Actions', args: ['ci', 'init', '--provider', 'github', '--type', 'monitor'] },
+          { id: 'ci-init-github-deploy', label: 'GitHub · Deploy', detail: 'PR smart-deploy workflow for GitHub Actions', args: ['ci', 'init', '--provider', 'github', '--type', 'deploy'] },
+          { id: 'ci-init-gitlab-monitor', label: 'GitLab · Monitor', detail: 'Scheduled org-monitoring pipeline for GitLab CI', args: ['ci', 'init', '--provider', 'gitlab', '--type', 'monitor'] },
+          { id: 'ci-init-gitlab-deploy', label: 'GitLab · Deploy', detail: 'MR smart-deploy pipeline for GitLab CI', args: ['ci', 'init', '--provider', 'gitlab', '--type', 'deploy'] },
+          { id: 'ci-init-azure-monitor', label: 'Azure · Monitor', detail: 'Scheduled org-monitoring pipeline for Azure DevOps', args: ['ci', 'init', '--provider', 'azure', '--type', 'monitor'] },
+          { id: 'ci-init-azure-deploy', label: 'Azure · Deploy', detail: 'PR smart-deploy pipeline for Azure DevOps', args: ['ci', 'init', '--provider', 'azure', '--type', 'deploy'] },
+          { id: 'ci-init-bitbucket-monitor', label: 'Bitbucket · Monitor', detail: 'Scheduled org-monitoring pipeline for Bitbucket Pipelines', args: ['ci', 'init', '--provider', 'bitbucket', '--type', 'monitor'] },
+          { id: 'ci-init-bitbucket-deploy', label: 'Bitbucket · Deploy', detail: 'PR smart-deploy pipeline for Bitbucket Pipelines', args: ['ci', 'init', '--provider', 'bitbucket', '--type', 'deploy'] },
+        ],
+      },
       { id: 'pull', label: 'Pull Metadata', detail: 'Retrieve metadata into the project', args: ['pull'], icon: 'cloud-download' },
       { id: 'dashboard', label: 'Open Dashboard', detail: 'Open the embedded sfdt dashboard', action: 'dashboard', icon: 'dashboard', docsUrl: 'https://sfdt.dev/cli/dashboard' },
       { id: 'mcp', label: 'Start MCP Server', detail: 'Start the stdio MCP server', args: ['mcp', 'start'], icon: 'server-process', docsUrl: 'https://sfdt.dev/cli/mcp' },

--- a/vscode/src/lib/commands.ts
+++ b/vscode/src/lib/commands.ts
@@ -68,7 +68,7 @@ export const COMMAND_GROUPS: CommandGroup[] = [
       { id: 'deploy-smart', label: 'Smart Deploy (validate)', detail: 'Delta validate-only deploy with smart test selection', args: ['deploy', '--smart', '--dry-run'], icon: 'cloud-upload' },
       { id: 'retrofit', label: 'Retrofit', detail: 'Retrieve from a source org, commit, and smart-deploy to a target', args: ['retrofit'], icon: 'sync' },
       { id: 'pr-comment', label: 'PR Comment (monitor)', detail: 'Post the latest monitor snapshot to the current PR', args: ['pr', 'comment', '--type', 'monitor'], icon: 'comment' },
-      { id: 'preflight', label: 'Preflight', detail: 'Run pre-deployment validation checks', args: ['preflight'], icon: 'checklist' },
+      { id: 'preflight', label: 'Preflight', detail: 'Run pre-deployment validation checks', args: ['preflight'], noOrg: true, icon: 'checklist' },
       { id: 'rollback', label: 'Rollback', detail: 'Roll back the last deployment', args: ['rollback'], destructive: true, icon: 'discard' },
       { id: 'release', label: 'Release', detail: 'Build a release (manifest + notes)', args: ['release'], icon: 'tag' },
       { id: 'manifest', label: 'Manifest', detail: 'Generate package.xml from a git diff', args: ['manifest'], icon: 'list-tree' },
@@ -138,7 +138,7 @@ export const COMMAND_GROUPS: CommandGroup[] = [
     icon: 'beaker',
     docsUrl: DOCS.testing,
     entries: [
-      { id: 'quality', label: 'Quality Analysis', detail: 'Analyze Apex test quality', args: ['quality'], icon: 'beaker' },
+      { id: 'quality', label: 'Quality Analysis', detail: 'Analyze Apex test quality', args: ['quality'], noOrg: true, icon: 'beaker' },
       { id: 'test', label: 'Run Tests', detail: 'Run Apex tests', args: ['test'], icon: 'beaker' },
       { id: 'coverage', label: 'Code Coverage', detail: 'Report Apex code coverage (org-wide + per-class)', args: ['coverage'], icon: 'shield' },
       { id: 'dependencies', label: 'Dependencies', detail: 'Show metadata dependencies for a component', args: ['dependencies'], icon: 'references' },

--- a/vscode/src/lib/diagnostics.ts
+++ b/vscode/src/lib/diagnostics.ts
@@ -1,0 +1,157 @@
+/**
+ * Map sfdt quality results (Salesforce Code Analyzer violations surfaced by
+ * `sfdt quality`) into plain diagnostic entries for the VS Code Problems pane.
+ *
+ * Deliberately free of any `vscode` import — the extension layer converts
+ * these entries into `vscode.Diagnostic`s. Audit/monitor findings are org
+ * inventory (usernames, license types, component names), not file locations,
+ * so quality violations are the only source of file-anchored diagnostics.
+ */
+
+import * as path from 'node:path';
+import type { SfdtJsonRun } from './run-json.js';
+import { parseQualityOutput, type QualityResult } from './render-summary.js';
+
+export type DiagnosticSeverity = 'error' | 'warning' | 'info';
+
+export interface DiagnosticEntry {
+  /** Absolute file path (relative scanner paths resolved against the workspace root). */
+  file: string;
+  /** 1-based line number (always ≥ 1). */
+  line: number;
+  severity: DiagnosticSeverity;
+  message: string;
+  /** Problems-pane "source" column. */
+  source: string;
+  /** Rule id (Problems-pane "code" column); empty when the scanner gave none. */
+  code: string;
+}
+
+/** Scanner severity → Problems-pane severity: 1 = error, 2 = warning, 3+ = info. */
+export function severityFor(severity: number | undefined): DiagnosticSeverity {
+  if (severity === 1) return 'error';
+  if (severity === 2) return 'warning';
+  return 'info';
+}
+
+/**
+ * Envelope shape of `logs/quality-latest.json` as written by the CLI's
+ * log-writer (`{ schemaVersion, type: 'quality', timestamp, data }`, where
+ * `data` is the QualityResult shape). This is the snapshot the GUI writes
+ * after a dashboard quality run and the MCP server reads back — the same
+ * file the extension consumes here.
+ */
+export interface QualityLogEnvelope {
+  schemaVersion?: string;
+  type?: string;
+  timestamp?: string;
+  data?: QualityResult | null;
+}
+
+/**
+ * Extract the quality result from a parsed `logs/quality-latest.json`
+ * envelope. Returns null for anything that is not a quality envelope with a
+ * violations array. When `since` is given, an envelope written before that
+ * instant (or with an unparseable timestamp) is rejected — used after a
+ * native run so a stale snapshot from an older scan is never attributed to
+ * the run that just finished.
+ */
+export function qualityFromSnapshot(
+  envelope: unknown,
+  options: { since?: string } = {},
+): QualityResult | null {
+  if (!envelope || typeof envelope !== 'object' || Array.isArray(envelope)) return null;
+  const env = envelope as QualityLogEnvelope;
+  if (env.type !== 'quality') return null;
+  const data = env.data;
+  if (!data || typeof data !== 'object' || !Array.isArray(data.violations)) return null;
+  if (options.since) {
+    const written = Date.parse(env.timestamp ?? '');
+    const since = Date.parse(options.since);
+    if (!Number.isFinite(written) || !Number.isFinite(since) || written < since) return null;
+  }
+  return data;
+}
+
+/** Optional extra sources consulted when the run itself carries no result. */
+export interface QualitySources {
+  /** Parsed `logs/quality-latest.json` envelope, when the caller read one. */
+  snapshot?: unknown;
+  /** ISO start-of-run timestamp; a snapshot older than this is ignored. */
+  since?: string;
+}
+
+/**
+ * Extract the structured quality result for a native `sfdt quality` run.
+ * Sources, in order:
+ *
+ * 1. the `--json` envelope payload, when it carries the violations shape
+ *    (future-proofing — `sfdt quality` has no `--json` today);
+ * 2. scanner JSON / skip markers parsed out of raw stdout. NOTE: today's CLI
+ *    captures the code-analyzer output internally and re-emits only the
+ *    "static violation scan was SKIPPED — …" warning, so on a real run this
+ *    path yields SKIPPED at most — never violations;
+ * 3. a fresh `logs/quality-latest.json` snapshot written during the run —
+ *    the only place the suite persists real violation data today.
+ *
+ * Null when no source produced a result (the caller should then clear any
+ * previously published diagnostics rather than leave them stale).
+ */
+export function qualityFromRun(run: SfdtJsonRun, sources: QualitySources = {}): QualityResult | null {
+  const r = run.result as QualityResult | null;
+  if (r && Array.isArray(r.violations)) return r;
+  return (
+    parseQualityOutput(run.raw) ??
+    qualityFromSnapshot(sources.snapshot, { since: sources.since })
+  );
+}
+
+/**
+ * Convert a quality result into diagnostic entries. A SKIPPED scan (scanner
+ * missing/crashed) yields no entries — there is nothing file-anchored to
+ * show. Violations without a usable file path are skipped, as are relative
+ * paths when no workspace root is available to resolve them against (a
+ * dangling relative Uri would open the wrong file — or none).
+ */
+export function qualityToDiagnostics(
+  result: QualityResult | null | undefined,
+  workspaceRoot: string | undefined,
+): DiagnosticEntry[] {
+  if (!result || (result.status ?? '').toUpperCase() === 'SKIPPED') return [];
+  const violations = Array.isArray(result.violations) ? result.violations : [];
+  const entries: DiagnosticEntry[] = [];
+  for (const v of violations) {
+    const rawFile = typeof v.file === 'string' ? v.file.trim() : '';
+    if (!rawFile) continue;
+    let file: string;
+    if (path.isAbsolute(rawFile)) {
+      file = path.normalize(rawFile);
+    } else if (workspaceRoot) {
+      file = path.resolve(workspaceRoot, rawFile);
+    } else {
+      continue;
+    }
+    const line = Number.isFinite(v.line) && Number(v.line) >= 1 ? Math.floor(Number(v.line)) : 1;
+    const rule = v.rule ?? '';
+    entries.push({
+      file,
+      line,
+      severity: severityFor(v.severity),
+      message: v.message || rule || 'code analyzer violation',
+      source: 'sfdt',
+      code: rule,
+    });
+  }
+  return entries;
+}
+
+/** Group entries per absolute file path — one Problems-pane bucket per Uri. */
+export function groupByFile(entries: DiagnosticEntry[]): Map<string, DiagnosticEntry[]> {
+  const byFile = new Map<string, DiagnosticEntry[]>();
+  for (const entry of entries) {
+    const bucket = byFile.get(entry.file);
+    if (bucket) bucket.push(entry);
+    else byFile.set(entry.file, [entry]);
+  }
+  return byFile;
+}

--- a/vscode/src/lib/io.ts
+++ b/vscode/src/lib/io.ts
@@ -29,6 +29,15 @@ export async function readSnapshots(
   return { audit, monitor };
 }
 
+/**
+ * Read the latest quality log envelope (`logs/quality-latest.json`) — the
+ * snapshot dashboard quality runs write and the MCP server reads. Returned
+ * untyped: `qualityFromSnapshot` (lib/diagnostics) validates the shape.
+ */
+export async function readQualityLog(projectRoot: string): Promise<unknown> {
+  return readJsonIfExists<unknown>(path.join(logsDir(projectRoot), 'quality-latest.json'));
+}
+
 /** Read the latest scan + drift snapshots (Org Health's secondary sections). */
 export async function readScanDrift(
   projectRoot: string,

--- a/vscode/src/lib/render-summary.ts
+++ b/vscode/src/lib/render-summary.ts
@@ -11,6 +11,7 @@
 import { describeFinding, classCoverageBand } from '@sfdt/flow-core';
 import type { SfdtJsonRun } from './run-json.js';
 import type { Snapshot, CheckResult } from './snapshots.js';
+import { stripAnsi } from './smart-deploy-output.js';
 
 export type SummaryKind = 'audit' | 'monitor' | 'quality' | 'coverage' | 'preflight' | 'generic';
 export type Severity = 'info' | 'warn' | 'error';
@@ -241,7 +242,6 @@ export interface QualityResult {
 }
 
 // Strip ANSI color codes so chalk-colored CLI lines still match markers.
-const ANSI_RE = /\u001b\[[0-9;]*m/g;
 
 /**
  * Shape a Salesforce Code Analyzer JSON payload (`sf scanner run --format
@@ -298,7 +298,7 @@ function shapeScannerJson(raw: unknown): QualityResult | null {
  * fabricated PASS.
  */
 export function parseQualityOutput(output: string): QualityResult | null {
-  const text = String(output ?? '').replace(ANSI_RE, '');
+  const text = stripAnsi(String(output ?? ''));
   let found: QualityResult | null = null;
   for (const line of text.split('\n')) {
     const trimmed = line.trim();

--- a/vscode/src/lib/render-summary.ts
+++ b/vscode/src/lib/render-summary.ts
@@ -1,0 +1,486 @@
+/**
+ * Pure renderers turning native sfdt run results into concise markdown
+ * summaries (title, counts by status/severity, top findings) for the
+ * "SFDT Results" output channel plus a one-line headline for toasts.
+ *
+ * Deliberately free of any `vscode` import — unit-testable in isolation.
+ * All shapes come from the CLI and are handled defensively: a result that
+ * doesn't look like the expected snapshot falls back to a generic summary.
+ */
+
+import { describeFinding, classCoverageBand } from '@sfdt/flow-core';
+import type { SfdtJsonRun } from './run-json.js';
+import type { Snapshot, CheckResult } from './snapshots.js';
+
+export type SummaryKind = 'audit' | 'monitor' | 'quality' | 'coverage' | 'preflight' | 'generic';
+export type Severity = 'info' | 'warn' | 'error';
+
+export interface RenderedSummary {
+  /** Short title, e.g. "Org Audit — myorg". */
+  title: string;
+  /** One-line headline for the information/warning toast. */
+  headline: string;
+  /** Full markdown body for the results channel. */
+  markdown: string;
+  severity: Severity;
+}
+
+/**
+ * How each natively-run command id (from the command catalog) invokes the
+ * CLI: which summary renderer applies, whether the command supports `--json`,
+ * and whether it accepts `--org`. Commands not listed here keep the terminal
+ * path (interactive pickers, deploys, init).
+ */
+export interface NativeCommandSpec {
+  kind: SummaryKind;
+  json: boolean;
+  org: boolean;
+}
+
+export const NATIVE_COMMANDS: Record<string, NativeCommandSpec> = {
+  audit: { kind: 'audit', json: true, org: true },
+  monitor: { kind: 'monitor', json: true, org: true },
+  coverage: { kind: 'coverage', json: true, org: true },
+  // `sfdt quality` has no --json/--org yet, and it captures the scanner
+  // output internally: on a real run stdout carries only progress chrome and
+  // (at most) the "scan was SKIPPED" warning parsed by parseQualityOutput.
+  // Violation data comes from the logs/quality-latest.json snapshot the
+  // caller reads alongside the run (renderSummary `options.quality`); a run
+  // with no data from any source renders as inconclusive — never as a clean
+  // success.
+  quality: { kind: 'quality', json: false, org: false },
+  // `sfdt preflight` has no --json yet — interpret by exit code and render
+  // the SFDT_LOG:check:<name>:<status>:<detail> markers it prints on stdout.
+  preflight: { kind: 'preflight', json: false, org: false },
+};
+
+/**
+ * Resolve the native-run spec for a command-catalog entry (tree leaf, palette
+ * quick-pick item, or dedicated shortcut). Exact id match first (the palette
+ * shortcuts use the parent ids), then the root CLI command (`args[0]`) so
+ * every `sfdt audit <check>` / `sfdt monitor <check>` subcommand in the tree
+ * gets the same native rendering — each supports `--json`/`--org` and emits
+ * the same snapshot shape as `all`. Destructive entries (e.g. `monitor
+ * backup`) and non-CLI actions keep the integrated-terminal path.
+ */
+export function nativeSpecFor(entry: {
+  id: string;
+  args?: string[];
+  destructive?: boolean;
+}): NativeCommandSpec | undefined {
+  if (!entry.args || entry.args.length === 0 || entry.destructive) return undefined;
+  return NATIVE_COMMANDS[entry.id] ?? NATIVE_COMMANDS[entry.args[0]];
+}
+
+const KIND_LABEL: Record<SummaryKind, string> = {
+  audit: 'Org Audit',
+  monitor: 'Org Monitor',
+  quality: 'Quality Analysis',
+  coverage: 'Code Coverage',
+  preflight: 'Preflight',
+  generic: 'sfdt',
+};
+
+export interface RenderSummaryOptions {
+  label?: string;
+  /**
+   * Pre-resolved quality result (qualityFromRun — envelope, stdout markers,
+   * or a fresh logs/quality-latest.json snapshot). Rendered ahead of the
+   * run-derived sources when set; only meaningful for `kind: 'quality'`.
+   */
+  quality?: QualityResult | null;
+}
+
+/** Render the summary for a completed (or failed) native run. */
+export function renderSummary(
+  kind: SummaryKind,
+  run: SfdtJsonRun,
+  options: RenderSummaryOptions = {},
+): RenderedSummary {
+  const label = options.label ?? KIND_LABEL[kind] ?? 'sfdt';
+
+  // Preflight communicates its checks via stdout markers and its verdict via
+  // the exit code — render the check list even when the run "failed".
+  if (kind === 'preflight') {
+    const rendered = renderPreflight(label, run);
+    if (rendered) return rendered;
+  }
+  if (!run.ok) return renderFailure(label, run);
+
+  switch (kind) {
+    case 'audit':
+    case 'monitor': {
+      const rendered = renderSnapshot(label, run);
+      if (rendered) return rendered;
+      break;
+    }
+    case 'coverage': {
+      const rendered = renderCoverage(label, run);
+      if (rendered) return rendered;
+      break;
+    }
+    case 'quality': {
+      const rendered =
+        (options.quality ? renderQualityResult(label, options.quality, run.warnings) : null) ??
+        renderQuality(label, run) ??
+        renderQualityFromOutput(label, run);
+      if (rendered) return rendered;
+      // No scan data from any source. Today's `sfdt quality` swallows the
+      // scanner output, so this is the normal outcome of a native run whose
+      // snapshot didn't update — never report it as a clean success.
+      return renderQualityInconclusive(label, run);
+    }
+  }
+  return renderGeneric(label, run);
+}
+
+/* ── audit / monitor snapshots ─────────────────────────────────────────── */
+
+function isSnapshot(v: unknown): v is Snapshot {
+  const s = v as Snapshot | null;
+  return !!s && Array.isArray(s.checks) && !!s.summary && typeof s.summary === 'object';
+}
+
+const STATUS_ORDER: Record<string, number> = { fail: 0, error: 1, warn: 2, ok: 3 };
+
+function renderSnapshot(label: string, run: SfdtJsonRun): RenderedSummary | null {
+  if (!isSnapshot(run.result)) return null;
+  const snap = run.result;
+  const s = snap.summary;
+  const counts = `${s.ok ?? 0} ok · ${s.warn ?? 0} warn · ${s.fail ?? 0} fail · ${s.error ?? 0} error`;
+  const severity: Severity = (s.fail ?? 0) + (s.error ?? 0) > 0 ? 'error' : (s.warn ?? 0) > 0 ? 'warn' : 'info';
+  const title = `${label} — ${snap.org ?? 'org'}`;
+  const issues = (s.warn ?? 0) + (s.fail ?? 0) + (s.error ?? 0);
+  const headline =
+    issues === 0
+      ? `${label}: all ${s.total ?? snap.checks.length} checks passed (${snap.org ?? 'org'})`
+      : `${label}: ${counts} (${snap.org ?? 'org'})`;
+
+  const attention = snap.checks
+    .filter((c) => c.status !== 'ok')
+    .sort((a, b) => (STATUS_ORDER[a.status] ?? 9) - (STATUS_ORDER[b.status] ?? 9));
+  const passing = snap.checks.filter((c) => c.status === 'ok');
+
+  const lines: string[] = [`# ${title}`, ''];
+  if (snap.timestamp) lines.push(`_${snap.timestamp}_`, '');
+  lines.push(`**Checks:** ${counts}`, '');
+  if (attention.length > 0) {
+    lines.push('## Attention needed', '');
+    for (const check of attention) lines.push(...renderCheck(check));
+  }
+  if (passing.length > 0) {
+    lines.push('## Passing', '');
+    for (const check of passing) lines.push(`- ${check.title} — ${check.summary}`);
+    lines.push('');
+  }
+  lines.push(...renderWarnings(run.warnings));
+  return { title, headline, markdown: lines.join('\n').trim(), severity };
+}
+
+function renderCheck(check: CheckResult, maxFindings = 5): string[] {
+  const lines = [`### ${check.status.toUpperCase()} · ${check.title}`, '', check.summary, ''];
+  const findings = Array.isArray(check.findings) ? check.findings : [];
+  for (const f of findings.slice(0, maxFindings)) {
+    lines.push(`- ${describeFinding(f)}`);
+  }
+  if (findings.length > maxFindings) lines.push(`- … +${findings.length - maxFindings} more`);
+  if (findings.length > 0) lines.push('');
+  return lines;
+}
+
+/* ── coverage ──────────────────────────────────────────────────────────── */
+
+interface CoverageResult {
+  org?: string;
+  threshold?: number;
+  orgWide?: number | null;
+  belowThreshold?: boolean;
+  classes?: Array<{ name: string; pct: number | null }>;
+}
+
+function renderCoverage(label: string, run: SfdtJsonRun): RenderedSummary | null {
+  const r = run.result as CoverageResult | null;
+  if (!r || !('orgWide' in r) || !Array.isArray(r.classes)) return null;
+  const orgWide = r.orgWide ?? null;
+  const orgLabel = orgWide === null ? 'unknown (run tests first)' : `${orgWide}%`;
+  const title = `${label} — ${r.org ?? 'org'}`;
+  const headline = `${label}: org-wide ${orgLabel} (threshold ${r.threshold ?? '?'}%)`;
+
+  const bands = { green: 0, amber: 0, red: 0, none: 0 };
+  for (const c of r.classes) bands[classCoverageBand(c.pct ?? null)]++;
+  const severity: Severity = r.belowThreshold ? 'error' : bands.red + bands.none > 0 ? 'warn' : 'info';
+
+  const lines = [
+    `# ${title}`,
+    '',
+    `**Org-wide:** ${orgLabel} (threshold ${r.threshold ?? '?'}%)${r.belowThreshold ? ' — **below threshold**' : ''}`,
+    '',
+    `**Classes:** ${bands.green} ≥90% · ${bands.amber} 75–90% · ${bands.red} <75% · ${bands.none} no lines`,
+    '',
+  ];
+  const worst = r.classes.filter((c) => classCoverageBand(c.pct ?? null) !== 'green').slice(0, 10);
+  if (worst.length > 0) {
+    lines.push('## Lowest coverage', '');
+    for (const c of worst) {
+      const pct = c.pct === null || c.pct === undefined ? 'no lines' : `${Math.round(c.pct * 100)}%`;
+      lines.push(`- ${pct} — ${c.name}`);
+    }
+    lines.push('');
+  }
+  lines.push(...renderWarnings(run.warnings));
+  return { title, headline, markdown: lines.join('\n').trim(), severity };
+}
+
+/* ── quality (logs/quality-latest.json `data` shape) ───────────────────── */
+
+export interface QualityResult {
+  status?: string;
+  summary?: { critical?: number; high?: number; medium?: number; low?: number };
+  violations?: Array<{ file?: string; line?: number; rule?: string; severity?: number; message?: string }>;
+  unavailableMessage?: string | null;
+}
+
+// Strip ANSI color codes so chalk-colored CLI lines still match markers.
+const ANSI_RE = /\u001b\[[0-9;]*m/g;
+
+/**
+ * Shape a Salesforce Code Analyzer JSON payload (`sf scanner run --format
+ * json` → `{ result: [{ fileName, violations }] }` or a bare file array, plus
+ * the `{"status":"skipped", …}` marker emitted by
+ * scripts/quality/code-analyzer.sh) into the quality-latest.json `data` shape.
+ * Same contract the GUI applies to the same script output (gui-server
+ * parseQualityLines). Returns null for anything else.
+ */
+function shapeScannerJson(raw: unknown): QualityResult | null {
+  const obj = raw as { status?: string; _sfdt_unavailable?: string; reason?: string; result?: unknown } | null;
+  const skipped = !!obj && !Array.isArray(obj) && (obj.status === 'skipped' || !!obj._sfdt_unavailable);
+  const files = Array.isArray(obj?.result) ? obj.result : Array.isArray(raw) ? raw : null;
+  if (!files && !skipped) return null;
+
+  const violations = (files ?? []).flatMap((file: { fileName?: string; violations?: Array<Record<string, unknown>> }) =>
+    (file.violations ?? []).map((v) => ({
+      file: file.fileName ?? '',
+      line: Number(v.line ?? 0),
+      rule: String(v.ruleName ?? v.rule ?? ''),
+      severity: Number(v.severity ?? 3),
+      message: String(v.message ?? ''),
+    })),
+  );
+  const summary = violations.reduce(
+    (acc, v) => {
+      if (v.severity === 1) acc.critical++;
+      else if (v.severity === 2) acc.high++;
+      else if (v.severity === 3) acc.medium++;
+      else acc.low++;
+      return acc;
+    },
+    { critical: 0, high: 0, medium: 0, low: 0 },
+  );
+  // A skipped scan (scanner missing or crashed) must never read as a clean
+  // PASS — mirror the CLI/GUI guard.
+  if (skipped) {
+    return {
+      status: 'SKIPPED',
+      summary,
+      violations,
+      unavailableMessage: obj?.reason ?? obj?._sfdt_unavailable ?? 'code scan skipped',
+    };
+  }
+  return { status: violations.length === 0 ? 'PASS' : 'FAIL', summary, violations };
+}
+
+/**
+ * Parse the structured quality result out of raw `sfdt quality` output:
+ * a scanner JSON line when the CLI surfaces one, else the CLI's own
+ * "static violation scan was SKIPPED — <reason>" warning (quality.js), so a
+ * skipped scan is never rendered as a clean success. Returns null when no
+ * marker is present — the caller falls back to the generic renderer, never a
+ * fabricated PASS.
+ */
+export function parseQualityOutput(output: string): QualityResult | null {
+  const text = String(output ?? '').replace(ANSI_RE, '');
+  let found: QualityResult | null = null;
+  for (const line of text.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith('{') && !trimmed.startsWith('[')) continue;
+    try {
+      const shaped = shapeScannerJson(JSON.parse(trimmed));
+      if (shaped) found = shaped;
+    } catch {
+      // Not a JSON line — keep scanning.
+    }
+  }
+  if (found) return found;
+  const skip = text.match(/static violation scan was SKIPPED — ([^\n]+)/);
+  if (skip) {
+    return {
+      status: 'SKIPPED',
+      summary: { critical: 0, high: 0, medium: 0, low: 0 },
+      violations: [],
+      unavailableMessage: skip[1].trim(),
+    };
+  }
+  return null;
+}
+
+function renderQualityFromOutput(label: string, run: SfdtJsonRun): RenderedSummary | null {
+  const parsed = parseQualityOutput(run.raw);
+  return parsed ? renderQualityResult(label, parsed, run.warnings) : null;
+}
+
+function renderQuality(label: string, run: SfdtJsonRun): RenderedSummary | null {
+  const r = run.result as QualityResult | null;
+  if (!r || !Array.isArray(r.violations)) return null;
+  return renderQualityResult(label, r, run.warnings);
+}
+
+/**
+ * Honest fallback for a quality run that finished without surfacing any scan
+ * data (no envelope, no stdout markers, no fresh snapshot). We cannot tell a
+ * clean scan from one full of critical violations, so this is a `warn`, and
+ * the headline says the outcome is unknown instead of claiming success.
+ */
+function renderQualityInconclusive(label: string, run: SfdtJsonRun): RenderedSummary {
+  const headline = `${label} finished, but no scan results were captured — violations may exist`;
+  const lines = [
+    `# ${label}`,
+    '',
+    '**Status:** inconclusive — the CLI did not surface scan results for this run.',
+    '',
+    '> This `sfdt` version does not print machine-readable scanner output. Run the scan',
+    '> from the SFDT dashboard (`sfdt ui` → Quality), which writes `logs/quality-latest.json`;',
+    '> the extension picks that snapshot up and populates the Problems pane automatically.',
+    '',
+  ];
+  lines.push(...renderWarnings(run.warnings));
+  lines.push(...fencedTail(run.raw, 20));
+  return {
+    title: label,
+    headline,
+    markdown: lines.join('\n').trim(),
+    severity: 'warn',
+  };
+}
+
+function renderQualityResult(label: string, r: QualityResult, warnings: string[]): RenderedSummary {
+  const s = r.summary ?? {};
+  const violations = Array.isArray(r.violations) ? r.violations : [];
+  const counts = `${s.critical ?? 0} critical · ${s.high ?? 0} high · ${s.medium ?? 0} medium · ${s.low ?? 0} low`;
+  const status = (r.status ?? '').toUpperCase();
+  const skipped = status === 'SKIPPED';
+  const severity: Severity =
+    status === 'FAIL' ? 'error' : skipped || violations.length > 0 ? 'warn' : 'info';
+  const title = label;
+  const headline = skipped
+    ? `${label}: scan SKIPPED — ${r.unavailableMessage ?? 'scanner unavailable'}`
+    : violations.length === 0
+      ? `${label}: no violations`
+      : `${label}: ${status || 'FAIL'} — ${counts}`;
+
+  const lines = [`# ${title}`, '', `**Status:** ${status || 'unknown'} — ${counts}`, ''];
+  if (skipped && r.unavailableMessage) {
+    lines.push(`> Static scan was skipped: ${r.unavailableMessage}`, '');
+  }
+  const top = [...violations].sort((a, b) => (a.severity ?? 9) - (b.severity ?? 9)).slice(0, 10);
+  if (top.length > 0) {
+    lines.push('## Top violations', '');
+    for (const v of top) {
+      const where = v.file ? `${v.file}${v.line ? `:${v.line}` : ''}` : '(unknown file)';
+      lines.push(`- [sev ${v.severity ?? '?'}] ${where} — ${v.rule ?? 'rule'}${v.message ? `: ${v.message}` : ''}`);
+    }
+    if (violations.length > top.length) lines.push(`- … +${violations.length - top.length} more`);
+    lines.push('');
+  }
+  lines.push(...renderWarnings(warnings));
+  return { title, headline, markdown: lines.join('\n').trim(), severity };
+}
+
+/* ── preflight (SFDT_LOG:check markers on stdout) ──────────────────────── */
+
+export interface PreflightCheck {
+  name: string;
+  status: string;
+  message: string;
+}
+
+/**
+ * Parse `SFDT_LOG:check:<name>:<PASS|WARN|FAIL>:<detail>` marker lines from
+ * preflight stdout (same format `src/lib/log-writer.js` parses server-side).
+ */
+export function parsePreflightChecks(output: string): PreflightCheck[] {
+  const checks: PreflightCheck[] = [];
+  for (const line of String(output ?? '').split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith('SFDT_LOG:')) continue;
+    const parts = trimmed.split(':');
+    if (parts[1] !== 'check') continue;
+    checks.push({ name: parts[2] ?? '', status: parts[3] ?? '', message: parts.slice(4).join(':') });
+  }
+  return checks;
+}
+
+function renderPreflight(label: string, run: SfdtJsonRun): RenderedSummary | null {
+  const checks = parsePreflightChecks(run.raw);
+  if (checks.length === 0) return null;
+  const fail = checks.filter((c) => c.status === 'FAIL');
+  const warn = checks.filter((c) => c.status === 'WARN');
+  const pass = checks.filter((c) => c.status === 'PASS');
+  const failed = fail.length > 0 || !run.ok;
+  const severity: Severity = failed ? 'error' : warn.length > 0 ? 'warn' : 'info';
+  const counts = `${pass.length} pass · ${warn.length} warn · ${fail.length} fail`;
+  const headline = failed ? `${label} failed: ${counts}` : `${label} passed: ${counts}`;
+
+  const lines = [`# ${label}`, '', `**Checks:** ${counts}`, ''];
+  const section = (heading: string, items: PreflightCheck[]) => {
+    if (items.length === 0) return;
+    lines.push(`## ${heading}`, '');
+    for (const c of items) lines.push(`- ${c.name}${c.message ? ` — ${c.message}` : ''}`);
+    lines.push('');
+  };
+  section('Failed', fail);
+  section('Warnings', warn);
+  section('Passed', pass);
+  if (failed && run.error) lines.push(`> ${run.error}`, '');
+  return { title: label, headline, markdown: lines.join('\n').trim(), severity };
+}
+
+/* ── failure / generic fallbacks ───────────────────────────────────────── */
+
+function fencedTail(raw: string, maxLines = 40, maxChars = 4000): string[] {
+  const text = String(raw ?? '').trim();
+  if (!text) return [];
+  let picked = text.split('\n').slice(-maxLines).join('\n');
+  if (picked.length > maxChars) picked = `…${picked.slice(-maxChars)}`;
+  return ['```', picked, '```', ''];
+}
+
+function renderWarnings(warnings: string[]): string[] {
+  if (!warnings || warnings.length === 0) return [];
+  return ['## Warnings', '', ...warnings.map((w) => `- ${w}`), ''];
+}
+
+function renderFailure(label: string, run: SfdtJsonRun): RenderedSummary {
+  const reason = run.error ?? 'command failed';
+  const lines = [`# ${label} failed`, '', `**Error:** ${reason}`, ''];
+  lines.push(...renderWarnings(run.warnings));
+  lines.push(...fencedTail(run.raw));
+  return {
+    title: `${label} failed`,
+    headline: `${label} failed: ${reason}`,
+    markdown: lines.join('\n').trim(),
+    severity: 'error',
+  };
+}
+
+function renderGeneric(label: string, run: SfdtJsonRun): RenderedSummary {
+  const severity: Severity = run.warnings.length > 0 ? 'warn' : 'info';
+  const lines = [`# ${label}`, '', `**Status:** completed successfully`, ''];
+  lines.push(...renderWarnings(run.warnings));
+  lines.push(...fencedTail(run.raw, 20));
+  return {
+    title: label,
+    headline: `${label} completed`,
+    markdown: lines.join('\n').trim(),
+    severity,
+  };
+}

--- a/vscode/src/lib/run-json.ts
+++ b/vscode/src/lib/run-json.ts
@@ -37,6 +37,8 @@ export interface CaptureResult {
   stdout: string;
   stderr: string;
   timedOut: boolean;
+  /** True when the caller aborted the run via `CaptureOptions.signal`. */
+  cancelled?: boolean;
   /** Message from a spawn-level failure (e.g. binary not found). */
   spawnError?: string;
 }
@@ -156,6 +158,9 @@ export function interpretCapture<T = unknown>(
   if (cap.spawnError) {
     return { ...base, ok: false, status: -1, error: `Could not run the sfdt CLI: ${cap.spawnError}` };
   }
+  if (cap.cancelled) {
+    return { ...base, ok: false, status: cap.code ?? -1, error: 'sfdt run was cancelled' };
+  }
   if (cap.timedOut) {
     return { ...base, ok: false, status: cap.code ?? -1, timedOut: true, error: 'sfdt timed out before completing' };
   }
@@ -200,8 +205,14 @@ export interface CaptureOptions {
   org?: string;
   /** Extra environment variables. */
   env?: NodeJS.ProcessEnv;
-  /** Kill the process after this long (default 10 minutes — audits can be slow). */
+  /**
+   * Kill the process after this long (default 10 minutes — audits can be
+   * slow). `0` (or any non-positive value) disables the timeout entirely —
+   * pair that with `signal` so the user can still stop the run.
+   */
   timeoutMs?: number;
+  /** Abort signal: aborting kills the child and resolves with `cancelled: true`. */
+  signal?: AbortSignal;
 }
 
 /**
@@ -210,39 +221,59 @@ export interface CaptureOptions {
  * the caller has a single code path.
  */
 export function captureSfdt(args: string[], options: CaptureOptions = {}): Promise<CaptureResult> {
-  const { cliPath = 'sfdt', cwd, org, env, timeoutMs = 600_000 } = options;
+  const { cliPath = 'sfdt', cwd, org, env, timeoutMs = 600_000, signal } = options;
   const argv = buildArgs(args, org);
   return new Promise((resolve) => {
     let stdout = '';
     let stderr = '';
     let settled = false;
+    if (signal?.aborted) {
+      resolve({ code: null, stdout, stderr, timedOut: false, cancelled: true });
+      return;
+    }
     let child: ReturnType<typeof spawn>;
     try {
       child = spawn(cliPath, argv, {
         cwd,
         env: { ...process.env, SFDT_NON_INTERACTIVE: 'true', ...env },
-        shell: false,
+        // npm installs expose sfdt as a .cmd shim on Windows, which Node
+        // refuses to spawn without a shell (EINVAL since the 2024 security
+        // patch). POSIX keeps shell:false for exact argv semantics.
+        shell: process.platform === 'win32',
       });
     } catch (err) {
       resolve({ code: null, stdout, stderr, timedOut: false, spawnError: (err as Error).message });
       return;
     }
-    // finish() only fires from the timer or child events, both of which run
-    // strictly after `timer` is initialized below.
-    const finish = (r: CaptureResult) => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timer);
-      resolve(r);
-    };
-    const timer = setTimeout(() => {
+    const killChild = () => {
       try {
         child.kill();
       } catch {
         /* already gone */
       }
-      finish({ code: null, stdout, stderr, timedOut: true });
-    }, timeoutMs);
+    };
+    const onAbort = () => {
+      killChild();
+      finish({ code: null, stdout, stderr, timedOut: false, cancelled: true });
+    };
+    // finish() only fires from the timer, the abort listener, or child events,
+    // all of which run strictly after `timer` is initialized below.
+    const finish = (r: CaptureResult) => {
+      if (settled) return;
+      settled = true;
+      if (timer) clearTimeout(timer);
+      signal?.removeEventListener('abort', onAbort);
+      resolve(r);
+    };
+    // timeoutMs <= 0 disables the timeout (the caller provides cancellation).
+    const timer =
+      timeoutMs > 0
+        ? setTimeout(() => {
+            killChild();
+            finish({ code: null, stdout, stderr, timedOut: true });
+          }, timeoutMs)
+        : undefined;
+    signal?.addEventListener('abort', onAbort, { once: true });
     child.stdout?.on('data', (d) => (stdout += d.toString()));
     child.stderr?.on('data', (d) => (stderr += d.toString()));
     child.on('error', (err) => finish({ code: null, stdout, stderr, timedOut: false, spawnError: err.message }));

--- a/vscode/src/lib/run-json.ts
+++ b/vscode/src/lib/run-json.ts
@@ -105,20 +105,34 @@ function isEnvelope(value: unknown): value is SfEnvelope {
 export function parseEnvelope(stdout: string): SfEnvelope | null {
   let found: SfEnvelope | null = null;
   let offset = 0;
-  for (const line of stdout.split('\n')) {
+  while (offset < stdout.length) {
+    const lineEnd = stdout.indexOf('\n', offset);
+    const end = lineEnd === -1 ? stdout.length : lineEnd;
+    const line = stdout.slice(offset, end);
     const braceCol = line.indexOf('{');
     if (braceCol !== -1 && line.slice(0, braceCol).trim() === '') {
       const candidate = matchBraces(stdout, offset + braceCol);
       if (candidate) {
         try {
           const parsed: unknown = JSON.parse(candidate);
-          if (isEnvelope(parsed)) found = parsed;
+          if (isEnvelope(parsed)) {
+            found = parsed;
+            // Skip the envelope's pretty-printed body: every nested object
+            // starts on its own indented line and would otherwise trigger a
+            // redundant brace-match + parse each (large audit/monitor results
+            // have thousands). Non-envelope JSON is NOT skipped — an envelope
+            // may legitimately appear nested inside a wrapper object.
+            const after = offset + braceCol + candidate.length;
+            const nextNl = stdout.indexOf('\n', after);
+            offset = nextNl === -1 ? stdout.length : nextNl + 1;
+            continue;
+          }
         } catch {
           // Stray brace / partial JSON — keep scanning.
         }
       }
     }
-    offset += line.length + 1;
+    offset = end + 1;
   }
   return found;
 }

--- a/vscode/src/lib/run-json.ts
+++ b/vscode/src/lib/run-json.ts
@@ -240,6 +240,9 @@ export function captureSfdt(args: string[], options: CaptureOptions = {}): Promi
         // refuses to spawn without a shell (EINVAL since the 2024 security
         // patch). POSIX keeps shell:false for exact argv semantics.
         shell: process.platform === 'win32',
+        // POSIX: own process group, so a timeout/cancel kill reaches the `sf`
+        // children sfdt spawns (they would otherwise keep querying the org).
+        detached: process.platform !== 'win32',
       });
     } catch (err) {
       resolve({ code: null, stdout, stderr, timedOut: false, spawnError: (err as Error).message });
@@ -247,9 +250,18 @@ export function captureSfdt(args: string[], options: CaptureOptions = {}): Promi
     }
     const killChild = () => {
       try {
-        child.kill();
+        if (process.platform !== 'win32' && child.pid) {
+          // Negative pid = the whole process group (see `detached` above).
+          process.kill(-child.pid, 'SIGTERM');
+        } else {
+          child.kill();
+        }
       } catch {
-        /* already gone */
+        try {
+          child.kill();
+        } catch {
+          /* already gone */
+        }
       }
     };
     const onAbort = () => {

--- a/vscode/src/lib/run-json.ts
+++ b/vscode/src/lib/run-json.ts
@@ -1,0 +1,274 @@
+/**
+ * Native `--json` result capture for the sfdt CLI.
+ *
+ * `sfdt` commands that support `--json` emit an sf-native envelope on stdout:
+ * `{ status, result, warnings }` on success (`status` is the numeric exit
+ * code, `0` for success) and `{ status, name, message, exitCode, warnings }`
+ * on error. Stdout may also carry stray non-JSON lines from subprocesses, so
+ * the envelope is located defensively (brace-matched scan, last match wins).
+ *
+ * Deliberately free of any `vscode` import so the parsing/interpretation layer
+ * can be unit-tested under vitest. The impure spawn wrapper (`captureSfdt`)
+ * is kept separate from the pure functions (`parseEnvelope`,
+ * `interpretCapture`) so tests can feed canned stdout strings.
+ */
+
+import { spawn } from 'node:child_process';
+import { buildArgs } from './cli.js';
+
+/** The sf-native JSON envelope emitted by sfdt commands supporting `--json`. */
+export interface SfEnvelope {
+  /** Numeric exit code; `0` on success. */
+  status: number;
+  /** Command payload (success envelopes). */
+  result?: unknown;
+  warnings?: string[];
+  /** Error-envelope fields (present when `status` is non-zero). */
+  name?: string;
+  message?: string;
+  exitCode?: number;
+  data?: unknown;
+}
+
+/** Raw output of one CLI invocation, before interpretation. */
+export interface CaptureResult {
+  /** Process exit code; `null` when the process never ran or was killed. */
+  code: number | null;
+  stdout: string;
+  stderr: string;
+  timedOut: boolean;
+  /** Message from a spawn-level failure (e.g. binary not found). */
+  spawnError?: string;
+}
+
+/** Interpreted outcome of a native sfdt run. */
+export interface SfdtJsonRun<T = unknown> {
+  ok: boolean;
+  /** Envelope status when one was found, otherwise the process exit code. */
+  status: number;
+  result: T | null;
+  warnings: string[];
+  /** Combined raw stdout+stderr for diagnostics / the results channel. */
+  raw: string;
+  /** Human-readable failure description; unset when `ok`. */
+  error?: string;
+  /** True when no sf envelope was found on stdout. */
+  noEnvelope: boolean;
+  timedOut: boolean;
+}
+
+/**
+ * Return the balanced `{…}` substring starting at `start` (which must point at
+ * a `{`), or null when the braces never balance. String contents (including
+ * escaped quotes) are skipped so braces inside JSON strings don't miscount.
+ */
+function matchBraces(text: string, start: number): string | null {
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  for (let i = start; i < text.length; i++) {
+    const ch = text[i];
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (ch === '\\') escaped = true;
+      else if (ch === '"') inString = false;
+      continue;
+    }
+    if (ch === '"') inString = true;
+    else if (ch === '{') depth++;
+    else if (ch === '}') {
+      depth--;
+      if (depth === 0) return text.slice(start, i + 1);
+    }
+  }
+  return null;
+}
+
+function isEnvelope(value: unknown): value is SfEnvelope {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const v = value as Record<string, unknown>;
+  if (typeof v.status !== 'number') return false;
+  // Distinguish the sfdt envelope from stray JSON that happens to carry a
+  // numeric `status`: a success envelope always has `result`+`warnings`, an
+  // error envelope always has `message`+`warnings`.
+  return 'result' in v || typeof v.message === 'string' || Array.isArray(v.warnings);
+}
+
+/**
+ * Scan stdout for the sf-native envelope, tolerating stray non-JSON lines
+ * (subprocess noise, progress text) before, between, and after JSON objects.
+ * Candidates are brace-matched from each line that starts with `{`; the last
+ * object that looks like an envelope wins (sfdt emits its envelope last).
+ */
+export function parseEnvelope(stdout: string): SfEnvelope | null {
+  let found: SfEnvelope | null = null;
+  let offset = 0;
+  for (const line of stdout.split('\n')) {
+    const braceCol = line.indexOf('{');
+    if (braceCol !== -1 && line.slice(0, braceCol).trim() === '') {
+      const candidate = matchBraces(stdout, offset + braceCol);
+      if (candidate) {
+        try {
+          const parsed: unknown = JSON.parse(candidate);
+          if (isEnvelope(parsed)) found = parsed;
+        } catch {
+          // Stray brace / partial JSON — keep scanning.
+        }
+      }
+    }
+    offset += line.length + 1;
+  }
+  return found;
+}
+
+/** Last few non-empty lines of a blob, single-spaced, for compact errors. */
+function tail(text: string, lines = 4, maxChars = 400): string {
+  const picked = text
+    .split('\n')
+    .map((l) => l.trim())
+    .filter(Boolean)
+    .slice(-lines)
+    .join(' · ');
+  return picked.length > maxChars ? `${picked.slice(0, maxChars)}…` : picked;
+}
+
+export interface InterpretOptions {
+  /**
+   * When true (default) a missing envelope is a failure even on exit code 0 —
+   * the caller asked for `--json` and got none. Set false for commands that
+   * don't support `--json` (plain exit-code semantics).
+   */
+  expectEnvelope?: boolean;
+}
+
+/**
+ * Pure interpretation of a capture: locate the envelope, derive ok/error.
+ * Never throws — every path returns a typed run result.
+ */
+export function interpretCapture<T = unknown>(
+  cap: CaptureResult,
+  options: InterpretOptions = {},
+): SfdtJsonRun<T> {
+  const expectEnvelope = options.expectEnvelope !== false;
+  const raw = [cap.stdout, cap.stderr].filter((s) => s && s.trim()).join('\n').trim();
+  const base = { result: null, warnings: [] as string[], raw, noEnvelope: true, timedOut: false };
+
+  if (cap.spawnError) {
+    return { ...base, ok: false, status: -1, error: `Could not run the sfdt CLI: ${cap.spawnError}` };
+  }
+  if (cap.timedOut) {
+    return { ...base, ok: false, status: cap.code ?? -1, timedOut: true, error: 'sfdt timed out before completing' };
+  }
+
+  const envelope = parseEnvelope(cap.stdout);
+  if (envelope) {
+    const ok = envelope.status === 0;
+    return {
+      ok,
+      status: envelope.status,
+      result: (envelope.result ?? null) as T | null,
+      warnings: Array.isArray(envelope.warnings) ? envelope.warnings : [],
+      raw,
+      error: ok ? undefined : envelope.message || `sfdt exited with status ${envelope.status}`,
+      noEnvelope: false,
+      timedOut: false,
+    };
+  }
+
+  const code = cap.code ?? -1;
+  if (code === 0 && !expectEnvelope) {
+    return { ...base, ok: true, status: code };
+  }
+  const detail = tail(cap.stderr || cap.stdout);
+  return {
+    ...base,
+    ok: false,
+    status: code,
+    error:
+      code === 0
+        ? `sfdt produced no JSON result on stdout${detail ? ` (${detail})` : ''}`
+        : detail || `sfdt exited with code ${code}`,
+  };
+}
+
+export interface CaptureOptions {
+  /** Path to the sfdt binary (defaults to "sfdt" on PATH). */
+  cliPath?: string;
+  /** Working directory — typically the workspace folder root. */
+  cwd?: string;
+  /** Org alias appended as `--org <alias>` when set (see cli.ts buildArgs). */
+  org?: string;
+  /** Extra environment variables. */
+  env?: NodeJS.ProcessEnv;
+  /** Kill the process after this long (default 10 minutes — audits can be slow). */
+  timeoutMs?: number;
+}
+
+/**
+ * Spawn the sfdt CLI and capture its output with a timeout. Never rejects —
+ * spawn failures and timeouts are reported in the returned CaptureResult so
+ * the caller has a single code path.
+ */
+export function captureSfdt(args: string[], options: CaptureOptions = {}): Promise<CaptureResult> {
+  const { cliPath = 'sfdt', cwd, org, env, timeoutMs = 600_000 } = options;
+  const argv = buildArgs(args, org);
+  return new Promise((resolve) => {
+    let stdout = '';
+    let stderr = '';
+    let settled = false;
+    let child: ReturnType<typeof spawn>;
+    try {
+      child = spawn(cliPath, argv, {
+        cwd,
+        env: { ...process.env, SFDT_NON_INTERACTIVE: 'true', ...env },
+        shell: false,
+      });
+    } catch (err) {
+      resolve({ code: null, stdout, stderr, timedOut: false, spawnError: (err as Error).message });
+      return;
+    }
+    // finish() only fires from the timer or child events, both of which run
+    // strictly after `timer` is initialized below.
+    const finish = (r: CaptureResult) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(r);
+    };
+    const timer = setTimeout(() => {
+      try {
+        child.kill();
+      } catch {
+        /* already gone */
+      }
+      finish({ code: null, stdout, stderr, timedOut: true });
+    }, timeoutMs);
+    child.stdout?.on('data', (d) => (stdout += d.toString()));
+    child.stderr?.on('data', (d) => (stderr += d.toString()));
+    child.on('error', (err) => finish({ code: null, stdout, stderr, timedOut: false, spawnError: err.message }));
+    child.on('close', (code) => finish({ code: code ?? 0, stdout, stderr, timedOut: false }));
+  });
+}
+
+export interface RunJsonOptions extends CaptureOptions {
+  /**
+   * Whether the command supports `--json` (default true). When false the flag
+   * is not appended and the run is interpreted by exit code alone.
+   */
+  json?: boolean;
+}
+
+/**
+ * Run an sfdt command natively and return the interpreted result. Appends
+ * `--json` (unless `json: false` or already present), captures with a
+ * timeout, and parses the envelope defensively. Never rejects.
+ */
+export async function runSfdtForResult<T = unknown>(
+  args: string[],
+  options: RunJsonOptions = {},
+): Promise<SfdtJsonRun<T>> {
+  const { json = true, ...capture } = options;
+  const argv = json && !args.includes('--json') ? [...args, '--json'] : args;
+  const cap = await captureSfdt(argv, capture);
+  return interpretCapture<T>(cap, { expectEnvelope: json });
+}

--- a/vscode/src/lib/smart-deploy-output.ts
+++ b/vscode/src/lib/smart-deploy-output.ts
@@ -12,7 +12,7 @@
  * vitest against canned CLI output.
  */
 
-import { buildTerminalCommand, shellQuote } from './terminal.js';
+import { shellQuote } from './terminal.js';
 
 /** Remove ANSI escape sequences (colors survive capture when forced). */
 export function stripAnsi(text: string): string {
@@ -163,8 +163,6 @@ export function isValidationJobId(id: string): boolean {
 }
 
 export interface QuickDeployCommandOptions {
-  /** Path to the sfdt binary (defaults to "sfdt" on PATH). */
-  cliPath?: string;
   /** Target org alias. */
   org?: string;
   /** The validated deploy request ID (0Af…). */
@@ -174,22 +172,28 @@ export interface QuickDeployCommandOptions {
 /**
  * Build the terminal command line for a Quick Deploy.
  *
- * The CLI's quick-deploy path lives in `deployment-assistant.sh`, which only
- * reads `SFDT_VALIDATION_JOB_ID` on its non-interactive branch — and the CLI's
- * script runner derives `SFDT_NON_INTERACTIVE` from whether stdin is a TTY.
- * So the command (a) env-prefixes `SFDT_VALIDATION_JOB_ID` (and
- * `SFDT_TARGET_ORG`, which passes through the script runner untouched), and
- * (b) redirects stdin from /dev/null to force the non-interactive branch
- * while output still streams to the visible terminal.
+ * This deliberately targets the sf CLI directly (`sf project deploy quick`)
+ * instead of routing through the sfdt CLI's `deployment-assistant.sh`. That
+ * script path cannot promote a smart-deploy validation job:
  *
- * POSIX-shell syntax (bash/zsh/fish-compatible enough): env prefixes and
- * `< /dev/null` do not work in PowerShell/cmd — the caller should warn on
- * Windows rather than attempt shell detection.
+ * - its quick-deploy confirmation `read` is NOT gated on
+ *   `SFDT_NON_INTERACTIVE`, so under the script's `set -euo pipefail` a
+ *   non-TTY stdin (EOF) aborts the run with exit 1 before the deploy starts;
+ * - its non-interactive branch requires a version-named release manifest
+ *   under `manifest/release/` (the smart validate's manifest lives in a temp
+ *   dir the CLI deletes after the run), exiting 1 when none exists — and when
+ *   an unrelated older release manifest does exist, a successful quick deploy
+ *   would archive it as "deployed" and tag from its version.
+ *
+ * Quick Deploy is a single sf command with no sfdt-side computation, so
+ * invoking sf directly (as the extension already does for `sf org list` /
+ * `sf org display`) stays within the thin-UI rule without inheriting the
+ * release-flow side effects. Plain argv (no env prefixes, no redirects) also
+ * works in every shell, PowerShell/cmd included.
  */
 export function buildQuickDeployCommand(options: QuickDeployCommandOptions): string {
-  const { cliPath = 'sfdt', org, jobId } = options;
-  const env = [`SFDT_VALIDATION_JOB_ID=${shellQuote(jobId)}`];
-  if (org) env.push(`SFDT_TARGET_ORG=${shellQuote(org)}`);
-  const base = buildTerminalCommand(['deploy'], { cliPath, org });
-  return `${env.join(' ')} ${base} < /dev/null`;
+  const { org, jobId } = options;
+  const argv = ['sf', 'project', 'deploy', 'quick', '--job-id', jobId];
+  if (org) argv.push('--target-org', org);
+  return argv.map(shellQuote).join(' ');
 }

--- a/vscode/src/lib/smart-deploy-output.ts
+++ b/vscode/src/lib/smart-deploy-output.ts
@@ -1,0 +1,195 @@
+/**
+ * Parsing helpers for `sfdt deploy --smart` output, plus the Quick Deploy
+ * terminal-command builder.
+ *
+ * `sfdt deploy` has no `--json` mode, so the extension captures the CLI's
+ * textual output from `sfdt deploy --smart --dry-run` and parses the summary
+ * lines the CLI prints (see `runSmartDeploy` in the CLI's
+ * `src/commands/deploy.js`). This module only *reads* what the CLI reported —
+ * it never recomputes deltas or test levels itself (thin-UI rule).
+ *
+ * Deliberately free of any `vscode` import so it can be unit-tested under
+ * vitest against canned CLI output.
+ */
+
+import { buildTerminalCommand, shellQuote } from './terminal.js';
+
+/** Remove ANSI escape sequences (colors survive capture when forced). */
+export function stripAnsi(text: string): string {
+  return text.replace(/\u001B\[[0-9;]*[A-Za-z]/g, '');
+}
+
+/** Parsed view of one `sfdt deploy --smart --dry-run` run's output. */
+export interface SmartDeploySummary {
+  /** Base git ref from the "Smart deploy (base...head)" header. */
+  base?: string;
+  /** Head git ref from the header. */
+  head?: string;
+  /** Target org alias, as the CLI resolved and reported it. */
+  org?: string;
+  /** True when the output flagged the org as `[PRODUCTION]` anywhere. */
+  production: boolean;
+  /** Additive component count from the "Delta:" line; null when not printed. */
+  addCount: number | null;
+  /** Destructive component count from the "Delta:" line; null when not printed. */
+  delCount: number | null;
+  /** Count from the "Overwrite-protected (skipped):" line (0 when absent). */
+  overwriteProtected: number;
+  /** Count of changed files the CLI could not map to a metadata type. */
+  unmappedCount: number;
+  /** Chosen test level (e.g. RunLocalTests, RunSpecifiedTests). */
+  testLevel?: string;
+  /** Specified test classes when testLevel is RunSpecifiedTests. */
+  tests: string[];
+  /** The CLI's stated reason for the test level. */
+  testReason?: string;
+  /** True when the CLI reported no metadata changes between the refs. */
+  noChanges: boolean;
+  /** True when the validate/deploy step reported success. */
+  succeeded: boolean;
+  /** True when the CLI reported a failure (deploy, preflight, or setup). */
+  failed: boolean;
+  /** Human-readable failure detail when one was printed. */
+  failureDetail?: string;
+}
+
+// Exact shapes printed by the CLI's runSmartDeploy (src/commands/deploy.js):
+//   Smart deploy (main...HEAD) → myorg [PRODUCTION] [validate]
+//   Delta: 3 additive, 1 destructive component(s).
+//   Overwrite-protected (skipped): 2 component(s).
+//   Test level: RunSpecifiedTests (FooTest, BarTest) — only Apex test classes changed
+//   2 changed file(s) could not be mapped to a metadata type (skipped).
+//   No metadata changes detected between refs — nothing to deploy.
+//   Validation succeeded — no changes applied.
+//   Smart deploy completed successfully.
+//   Smart deploy failed.
+//   Preflight failed — aborting deploy: <message>
+//   Deployment failed: <message>
+const HEADER_RE = /^Smart deploy \((.+?)\.\.\.(.+?)\) → (.+?)( \[PRODUCTION\])?( \[validate\])?$/;
+const DELTA_RE = /^Delta: (\d+) additive, (\d+) destructive component\(s\)\.$/;
+const PROTECTED_RE = /^Overwrite-protected \(skipped\): (\d+) component\(s\)\.$/;
+const TEST_LEVEL_RE = /^Test level: (\S+?)(?: \(([^)]*)\))? — (.+)$/;
+const UNMAPPED_RE = /^(\d+) changed file\(s\) could not be mapped to a metadata type \(skipped\)\.$/;
+const NO_CHANGES_RE = /^No metadata changes detected between refs — nothing to deploy\.$/;
+const SUCCESS_RE = /^(?:Validation succeeded — no changes applied\.|Smart deploy completed successfully\.)$/;
+const FAILED_RE = /^Smart deploy failed\.$/;
+const PREFLIGHT_FAIL_RE = /^Preflight failed — aborting deploy: (.+)$/;
+const DEPLOY_FAIL_RE = /^Deployment failed: (.+)$/;
+
+/**
+ * Parse the captured stdout(+stderr) of `sfdt deploy --smart --dry-run` into a
+ * structured summary. Tolerates ANSI colors, the CLI's two-space indentation,
+ * header rules, and stray subprocess lines — unrecognised lines are skipped.
+ */
+export function parseSmartDeployOutput(output: string): SmartDeploySummary {
+  const summary: SmartDeploySummary = {
+    production: false,
+    addCount: null,
+    delCount: null,
+    overwriteProtected: 0,
+    unmappedCount: 0,
+    tests: [],
+    noChanges: false,
+    succeeded: false,
+    failed: false,
+  };
+  const clean = stripAnsi(output ?? '');
+  for (const raw of clean.split('\n')) {
+    const line = raw.trim();
+    if (!line) continue;
+    let m: RegExpMatchArray | null;
+    if ((m = line.match(HEADER_RE))) {
+      summary.base = m[1];
+      summary.head = m[2];
+      summary.org = m[3];
+      if (m[4]) summary.production = true;
+    } else if ((m = line.match(DELTA_RE))) {
+      summary.addCount = Number(m[1]);
+      summary.delCount = Number(m[2]);
+    } else if ((m = line.match(PROTECTED_RE))) {
+      summary.overwriteProtected = Number(m[1]);
+    } else if ((m = line.match(TEST_LEVEL_RE))) {
+      summary.testLevel = m[1];
+      summary.tests = m[2] ? m[2].split(',').map((t) => t.trim()).filter(Boolean) : [];
+      summary.testReason = m[3];
+    } else if ((m = line.match(UNMAPPED_RE))) {
+      summary.unmappedCount = Number(m[1]);
+    } else if (NO_CHANGES_RE.test(line)) {
+      summary.noChanges = true;
+    } else if (SUCCESS_RE.test(line)) {
+      summary.succeeded = true;
+    } else if (FAILED_RE.test(line)) {
+      summary.failed = true;
+    } else if ((m = line.match(PREFLIGHT_FAIL_RE)) || (m = line.match(DEPLOY_FAIL_RE))) {
+      summary.failed = true;
+      if (!summary.failureDetail) summary.failureDetail = m[1];
+    }
+  }
+  // Belt-and-braces: the org marker is the production signal the confirm
+  // dialog keys off, so honour it wherever it appeared in the raw output.
+  if (clean.includes('[PRODUCTION]')) summary.production = true;
+  return summary;
+}
+
+/** Human-readable lines describing a parsed summary (for pickers/dialogs). */
+export function summaryLines(summary: SmartDeploySummary): string[] {
+  const lines: string[] = [];
+  if (summary.org) lines.push(`Org: ${summary.org}${summary.production ? '  ⚠ PRODUCTION' : ''}`);
+  if (summary.base && summary.head) lines.push(`Delta range: ${summary.base}...${summary.head}`);
+  if (summary.noChanges) {
+    lines.push('No metadata changes detected — nothing to deploy.');
+    return lines;
+  }
+  if (summary.addCount !== null && summary.delCount !== null) {
+    lines.push(`Delta: ${summary.addCount} additive, ${summary.delCount} destructive component(s)`);
+  }
+  if (summary.testLevel) {
+    const tests = summary.tests.length ? ` (${summary.tests.join(', ')})` : '';
+    lines.push(`Test level: ${summary.testLevel}${tests}${summary.testReason ? ` — ${summary.testReason}` : ''}`);
+  }
+  if (summary.overwriteProtected > 0) lines.push(`Overwrite-protected (skipped): ${summary.overwriteProtected} component(s)`);
+  if (summary.unmappedCount > 0) lines.push(`Unmapped changed files (skipped): ${summary.unmappedCount}`);
+  if (summary.failed) lines.push(`Validation failed${summary.failureDetail ? `: ${summary.failureDetail}` : ''}`);
+  return lines;
+}
+
+/**
+ * Validate a Salesforce deploy-request (validation job) ID: `0Af` prefix,
+ * 15 or 18 alphanumeric characters total — the shape `sf project deploy
+ * quick --job-id` accepts and the CLI's quick-deploy path expects.
+ */
+export function isValidationJobId(id: string): boolean {
+  return /^0Af[A-Za-z0-9]{12}(?:[A-Za-z0-9]{3})?$/.test(id);
+}
+
+export interface QuickDeployCommandOptions {
+  /** Path to the sfdt binary (defaults to "sfdt" on PATH). */
+  cliPath?: string;
+  /** Target org alias. */
+  org?: string;
+  /** The validated deploy request ID (0Af…). */
+  jobId: string;
+}
+
+/**
+ * Build the terminal command line for a Quick Deploy.
+ *
+ * The CLI's quick-deploy path lives in `deployment-assistant.sh`, which only
+ * reads `SFDT_VALIDATION_JOB_ID` on its non-interactive branch — and the CLI's
+ * script runner derives `SFDT_NON_INTERACTIVE` from whether stdin is a TTY.
+ * So the command (a) env-prefixes `SFDT_VALIDATION_JOB_ID` (and
+ * `SFDT_TARGET_ORG`, which passes through the script runner untouched), and
+ * (b) redirects stdin from /dev/null to force the non-interactive branch
+ * while output still streams to the visible terminal.
+ *
+ * POSIX-shell syntax (bash/zsh/fish-compatible enough): env prefixes and
+ * `< /dev/null` do not work in PowerShell/cmd — the caller should warn on
+ * Windows rather than attempt shell detection.
+ */
+export function buildQuickDeployCommand(options: QuickDeployCommandOptions): string {
+  const { cliPath = 'sfdt', org, jobId } = options;
+  const env = [`SFDT_VALIDATION_JOB_ID=${shellQuote(jobId)}`];
+  if (org) env.push(`SFDT_TARGET_ORG=${shellQuote(org)}`);
+  const base = buildTerminalCommand(['deploy'], { cliPath, org });
+  return `${env.join(' ')} ${base} < /dev/null`;
+}

--- a/vscode/src/lib/snapshots.ts
+++ b/vscode/src/lib/snapshots.ts
@@ -30,6 +30,14 @@ export interface TreeNode {
   status?: CheckStatus;
   /** A run-able sfdt command (palette/inline), e.g. ['audit','mfa']. */
   command?: string[];
+  /** Rich hover text; the tree layer falls back to the command when unset. */
+  tooltip?: string;
+  /**
+   * Set on a section node that renders an audit/monitor snapshot, enabling
+   * snapshot-level actions (e.g. "Send snapshot to channels"). Only present
+   * when a snapshot actually exists to send.
+   */
+  snapshotType?: 'audit' | 'monitor';
   children?: TreeNode[];
 }
 
@@ -63,17 +71,21 @@ function sectionFromSnapshot(id: string, label: string, snap: Snapshot | null, r
       children: [{ id: `${id}.empty`, label: 'Run to populate…', command: runAll }],
     };
   }
+  const head = runAll[0];
+  const snapshotType = head === 'audit' || head === 'monitor' ? head : undefined;
   return {
     id,
     label,
     description: `${snap.summary.warn + snap.summary.fail + snap.summary.error} issue(s) · ${snap.org}`,
     status: rollupStatus(snap.checks),
+    snapshotType,
     children: snap.checks.map((c) => ({
       id: `${id}.${c.id}`,
       label: c.title,
       description: c.summary,
       status: c.status,
       command: [...runAll.slice(0, 1), c.id],
+      tooltip: `${c.title} [${c.status}]\n${c.summary}\n\nRun: sfdt ${runAll[0]} ${c.id}`,
       children: c.findings.slice(0, 25).map((f, i) => ({
         id: `${id}.${c.id}.${i}`,
         label: describeFinding(f),

--- a/vscode/src/tree.ts
+++ b/vscode/src/tree.ts
@@ -47,6 +47,12 @@ export class OrgHealthProvider implements vscode.TreeDataProvider<TreeNode> {
       };
       item.tooltip = `Run: sfdt ${node.command.join(' ')}`;
     }
+    // A richer per-check tooltip (title, status, summary) wins over the
+    // generic "Run: …" hover when the snapshot layer provides one.
+    if (node.tooltip) item.tooltip = node.tooltip;
+    // Snapshot section nodes expose "Send snapshot to channels" via the
+    // context/inline menu (see package.json view/item/context).
+    if (node.snapshotType) item.contextValue = `sfdtHealthSnapshot.${node.snapshotType}`;
     return item;
   }
 

--- a/vscode/test/commands.test.ts
+++ b/vscode/test/commands.test.ts
@@ -49,8 +49,61 @@ describe('COMMAND_GROUPS', () => {
     }
   });
 
-  it('surfaces the full CLI breadth (>= 30 runnable leaves)', () => {
-    expect(flattenCommands().length).toBeGreaterThanOrEqual(30);
+  it('surfaces the full CLI breadth (>= 80 runnable leaves)', () => {
+    expect(flattenCommands().length).toBeGreaterThanOrEqual(80);
+  });
+
+  it('covers the ci init provider/type matrix', () => {
+    for (const provider of ['github', 'gitlab', 'azure', 'bitbucket']) {
+      for (const type of ['monitor', 'deploy']) {
+        expect(findCommand(`ci-init-${provider}-${type}`)?.args).toEqual([
+          'ci', 'init', '--provider', provider, '--type', type,
+        ]);
+      }
+    }
+  });
+
+  it('covers the feature-flags family', () => {
+    expect(findCommand('feature-flags-list')?.args).toEqual(['feature-flags', 'list']);
+    expect(findCommand('feature-flags-clear')?.args).toEqual(['feature-flags', 'clear']);
+    // disable/enable need a <featureId> the user appends in the terminal.
+    expect(findCommand('feature-flags-disable')?.argsIncomplete).toBe(true);
+    expect(findCommand('feature-flags-enable')?.argsIncomplete).toBe(true);
+  });
+
+  it('covers config get/set as incomplete-args terminal commands', () => {
+    expect(findCommand('config-get')?.args).toEqual(['config', 'get']);
+    expect(findCommand('config-get')?.argsIncomplete).toBe(true);
+    expect(findCommand('config-set')?.args).toEqual(['config', 'set']);
+    expect(findCommand('config-set')?.argsIncomplete).toBe(true);
+  });
+
+  it('covers the generic notify, pr-description, and ai prompt entries', () => {
+    expect(findCommand('notify')?.args).toEqual(['notify']);
+    expect(findCommand('notify')?.argsIncomplete).toBe(true);
+    expect(findCommand('pr-description')?.args).toEqual(['pr-description']);
+    expect(findCommand('ai-prompt')?.args).toEqual(['ai', 'prompt']);
+    expect(findCommand('ai-prompt')?.argsIncomplete).toBe(true);
+  });
+
+  it('every incomplete-args entry still carries a runnable prefix', () => {
+    for (const leaf of flattenCommands()) {
+      if (leaf.argsIncomplete) {
+        expect(leaf.args && leaf.args.length > 0, `${leaf.id} needs an args prefix`).toBe(true);
+      }
+    }
+  });
+
+  it('marks commands whose CLI takes no --org flag as noOrg', () => {
+    // These CLI commands reject --org with "unknown option" (exit 1), so the
+    // extension must not inject the configured sfdt.defaultOrg.
+    for (const id of ['doctor', 'init', 'feature-flags-list', 'feature-flags-clear']) {
+      expect(findCommand(id)?.noOrg, `${id} should be noOrg`).toBe(true);
+    }
+    // Org-scoped commands must keep --org injection.
+    for (const id of ['audit', 'monitor-limits', 'deploy', 'notify-monitor', 'ci-init-github-monitor']) {
+      expect(findCommand(id)?.noOrg, `${id} should keep --org injection`).toBeUndefined();
+    }
   });
 
   it('marks org/repo-mutating commands destructive', () => {

--- a/vscode/test/diagnostics.test.ts
+++ b/vscode/test/diagnostics.test.ts
@@ -1,0 +1,268 @@
+import { describe, it, expect } from 'vitest';
+import {
+  severityFor,
+  qualityFromRun,
+  qualityFromSnapshot,
+  qualityToDiagnostics,
+  groupByFile,
+  type DiagnosticEntry,
+  type QualityLogEnvelope,
+} from '../src/lib/diagnostics.js';
+import type { QualityResult } from '../src/lib/render-summary.js';
+import type { SfdtJsonRun } from '../src/lib/run-json.js';
+
+const ROOT = '/work/my-sf-project';
+
+function quality(violations: QualityResult['violations'], status = 'FAIL'): QualityResult {
+  return { status, summary: { critical: 0, high: 0, medium: 0, low: 0 }, violations };
+}
+
+function run(extra: Partial<SfdtJsonRun> = {}): SfdtJsonRun {
+  return { ok: true, status: 0, result: null, warnings: [], raw: '', noEnvelope: true, timedOut: false, ...extra };
+}
+
+describe('severityFor', () => {
+  it('maps scanner severity 1 to error, 2 to warning, 3+ to info', () => {
+    expect(severityFor(1)).toBe('error');
+    expect(severityFor(2)).toBe('warning');
+    expect(severityFor(3)).toBe('info');
+    expect(severityFor(4)).toBe('info');
+    expect(severityFor(5)).toBe('info');
+  });
+
+  it('treats a missing severity as info', () => {
+    expect(severityFor(undefined)).toBe('info');
+  });
+});
+
+describe('qualityToDiagnostics', () => {
+  it('maps violations to entries with source/code and resolved paths', () => {
+    const result = quality([
+      { file: 'force-app/main/default/classes/Foo.cls', line: 12, rule: 'ApexCRUDViolation', severity: 1, message: 'CRUD check missing' },
+      { file: 'force-app/main/default/classes/Bar.cls', line: 3, rule: 'EmptyCatchBlock', severity: 2, message: 'Empty catch' },
+      { file: 'force-app/main/default/classes/Baz.cls', line: 7, rule: 'ExcessiveParameterList', severity: 3, message: 'Too many params' },
+    ]);
+    const entries = qualityToDiagnostics(result, ROOT);
+    expect(entries).toEqual([
+      {
+        file: `${ROOT}/force-app/main/default/classes/Foo.cls`,
+        line: 12,
+        severity: 'error',
+        message: 'CRUD check missing',
+        source: 'sfdt',
+        code: 'ApexCRUDViolation',
+      },
+      {
+        file: `${ROOT}/force-app/main/default/classes/Bar.cls`,
+        line: 3,
+        severity: 'warning',
+        message: 'Empty catch',
+        source: 'sfdt',
+        code: 'EmptyCatchBlock',
+      },
+      {
+        file: `${ROOT}/force-app/main/default/classes/Baz.cls`,
+        line: 7,
+        severity: 'info',
+        message: 'Too many params',
+        source: 'sfdt',
+        code: 'ExcessiveParameterList',
+      },
+    ]);
+  });
+
+  it('keeps absolute scanner paths as-is (normalized)', () => {
+    const abs = `${ROOT}/force-app/main/default/classes/Abs.cls`;
+    const entries = qualityToDiagnostics(
+      quality([{ file: `${ROOT}/force-app/main/default/classes/../classes/Abs.cls`, line: 1, rule: 'R', severity: 2, message: 'm' }]),
+      ROOT,
+    );
+    expect(entries).toHaveLength(1);
+    expect(entries[0].file).toBe(abs);
+  });
+
+  it('skips violations without a usable file path', () => {
+    const entries = qualityToDiagnostics(
+      quality([
+        { file: '', line: 1, rule: 'R', severity: 1, message: 'no file' },
+        { file: '   ', line: 2, rule: 'R', severity: 1, message: 'blank file' },
+        { line: 3, rule: 'R', severity: 1, message: 'missing file' },
+        { file: 'classes/Ok.cls', line: 4, rule: 'R', severity: 1, message: 'kept' },
+      ]),
+      ROOT,
+    );
+    expect(entries).toHaveLength(1);
+    expect(entries[0].message).toBe('kept');
+  });
+
+  it('skips relative paths when no workspace root is available', () => {
+    const abs = '/elsewhere/classes/Abs.cls';
+    const entries = qualityToDiagnostics(
+      quality([
+        { file: 'classes/Rel.cls', line: 1, rule: 'R', severity: 1, message: 'relative' },
+        { file: abs, line: 2, rule: 'R', severity: 1, message: 'absolute' },
+      ]),
+      undefined,
+    );
+    expect(entries).toHaveLength(1);
+    expect(entries[0].file).toBe(abs);
+  });
+
+  it('returns an empty list for a SKIPPED scan', () => {
+    const skipped: QualityResult = {
+      status: 'SKIPPED',
+      summary: { critical: 0, high: 0, medium: 0, low: 0 },
+      violations: [{ file: 'classes/Foo.cls', line: 1, rule: 'R', severity: 1, message: 'ignored' }],
+      unavailableMessage: 'scanner not installed',
+    };
+    expect(qualityToDiagnostics(skipped, ROOT)).toEqual([]);
+  });
+
+  it('returns an empty list for null/undefined results and missing violations', () => {
+    expect(qualityToDiagnostics(null, ROOT)).toEqual([]);
+    expect(qualityToDiagnostics(undefined, ROOT)).toEqual([]);
+    expect(qualityToDiagnostics({ status: 'PASS' } as QualityResult, ROOT)).toEqual([]);
+  });
+
+  it('clamps missing or bogus line numbers to 1', () => {
+    const entries = qualityToDiagnostics(
+      quality([
+        { file: 'a.cls', rule: 'R', severity: 1, message: 'no line' },
+        { file: 'b.cls', line: 0, rule: 'R', severity: 1, message: 'zero' },
+        { file: 'c.cls', line: -4, rule: 'R', severity: 1, message: 'negative' },
+        { file: 'd.cls', line: 2.7, rule: 'R', severity: 1, message: 'fractional' },
+      ]),
+      ROOT,
+    );
+    expect(entries.map((e) => e.line)).toEqual([1, 1, 1, 2]);
+  });
+
+  it('falls back to the rule name when the message is empty', () => {
+    const entries = qualityToDiagnostics(
+      quality([{ file: 'a.cls', line: 1, rule: 'ApexDoc', severity: 3, message: '' }]),
+      ROOT,
+    );
+    expect(entries[0].message).toBe('ApexDoc');
+    expect(entries[0].code).toBe('ApexDoc');
+  });
+});
+
+/** logs/quality-latest.json envelope as written by src/lib/log-writer.js. */
+function snapshotEnvelope(data: QualityResult, timestamp = '2026-07-04T10:00:00.000Z'): QualityLogEnvelope {
+  return { schemaVersion: '1', type: 'quality', timestamp, data };
+}
+
+/**
+ * What `sfdt quality` actually prints on a real violations run today: chalk
+ * chrome only — the scanner JSON is captured internally by quality.js and
+ * never re-emitted. There is nothing parseable here by design.
+ */
+const REAL_CLI_VIOLATIONS_RUN_STDOUT = [
+  '\u001b[1mQuality Analysis\u001b[22m',
+  'Running Code Analyzer...',
+  '\u001b[32m✔ Code Analyzer completed.\u001b[39m',
+].join('\n');
+
+describe('qualityFromRun', () => {
+  it('prefers a structured envelope result carrying violations', () => {
+    const result = quality([{ file: 'a.cls', line: 1, rule: 'R', severity: 1, message: 'm' }]);
+    expect(qualityFromRun(run({ result, noEnvelope: false }))).toBe(result);
+  });
+
+  it('returns null for a real violations run (chrome-only stdout) with no snapshot', () => {
+    // The caller must then CLEAR previously published diagnostics — see
+    // extension.ts runNative — never keep stale ones or fabricate a result.
+    expect(qualityFromRun(run({ raw: REAL_CLI_VIOLATIONS_RUN_STDOUT }))).toBeNull();
+  });
+
+  it('parses the CLI skip warning the real CLI does print on stdout', () => {
+    const raw = `${REAL_CLI_VIOLATIONS_RUN_STDOUT}\n\u001b[33mCode Analyzer: static violation scan was SKIPPED — sf code-analyzer not installed.\u001b[39m`;
+    const parsed = qualityFromRun(run({ raw }));
+    expect(parsed?.status).toBe('SKIPPED');
+  });
+
+  it('parses scanner JSON out of raw output when a CLI version surfaces it', () => {
+    const raw = [
+      'Running scanner…',
+      JSON.stringify({ result: [{ fileName: 'classes/Foo.cls', violations: [{ line: 5, ruleName: 'EmptyCatchBlock', severity: 2, message: 'Empty catch' }] }] }),
+    ].join('\n');
+    const parsed = qualityFromRun(run({ raw }));
+    expect(parsed?.status).toBe('FAIL');
+    expect(parsed?.violations).toEqual([
+      { file: 'classes/Foo.cls', line: 5, rule: 'EmptyCatchBlock', severity: 2, message: 'Empty catch' },
+    ]);
+  });
+
+  it('falls back to a quality snapshot written during the run', () => {
+    const data = quality([{ file: 'classes/Foo.cls', line: 5, rule: 'R', severity: 2, message: 'm' }]);
+    const parsed = qualityFromRun(run({ raw: REAL_CLI_VIOLATIONS_RUN_STDOUT }), {
+      snapshot: snapshotEnvelope(data, '2026-07-04T10:00:05.000Z'),
+      since: '2026-07-04T10:00:00.000Z',
+    });
+    expect(parsed).toBe(data);
+  });
+
+  it('ignores a snapshot written before the run started (stale scan data)', () => {
+    const data = quality([{ file: 'classes/Old.cls', line: 1, rule: 'R', severity: 1, message: 'old' }]);
+    const parsed = qualityFromRun(run({ raw: REAL_CLI_VIOLATIONS_RUN_STDOUT }), {
+      snapshot: snapshotEnvelope(data, '2026-07-03T10:00:00.000Z'),
+      since: '2026-07-04T10:00:00.000Z',
+    });
+    expect(parsed).toBeNull();
+  });
+
+  it('returns null when no source has a quality shape', () => {
+    expect(qualityFromRun(run({ raw: 'plain text output' }))).toBeNull();
+  });
+});
+
+describe('qualityFromSnapshot', () => {
+  const data = quality([{ file: 'classes/Foo.cls', line: 5, rule: 'R', severity: 2, message: 'm' }]);
+
+  it('accepts a quality envelope and returns its data payload', () => {
+    expect(qualityFromSnapshot(snapshotEnvelope(data))).toBe(data);
+  });
+
+  it('accepts any timestamp when no since gate is given', () => {
+    expect(qualityFromSnapshot(snapshotEnvelope(data, '2020-01-01T00:00:00.000Z'))).toBe(data);
+  });
+
+  it('rejects envelopes of another type, malformed payloads, and non-objects', () => {
+    expect(qualityFromSnapshot({ ...snapshotEnvelope(data), type: 'preflight' })).toBeNull();
+    expect(qualityFromSnapshot({ schemaVersion: '1', type: 'quality', data: { status: 'PASS' } })).toBeNull();
+    expect(qualityFromSnapshot(null)).toBeNull();
+    expect(qualityFromSnapshot('garbage')).toBeNull();
+    expect(qualityFromSnapshot([snapshotEnvelope(data)])).toBeNull();
+  });
+
+  it('rejects a stale or untimestamped envelope when since is given', () => {
+    expect(
+      qualityFromSnapshot(snapshotEnvelope(data, '2026-07-04T09:59:59.000Z'), { since: '2026-07-04T10:00:00.000Z' }),
+    ).toBeNull();
+    expect(
+      qualityFromSnapshot({ schemaVersion: '1', type: 'quality', data }, { since: '2026-07-04T10:00:00.000Z' }),
+    ).toBeNull();
+  });
+
+  it('accepts an envelope written at or after since', () => {
+    expect(
+      qualityFromSnapshot(snapshotEnvelope(data, '2026-07-04T10:00:00.000Z'), { since: '2026-07-04T10:00:00.000Z' }),
+    ).toBe(data);
+  });
+});
+
+describe('groupByFile', () => {
+  it('buckets entries per absolute path, preserving order', () => {
+    const a1: DiagnosticEntry = { file: '/r/a.cls', line: 1, severity: 'error', message: '1', source: 'sfdt', code: 'R' };
+    const b1: DiagnosticEntry = { file: '/r/b.cls', line: 2, severity: 'info', message: '2', source: 'sfdt', code: 'R' };
+    const a2: DiagnosticEntry = { file: '/r/a.cls', line: 3, severity: 'warning', message: '3', source: 'sfdt', code: 'R' };
+    const grouped = groupByFile([a1, b1, a2]);
+    expect([...grouped.keys()]).toEqual(['/r/a.cls', '/r/b.cls']);
+    expect(grouped.get('/r/a.cls')).toEqual([a1, a2]);
+    expect(grouped.get('/r/b.cls')).toEqual([b1]);
+  });
+
+  it('returns an empty map for no entries', () => {
+    expect(groupByFile([]).size).toBe(0);
+  });
+});

--- a/vscode/test/render-summary.test.ts
+++ b/vscode/test/render-summary.test.ts
@@ -1,0 +1,418 @@
+import { describe, it, expect } from 'vitest';
+import {
+  renderSummary,
+  parsePreflightChecks,
+  parseQualityOutput,
+  nativeSpecFor,
+  NATIVE_COMMANDS,
+} from '../src/lib/render-summary.js';
+import type { SfdtJsonRun } from '../src/lib/run-json.js';
+import { flattenCommands } from '../src/lib/commands.js';
+
+function okRun(result: unknown, extra: Partial<SfdtJsonRun> = {}): SfdtJsonRun {
+  return { ok: true, status: 0, result, warnings: [], raw: '', noEnvelope: false, timedOut: false, ...extra };
+}
+
+function failRun(error: string, extra: Partial<SfdtJsonRun> = {}): SfdtJsonRun {
+  return {
+    ok: false,
+    status: 1,
+    result: null,
+    warnings: [],
+    raw: 'some raw output\nlast line',
+    error,
+    noEnvelope: false,
+    timedOut: false,
+    ...extra,
+  };
+}
+
+/** Snapshot shape produced by audit-runner/monitor-runner. */
+const auditSnapshot = {
+  timestamp: '2026-07-04T10:00:00.000Z',
+  org: 'devhub',
+  checks: [
+    {
+      id: 'mfa',
+      title: 'MFA Coverage',
+      status: 'fail',
+      summary: '4 users without MFA',
+      findings: [
+        { username: 'a@x.com' },
+        { username: 'b@x.com' },
+        { username: 'c@x.com' },
+        { username: 'd@x.com' },
+        { username: 'e@x.com' },
+        { username: 'f@x.com' },
+      ],
+    },
+    { id: 'licenses', title: 'License Usage', status: 'warn', summary: '1 license near limit', findings: [] },
+    { id: 'audittrail', title: 'Setup Audit Trail', status: 'ok', summary: 'no suspicious activity', findings: [] },
+  ],
+  summary: { total: 3, ok: 1, warn: 1, fail: 1, error: 0 },
+};
+
+describe('renderSummary — audit/monitor snapshots', () => {
+  it('renders counts, issue checks, and top findings', () => {
+    const s = renderSummary('audit', okRun(auditSnapshot));
+    expect(s.title).toBe('Org Audit — devhub');
+    expect(s.severity).toBe('error');
+    expect(s.headline).toContain('1 fail');
+    expect(s.headline).toContain('devhub');
+    expect(s.markdown).toContain('**Checks:** 1 ok · 1 warn · 1 fail · 0 error');
+    expect(s.markdown).toContain('### FAIL · MFA Coverage');
+    expect(s.markdown).toContain('4 users without MFA');
+    // Findings are capped at 5 with a "+n more" marker.
+    expect(s.markdown).toContain('… +1 more');
+    // Passing checks are listed compactly.
+    expect(s.markdown).toContain('- Setup Audit Trail — no suspicious activity');
+  });
+
+  it('orders attention section worst-first (fail before warn)', () => {
+    const s = renderSummary('audit', okRun(auditSnapshot));
+    const failIdx = s.markdown.indexOf('FAIL · MFA Coverage');
+    const warnIdx = s.markdown.indexOf('WARN · License Usage');
+    expect(failIdx).toBeGreaterThan(-1);
+    expect(warnIdx).toBeGreaterThan(failIdx);
+  });
+
+  it('is info severity with an all-clear headline when everything passes', () => {
+    const clean = {
+      ...auditSnapshot,
+      checks: [auditSnapshot.checks[2]],
+      summary: { total: 1, ok: 1, warn: 0, fail: 0, error: 0 },
+    };
+    const s = renderSummary('monitor', okRun(clean));
+    expect(s.severity).toBe('info');
+    expect(s.title).toBe('Org Monitor — devhub');
+    expect(s.headline).toContain('all 1 checks passed');
+  });
+
+  it('is warn severity when only warnings exist', () => {
+    const warnOnly = {
+      ...auditSnapshot,
+      checks: [auditSnapshot.checks[1]],
+      summary: { total: 1, ok: 0, warn: 1, fail: 0, error: 0 },
+    };
+    expect(renderSummary('audit', okRun(warnOnly)).severity).toBe('warn');
+  });
+
+  it('falls back to a generic summary when the result is not a snapshot', () => {
+    const s = renderSummary('audit', okRun({ unexpected: true }));
+    expect(s.severity).toBe('info');
+    expect(s.headline).toContain('completed');
+  });
+});
+
+describe('renderSummary — coverage', () => {
+  const coverage = {
+    org: 'devhub',
+    threshold: 75,
+    orgWide: 68,
+    belowThreshold: true,
+    classes: [
+      { name: 'GoodClass', covered: 95, uncovered: 5, total: 100, pct: 0.95 },
+      { name: 'BadClass', covered: 10, uncovered: 90, total: 100, pct: 0.1 },
+      { name: 'NoLines', covered: 0, uncovered: 0, total: 0, pct: null },
+    ],
+  };
+
+  it('renders the org-wide figure, band counts, and worst classes', () => {
+    const s = renderSummary('coverage', okRun(coverage));
+    expect(s.severity).toBe('error');
+    expect(s.headline).toContain('org-wide 68%');
+    expect(s.headline).toContain('threshold 75%');
+    expect(s.markdown).toContain('1 ≥90%');
+    expect(s.markdown).toContain('- 10% — BadClass');
+    expect(s.markdown).toContain('- no lines — NoLines');
+    expect(s.markdown).not.toContain('GoodClass'); // green classes are not listed
+  });
+
+  it('is info severity when above threshold with healthy classes', () => {
+    const healthy = {
+      ...coverage,
+      orgWide: 92,
+      belowThreshold: false,
+      classes: [{ name: 'GoodClass', covered: 95, uncovered: 5, total: 100, pct: 0.95 }],
+    };
+    expect(renderSummary('coverage', okRun(healthy)).severity).toBe('info');
+  });
+});
+
+describe('renderSummary — quality', () => {
+  const quality = {
+    status: 'FAIL',
+    summary: { critical: 1, high: 2, medium: 0, low: 0 },
+    violations: [
+      { file: 'classes/A.cls', line: 10, rule: 'ApexCRUDViolation', severity: 1, message: 'no CRUD check' },
+      { file: 'classes/B.cls', line: 5, rule: 'AvoidSoqlInLoops', severity: 2, message: 'SOQL in loop' },
+      { file: 'classes/C.cls', line: 1, rule: 'X', severity: 2, message: 'y' },
+    ],
+  };
+
+  it('renders severity counts and top violations (worst first)', () => {
+    const s = renderSummary('quality', okRun(quality));
+    expect(s.severity).toBe('error');
+    expect(s.headline).toContain('1 critical · 2 high');
+    expect(s.markdown).toContain('[sev 1] classes/A.cls:10 — ApexCRUDViolation: no CRUD check');
+    expect(s.markdown.indexOf('A.cls')).toBeLessThan(s.markdown.indexOf('B.cls'));
+  });
+
+  it('marks a skipped scan as warn, never a clean pass', () => {
+    const skipped = {
+      status: 'SKIPPED',
+      summary: { critical: 0, high: 0, medium: 0, low: 0 },
+      violations: [],
+      unavailableMessage: 'scanner not installed',
+    };
+    const s = renderSummary('quality', okRun(skipped));
+    expect(s.severity).toBe('warn');
+    expect(s.headline).toContain('SKIPPED');
+    expect(s.markdown).toContain('scanner not installed');
+  });
+
+  it('is info with no violations', () => {
+    const clean = { status: 'PASS', summary: { critical: 0, high: 0, medium: 0, low: 0 }, violations: [] };
+    const s = renderSummary('quality', okRun(clean));
+    expect(s.severity).toBe('info');
+    expect(s.headline).toContain('no violations');
+  });
+
+  it('renders violations parsed from raw scanner JSON when there is no envelope result', () => {
+    const raw = [
+      'Running Code Analyzer...',
+      JSON.stringify({
+        result: [
+          {
+            fileName: 'classes/A.cls',
+            violations: [{ line: 10, ruleName: 'ApexCRUDViolation', severity: 1, message: 'no CRUD check' }],
+          },
+        ],
+      }),
+      'Code Analyzer completed.',
+    ].join('\n');
+    const s = renderSummary('quality', okRun(null, { raw, noEnvelope: true }));
+    expect(s.severity).toBe('error');
+    expect(s.headline).toContain('1 critical');
+    expect(s.markdown).toContain('[sev 1] classes/A.cls:10 — ApexCRUDViolation: no CRUD check');
+  });
+
+  it('renders the CLI skip warning as SKIPPED (warn), never a clean pass', () => {
+    const raw = 'Code Analyzer: static violation scan was SKIPPED — sf code-analyzer not installed. Install the scanner';
+    const s = renderSummary('quality', okRun(null, { raw, noEnvelope: true }));
+    expect(s.severity).toBe('warn');
+    expect(s.headline).toContain('SKIPPED');
+  });
+
+  it('renders a pre-resolved quality result (e.g. from the quality snapshot) ahead of run output', () => {
+    // Today's `sfdt quality` swallows the scanner output, so the caller
+    // resolves violations from logs/quality-latest.json and passes them in.
+    const s = renderSummary('quality', okRun(null, { raw: 'chrome only', noEnvelope: true }), { quality });
+    expect(s.severity).toBe('error');
+    expect(s.headline).toContain('1 critical · 2 high');
+    expect(s.markdown).toContain('[sev 1] classes/A.cls:10 — ApexCRUDViolation: no CRUD check');
+  });
+
+  it('is inconclusive (warn, no success claim) when no source yields scan data', () => {
+    // A real violations run prints only progress chrome — the outcome is
+    // unknown, so it must never toast as an info-level clean success.
+    const s = renderSummary('quality', okRun(null, { raw: 'Quality Analysis\nall done', noEnvelope: true }));
+    expect(s.severity).toBe('warn');
+    expect(s.headline).toContain('no scan results were captured');
+    expect(s.headline).not.toContain('completed successfully');
+    expect(s.markdown).toContain('inconclusive');
+  });
+});
+
+describe('parseQualityOutput', () => {
+  it('parses the sf scanner JSON envelope and counts severities', () => {
+    const out = [
+      'noise',
+      JSON.stringify({
+        result: [
+          {
+            fileName: 'classes/A.cls',
+            violations: [
+              { line: 1, ruleName: 'R1', severity: 1, message: 'm1' },
+              { line: 2, rule: 'R2', severity: 3, message: 'm2' },
+            ],
+          },
+        ],
+      }),
+    ].join('\n');
+    const r = parseQualityOutput(out);
+    expect(r).not.toBeNull();
+    expect(r?.status).toBe('FAIL');
+    expect(r?.summary).toEqual({ critical: 1, high: 0, medium: 1, low: 0 });
+    expect(r?.violations).toHaveLength(2);
+    expect(r?.violations?.[0]).toEqual({ file: 'classes/A.cls', line: 1, rule: 'R1', severity: 1, message: 'm1' });
+  });
+
+  it('parses a bare file array and reports PASS when violation-free', () => {
+    const out = JSON.stringify([{ fileName: 'classes/B.cls', violations: [] }]);
+    const r = parseQualityOutput(out);
+    expect(r?.status).toBe('PASS');
+    expect(r?.violations).toEqual([]);
+  });
+
+  it('maps the code-analyzer.sh skipped marker to SKIPPED with the reason', () => {
+    const out = '{"status":"skipped","reason":"sf code-analyzer not installed","result":[],"_sfdt_unavailable":"sf scanner plugin not installed."}';
+    const r = parseQualityOutput(out);
+    expect(r?.status).toBe('SKIPPED');
+    expect(r?.unavailableMessage).toBe('sf code-analyzer not installed');
+  });
+
+  it('detects the CLI skip warning line even when chalk-colored', () => {
+    const out = '\u001b[33mCode Analyzer: static violation scan was SKIPPED — scanner missing.\u001b[39m';
+    const r = parseQualityOutput(out);
+    expect(r?.status).toBe('SKIPPED');
+    expect(r?.unavailableMessage).toBe('scanner missing.');
+  });
+
+  it('returns null (never a fabricated PASS) when no marker is present', () => {
+    expect(parseQualityOutput('Quality Analysis\nOverall quality: GOOD')).toBeNull();
+    expect(parseQualityOutput('{"status":0,"result":{"unrelated":true}}')).toBeNull();
+  });
+});
+
+describe('parsePreflightChecks', () => {
+  it('parses SFDT_LOG:check marker lines and keeps colons in the detail', () => {
+    const out = [
+      'some banner',
+      'SFDT_LOG:check:Git working directory is clean:PASS:',
+      'SFDT_LOG:check:CHANGELOG.md:WARN:no unreleased content: see docs',
+      'SFDT_LOG:component:Foo:ApexClass:changed', // not a check
+      'noise',
+    ].join('\n');
+    expect(parsePreflightChecks(out)).toEqual([
+      { name: 'Git working directory is clean', status: 'PASS', message: '' },
+      { name: 'CHANGELOG.md', status: 'WARN', message: 'no unreleased content: see docs' },
+    ]);
+  });
+
+  it('returns an empty list for output without markers', () => {
+    expect(parsePreflightChecks('nothing here')).toEqual([]);
+  });
+});
+
+describe('renderSummary — preflight', () => {
+  const markers = [
+    'SFDT_LOG:check:Git clean:PASS:',
+    'SFDT_LOG:check:Branch naming:WARN:feature/x does not match',
+    'SFDT_LOG:check:Apex tests:FAIL:coverage 60% below 75%',
+  ].join('\n');
+
+  it('renders check sections even when the run failed (non-zero exit)', () => {
+    const s = renderSummary('preflight', failRun('exit 1', { raw: markers, noEnvelope: true }));
+    expect(s.severity).toBe('error');
+    expect(s.headline).toContain('failed');
+    expect(s.headline).toContain('1 pass · 1 warn · 1 fail');
+    expect(s.markdown).toContain('## Failed');
+    expect(s.markdown).toContain('- Apex tests — coverage 60% below 75%');
+    expect(s.markdown).toContain('## Warnings');
+    expect(s.markdown).toContain('## Passed');
+  });
+
+  it('is warn when checks pass with warnings', () => {
+    const raw = 'SFDT_LOG:check:Git clean:PASS:\nSFDT_LOG:check:Branch naming:WARN:odd branch';
+    const s = renderSummary('preflight', okRun(null, { raw, noEnvelope: true }));
+    expect(s.severity).toBe('warn');
+    expect(s.headline).toContain('passed');
+  });
+
+  it('is info when every check passes', () => {
+    const raw = 'SFDT_LOG:check:Git clean:PASS:';
+    const s = renderSummary('preflight', okRun(null, { raw, noEnvelope: true }));
+    expect(s.severity).toBe('info');
+  });
+
+  it('falls back to the failure renderer when no markers were captured', () => {
+    const s = renderSummary('preflight', failRun('sfdt exited with code 1'));
+    expect(s.severity).toBe('error');
+    expect(s.headline).toContain('sfdt exited with code 1');
+  });
+});
+
+describe('renderSummary — failures and generic', () => {
+  it('renders CLI failures with the error and a fenced raw tail', () => {
+    const s = renderSummary('audit', failRun('No org specified'));
+    expect(s.severity).toBe('error');
+    expect(s.title).toBe('Org Audit failed');
+    expect(s.headline).toContain('No org specified');
+    expect(s.markdown).toContain('```');
+    expect(s.markdown).toContain('last line');
+  });
+
+  it('renders timeouts through the failure path', () => {
+    const s = renderSummary('monitor', failRun('sfdt timed out before completing', { timedOut: true }));
+    expect(s.headline).toContain('timed out');
+  });
+
+  it('renders a generic success with warnings elevated to warn severity', () => {
+    const s = renderSummary('generic', okRun(null, { warnings: ['heads up'], raw: 'done' }), {
+      label: 'My Command',
+    });
+    expect(s.severity).toBe('warn');
+    expect(s.headline).toBe('My Command completed');
+    expect(s.markdown).toContain('- heads up');
+  });
+});
+
+describe('NATIVE_COMMANDS', () => {
+  it('covers the dedicated shortcuts and matches CLI capabilities', () => {
+    expect(NATIVE_COMMANDS.audit).toEqual({ kind: 'audit', json: true, org: true });
+    expect(NATIVE_COMMANDS.monitor).toEqual({ kind: 'monitor', json: true, org: true });
+    expect(NATIVE_COMMANDS.coverage).toEqual({ kind: 'coverage', json: true, org: true });
+    // preflight and quality support neither --json nor --org today — passing
+    // them would make Commander reject the invocation.
+    expect(NATIVE_COMMANDS.preflight).toEqual({ kind: 'preflight', json: false, org: false });
+    expect(NATIVE_COMMANDS.quality).toEqual({ kind: 'quality', json: false, org: false });
+    // Interactive commands must NOT be routed natively.
+    expect(NATIVE_COMMANDS.deploy).toBeUndefined();
+    expect(NATIVE_COMMANDS.init).toBeUndefined();
+  });
+});
+
+describe('nativeSpecFor', () => {
+  it('matches the parent shortcuts by id', () => {
+    expect(nativeSpecFor({ id: 'audit', args: ['audit', 'all'] })?.kind).toBe('audit');
+    expect(nativeSpecFor({ id: 'monitor', args: ['monitor', 'all'] })?.kind).toBe('monitor');
+    expect(nativeSpecFor({ id: 'preflight', args: ['preflight'] })?.kind).toBe('preflight');
+    expect(nativeSpecFor({ id: 'coverage', args: ['coverage'] })?.kind).toBe('coverage');
+    expect(nativeSpecFor({ id: 'quality', args: ['quality'] })?.kind).toBe('quality');
+  });
+
+  it('routes audit/monitor subcommand entries (tree leaves) via args[0]', () => {
+    expect(nativeSpecFor({ id: 'audit-mfa', args: ['audit', 'mfa'] })?.kind).toBe('audit');
+    expect(nativeSpecFor({ id: 'audit-all', args: ['audit', 'all'] })?.kind).toBe('audit');
+    expect(nativeSpecFor({ id: 'monitor-limits', args: ['monitor', 'limits'] })?.kind).toBe('monitor');
+  });
+
+  it('keeps the terminal for interactive, destructive, and non-CLI entries', () => {
+    expect(nativeSpecFor({ id: 'deploy', args: ['deploy'], destructive: true })).toBeUndefined();
+    expect(nativeSpecFor({ id: 'deploy-smart', args: ['deploy', '--smart', '--dry-run'] })).toBeUndefined();
+    // `monitor backup` is destructive — never run it silently in the background.
+    expect(nativeSpecFor({ id: 'backup', args: ['monitor', 'backup'], destructive: true })).toBeUndefined();
+    expect(nativeSpecFor({ id: 'dashboard' })).toBeUndefined();
+    expect(nativeSpecFor({ id: 'init', args: ['init'] })).toBeUndefined();
+  });
+
+  it('resolves every audit/monitor/quality/coverage/preflight catalog leaf natively and no destructive one', () => {
+    const kindByRoot: Record<string, string> = {
+      audit: 'audit',
+      monitor: 'monitor',
+      quality: 'quality',
+      coverage: 'coverage',
+      preflight: 'preflight',
+    };
+    for (const entry of flattenCommands()) {
+      const spec = nativeSpecFor(entry);
+      const root = entry.args?.[0];
+      if (entry.destructive || !root) {
+        expect(spec, entry.id).toBeUndefined();
+      } else if (kindByRoot[root]) {
+        expect(spec?.kind, entry.id).toBe(kindByRoot[root]);
+      }
+    }
+  });
+});

--- a/vscode/test/run-json.test.ts
+++ b/vscode/test/run-json.test.ts
@@ -149,6 +149,13 @@ describe('interpretCapture', () => {
     expect(spawnErr.error).toMatch(/Could not run the sfdt CLI/);
   });
 
+  it('reports cancelled runs as failures', () => {
+    const run = interpretCapture(cap({ code: null, cancelled: true }));
+    expect(run.ok).toBe(false);
+    expect(run.timedOut).toBe(false);
+    expect(run.error).toMatch(/cancelled/);
+  });
+
   it('keeps combined raw output for diagnostics', () => {
     const run = interpretCapture(cap({ stdout: 'out line', stderr: 'err line', code: 3 }), {
       expectEnvelope: false,
@@ -218,6 +225,44 @@ describe('captureSfdt', () => {
     const res = await captureSfdt(['audit']);
     expect(res.spawnError).toBe('spawn sfdt ENOENT');
     expect(res.code).toBeNull();
+  });
+
+  it('kills the child and reports cancelled when the abort signal fires', async () => {
+    const child = fakeChild('partial', '', 0, true);
+    spawnMock.mockReturnValue(child);
+    const abort = new AbortController();
+    const promise = captureSfdt(['deploy', '--smart', '--dry-run'], { signal: abort.signal });
+    await Promise.resolve(); // let the fake child flush its stdout
+    abort.abort();
+    const res = await promise;
+    expect(res.cancelled).toBe(true);
+    expect(res.timedOut).toBe(false);
+    expect(res.code).toBeNull();
+    expect(res.stdout).toBe('partial');
+    expect(child.kill).toHaveBeenCalled();
+  });
+
+  it('never spawns when the signal is already aborted', async () => {
+    const abort = new AbortController();
+    abort.abort();
+    const res = await captureSfdt(['deploy'], { signal: abort.signal });
+    expect(res.cancelled).toBe(true);
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it('disables the timeout entirely when timeoutMs is 0', async () => {
+    vi.useFakeTimers();
+    const child = fakeChild('slow output', '', 0, true);
+    spawnMock.mockReturnValue(child);
+    const promise = captureSfdt(['deploy', '--smart', '--dry-run'], { timeoutMs: 0 });
+    // Way past the 10-minute default — a prod validation can run for hours.
+    await vi.advanceTimersByTimeAsync(3 * 60 * 60 * 1000);
+    expect(child.kill).not.toHaveBeenCalled();
+    child.emit('close', 0);
+    const res = await promise;
+    expect(res.timedOut).toBe(false);
+    expect(res.code).toBe(0);
+    expect(res.stdout).toBe('slow output');
   });
 });
 

--- a/vscode/test/run-json.test.ts
+++ b/vscode/test/run-json.test.ts
@@ -1,0 +1,256 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+
+vi.mock('node:child_process', () => ({ spawn: vi.fn() }));
+import { spawn } from 'node:child_process';
+import {
+  parseEnvelope,
+  interpretCapture,
+  captureSfdt,
+  runSfdtForResult,
+  type CaptureResult,
+} from '../src/lib/run-json.js';
+
+const spawnMock = spawn as unknown as ReturnType<typeof vi.fn>;
+
+/** A canned success envelope as sfdt emits it (pretty-printed, 2-space). */
+const auditEnvelope = JSON.stringify(
+  {
+    status: 0,
+    result: { org: 'dev', checks: [], summary: { total: 0, ok: 0, warn: 0, fail: 0, error: 0 } },
+    warnings: [],
+  },
+  null,
+  2,
+);
+
+const errorEnvelope = JSON.stringify(
+  { status: 1, name: 'Error', message: 'No org specified', exitCode: 1, warnings: [] },
+  null,
+  2,
+);
+
+function cap(partial: Partial<CaptureResult>): CaptureResult {
+  return { code: 0, stdout: '', stderr: '', timedOut: false, ...partial };
+}
+
+describe('parseEnvelope', () => {
+  it('parses a bare pretty-printed envelope', () => {
+    const env = parseEnvelope(auditEnvelope);
+    expect(env?.status).toBe(0);
+    expect((env?.result as { org: string }).org).toBe('dev');
+  });
+
+  it('tolerates stray non-JSON lines before and after the envelope', () => {
+    const stdout = `Pulling metadata...\nWarning: slow org\n${auditEnvelope}\ntrailing noise\n`;
+    expect(parseEnvelope(stdout)?.status).toBe(0);
+  });
+
+  it('skips stray JSON objects that are not envelopes', () => {
+    const stray = '{"status":"skipped","reason":"scanner missing"}';
+    const stdout = `${stray}\n${auditEnvelope}`;
+    const env = parseEnvelope(stdout);
+    expect(env?.status).toBe(0);
+    expect(env && 'result' in env).toBe(true);
+  });
+
+  it('picks the last envelope when several JSON objects appear', () => {
+    const first = JSON.stringify({ status: 0, result: { org: 'first' }, warnings: [] });
+    const stdout = `${first}\nmore output\n${errorEnvelope}`;
+    const env = parseEnvelope(stdout);
+    expect(env?.status).toBe(1);
+    expect(env?.message).toBe('No org specified');
+  });
+
+  it('survives an unclosed stray brace earlier in the stream', () => {
+    const stdout = `{oops this never closes\n${auditEnvelope}`;
+    expect(parseEnvelope(stdout)?.status).toBe(0);
+  });
+
+  it('ignores braces inside JSON strings when matching', () => {
+    const env = JSON.stringify({ status: 0, result: { msg: 'a } b { c' }, warnings: [] }, null, 2);
+    const parsed = parseEnvelope(`noise\n${env}`);
+    expect((parsed?.result as { msg: string }).msg).toBe('a } b { c');
+  });
+
+  it('ignores JSON preceded by non-whitespace on the same line', () => {
+    // Only lines that *start* a JSON object are candidates.
+    const stdout = 'log: {"status":5,"message":"inline"}';
+    expect(parseEnvelope(stdout)).toBeNull();
+  });
+
+  it('returns null for garbage and for empty output', () => {
+    expect(parseEnvelope('')).toBeNull();
+    expect(parseEnvelope('not json at all')).toBeNull();
+    expect(parseEnvelope('{"partial":')).toBeNull();
+    expect(parseEnvelope('[1,2,3]')).toBeNull();
+  });
+});
+
+describe('interpretCapture', () => {
+  it('interprets a success envelope', () => {
+    const run = interpretCapture<{ org: string }>(cap({ stdout: auditEnvelope }));
+    expect(run.ok).toBe(true);
+    expect(run.status).toBe(0);
+    expect(run.result?.org).toBe('dev');
+    expect(run.noEnvelope).toBe(false);
+    expect(run.error).toBeUndefined();
+  });
+
+  it('interprets an error envelope (message wins over exit code)', () => {
+    const run = interpretCapture(cap({ stdout: errorEnvelope, code: 1 }));
+    expect(run.ok).toBe(false);
+    expect(run.status).toBe(1);
+    expect(run.result).toBeNull();
+    expect(run.error).toBe('No org specified');
+  });
+
+  it('surfaces envelope warnings', () => {
+    const stdout = JSON.stringify({ status: 0, result: {}, warnings: ['below threshold'] });
+    const run = interpretCapture(cap({ stdout }));
+    expect(run.warnings).toEqual(['below threshold']);
+  });
+
+  it('trusts the envelope status over the process exit code', () => {
+    // audit sets process exitCode 1 on failing checks but still emits status 0.
+    const run = interpretCapture(cap({ stdout: auditEnvelope, code: 1 }));
+    expect(run.ok).toBe(true);
+  });
+
+  it('fails when --json was expected but no envelope appeared (even exit 0)', () => {
+    const run = interpretCapture(cap({ stdout: 'plain text output', code: 0 }));
+    expect(run.ok).toBe(false);
+    expect(run.noEnvelope).toBe(true);
+    expect(run.error).toMatch(/no JSON result/);
+  });
+
+  it('uses exit-code semantics when expectEnvelope is false', () => {
+    const okRun = interpretCapture(cap({ stdout: 'checks passed', code: 0 }), { expectEnvelope: false });
+    expect(okRun.ok).toBe(true);
+    expect(okRun.noEnvelope).toBe(true);
+
+    const failRun = interpretCapture(
+      cap({ stdout: 'SFDT_LOG:check:Git:FAIL:dirty', stderr: 'preflight failed', code: 2 }),
+      { expectEnvelope: false },
+    );
+    expect(failRun.ok).toBe(false);
+    expect(failRun.status).toBe(2);
+    expect(failRun.error).toContain('preflight failed');
+  });
+
+  it('reports timeouts and spawn errors', () => {
+    const timedOut = interpretCapture(cap({ code: null, timedOut: true }));
+    expect(timedOut.ok).toBe(false);
+    expect(timedOut.timedOut).toBe(true);
+    expect(timedOut.error).toMatch(/timed out/);
+
+    const spawnErr = interpretCapture(cap({ code: null, spawnError: 'spawn sfdt ENOENT' }));
+    expect(spawnErr.ok).toBe(false);
+    expect(spawnErr.error).toMatch(/Could not run the sfdt CLI/);
+  });
+
+  it('keeps combined raw output for diagnostics', () => {
+    const run = interpretCapture(cap({ stdout: 'out line', stderr: 'err line', code: 3 }), {
+      expectEnvelope: false,
+    });
+    expect(run.raw).toContain('out line');
+    expect(run.raw).toContain('err line');
+  });
+});
+
+/** Build a fake child process that emits the given stdout/stderr then closes. */
+function fakeChild(stdout = '', stderr = '', code = 0, neverClose = false) {
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+    kill: ReturnType<typeof vi.fn>;
+  };
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.kill = vi.fn();
+  queueMicrotask(() => {
+    if (stdout) child.stdout.emit('data', Buffer.from(stdout));
+    if (stderr) child.stderr.emit('data', Buffer.from(stderr));
+    if (!neverClose) child.emit('close', code);
+  });
+  return child;
+}
+
+beforeEach(() => vi.resetAllMocks());
+afterEach(() => vi.useRealTimers());
+
+describe('captureSfdt', () => {
+  it('captures stdout/stderr and the exit code', async () => {
+    spawnMock.mockReturnValue(fakeChild('hello', 'warn', 2));
+    const res = await captureSfdt(['preflight'], { cliPath: 'sfdt', cwd: '/proj' });
+    expect(res).toEqual({ code: 2, stdout: 'hello', stderr: 'warn', timedOut: false });
+    expect(spawnMock).toHaveBeenCalledWith(
+      'sfdt',
+      ['preflight'],
+      expect.objectContaining({ cwd: '/proj', shell: false }),
+    );
+    const env = spawnMock.mock.calls[0][2].env;
+    expect(env.SFDT_NON_INTERACTIVE).toBe('true');
+  });
+
+  it('appends --org via the shared buildArgs convention', async () => {
+    spawnMock.mockReturnValue(fakeChild('', '', 0));
+    await captureSfdt(['audit', 'all'], { org: 'dev' });
+    expect(spawnMock.mock.calls[0][1]).toEqual(['audit', 'all', '--org', 'dev']);
+  });
+
+  it('kills the child and reports timedOut after the timeout', async () => {
+    vi.useFakeTimers();
+    const child = fakeChild('partial', '', 0, true);
+    spawnMock.mockReturnValue(child);
+    const promise = captureSfdt(['audit', 'all'], { timeoutMs: 1000 });
+    await vi.advanceTimersByTimeAsync(1001);
+    const res = await promise;
+    expect(res.timedOut).toBe(true);
+    expect(res.stdout).toBe('partial');
+    expect(child.kill).toHaveBeenCalled();
+  });
+
+  it('resolves with spawnError when the binary cannot be started', async () => {
+    const child = fakeChild('', '', 0, true);
+    spawnMock.mockReturnValue(child);
+    queueMicrotask(() => child.emit('error', new Error('spawn sfdt ENOENT')));
+    const res = await captureSfdt(['audit']);
+    expect(res.spawnError).toBe('spawn sfdt ENOENT');
+    expect(res.code).toBeNull();
+  });
+});
+
+describe('runSfdtForResult', () => {
+  it('appends --json and parses the envelope end-to-end', async () => {
+    spawnMock.mockReturnValue(fakeChild(`noise\n${auditEnvelope}`, '', 0));
+    const run = await runSfdtForResult<{ org: string }>(['audit', 'all'], { org: 'dev' });
+    expect(run.ok).toBe(true);
+    expect(run.result?.org).toBe('dev');
+    const argv = spawnMock.mock.calls[0][1];
+    expect(argv).toContain('--json');
+    expect(argv).toEqual(expect.arrayContaining(['--org', 'dev']));
+  });
+
+  it('does not duplicate --json when already present', async () => {
+    spawnMock.mockReturnValue(fakeChild(auditEnvelope, '', 0));
+    await runSfdtForResult(['audit', 'all', '--json']);
+    const argv = spawnMock.mock.calls[0][1] as string[];
+    expect(argv.filter((a) => a === '--json')).toHaveLength(1);
+  });
+
+  it('omits --json and uses exit-code semantics when json: false', async () => {
+    spawnMock.mockReturnValue(fakeChild('SFDT_LOG:check:Git:PASS:clean', '', 0));
+    const run = await runSfdtForResult(['preflight'], { json: false });
+    expect(spawnMock.mock.calls[0][1]).toEqual(['preflight']);
+    expect(run.ok).toBe(true);
+    expect(run.noEnvelope).toBe(true);
+  });
+
+  it('never rejects on CLI failure', async () => {
+    spawnMock.mockReturnValue(fakeChild('', 'boom', 1));
+    const run = await runSfdtForResult(['audit', 'all']);
+    expect(run.ok).toBe(false);
+    expect(run.error).toContain('boom');
+  });
+});

--- a/vscode/test/smart-deploy-output.test.ts
+++ b/vscode/test/smart-deploy-output.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect } from 'vitest';
+import {
+  stripAnsi,
+  parseSmartDeployOutput,
+  summaryLines,
+  isValidationJobId,
+  buildQuickDeployCommand,
+} from '../src/lib/smart-deploy-output.js';
+
+// Canned output mirroring the CLI's print statements in src/commands/deploy.js
+// (runSmartDeploy): print.header wraps the title in dashed rules; print.info/
+// print.warning indent by two spaces.
+const VALIDATE_OK = [
+  '',
+  '--------------------------------------------------',
+  '  Smart deploy (main...HEAD) → devorg [validate]',
+  '--------------------------------------------------',
+  '',
+  '  Delta: 3 additive, 1 destructive component(s).',
+  '  Overwrite-protected (skipped): 2 component(s).',
+  '  Test level: RunSpecifiedTests (FooTest, BarTest) — only Apex test classes changed',
+  '  2 changed file(s) could not be mapped to a metadata type (skipped).',
+  '  Running: sf project deploy validate --manifest /tmp/sfdt-smart-x/package.xml --target-org devorg --test-level RunSpecifiedTests --tests FooTest --tests BarTest',
+  'Deploying v63.0 metadata to devorg using the v63.0 SOAP API.',
+  '  Validation succeeded — no changes applied.',
+].join('\n');
+
+const VALIDATE_PROD = [
+  '--------------------------------------------------',
+  '  Smart deploy (release/1.2...HEAD) → My Prod Org [PRODUCTION] [validate]',
+  '--------------------------------------------------',
+  '',
+  '  Delta: 12 additive, 0 destructive component(s).',
+  '  Test level: RunLocalTests — production deploy',
+  '  Running: sf project deploy validate --manifest /tmp/p/package.xml --target-org My Prod Org --test-level RunLocalTests',
+  '  Validation succeeded — no changes applied.',
+].join('\n');
+
+describe('stripAnsi', () => {
+  it('removes color escapes but not bracketed words', () => {
+    expect(stripAnsi('[36m  Delta: 1 additive[39m')).toBe('  Delta: 1 additive');
+    expect(stripAnsi('org [PRODUCTION] [validate]')).toBe('org [PRODUCTION] [validate]');
+  });
+});
+
+describe('parseSmartDeployOutput', () => {
+  it('parses the full non-prod validate summary', () => {
+    const s = parseSmartDeployOutput(VALIDATE_OK);
+    expect(s.base).toBe('main');
+    expect(s.head).toBe('HEAD');
+    expect(s.org).toBe('devorg');
+    expect(s.production).toBe(false);
+    expect(s.addCount).toBe(3);
+    expect(s.delCount).toBe(1);
+    expect(s.overwriteProtected).toBe(2);
+    expect(s.unmappedCount).toBe(2);
+    expect(s.testLevel).toBe('RunSpecifiedTests');
+    expect(s.tests).toEqual(['FooTest', 'BarTest']);
+    expect(s.testReason).toBe('only Apex test classes changed');
+    expect(s.noChanges).toBe(false);
+    expect(s.succeeded).toBe(true);
+    expect(s.failed).toBe(false);
+  });
+
+  it('detects the production marker and orgs with spaces', () => {
+    const s = parseSmartDeployOutput(VALIDATE_PROD);
+    expect(s.org).toBe('My Prod Org');
+    expect(s.production).toBe(true);
+    expect(s.testLevel).toBe('RunLocalTests');
+    expect(s.tests).toEqual([]);
+    expect(s.testReason).toBe('production deploy');
+    expect(s.succeeded).toBe(true);
+  });
+
+  it('parses ANSI-colored output', () => {
+    const colored = VALIDATE_OK.split('\n').map((l) => `[36m${l}[39m`).join('\n');
+    const s = parseSmartDeployOutput(colored);
+    expect(s.addCount).toBe(3);
+    expect(s.succeeded).toBe(true);
+  });
+
+  it('reports an empty delta', () => {
+    const s = parseSmartDeployOutput(
+      '  Smart deploy (main...HEAD) → devorg [validate]\n  No metadata changes detected between refs — nothing to deploy.',
+    );
+    expect(s.noChanges).toBe(true);
+    expect(s.succeeded).toBe(false);
+    expect(s.addCount).toBeNull();
+  });
+
+  it('reports a failed validation', () => {
+    const s = parseSmartDeployOutput(
+      '  Delta: 2 additive, 0 destructive component(s).\n  Test level: RunLocalTests — impacting types changed: ApexClass\n  Smart deploy failed.',
+    );
+    expect(s.failed).toBe(true);
+    expect(s.succeeded).toBe(false);
+  });
+
+  it('captures preflight and setup failure detail', () => {
+    const pf = parseSmartDeployOutput('  Preflight failed — aborting deploy: Script "ops/preflight.sh" exited with code 1');
+    expect(pf.failed).toBe(true);
+    expect(pf.failureDetail).toContain('preflight.sh');
+    const setup = parseSmartDeployOutput('  Deployment failed: No org specified — pass --org <alias> or set defaultOrg in .sfdt/config.json');
+    expect(setup.failed).toBe(true);
+    expect(setup.failureDetail).toContain('No org specified');
+  });
+
+  it('flags production even when only the raw output carries the marker', () => {
+    const s = parseSmartDeployOutput('some stray line [PRODUCTION]\n  Delta: 1 additive, 0 destructive component(s).');
+    expect(s.production).toBe(true);
+  });
+
+  it('never throws on empty or junk output', () => {
+    expect(parseSmartDeployOutput('').failed).toBe(false);
+    const s = parseSmartDeployOutput('random\n{not json}\nnoise');
+    expect(s.addCount).toBeNull();
+    expect(s.succeeded).toBe(false);
+  });
+});
+
+describe('summaryLines', () => {
+  it('renders the parsed summary', () => {
+    const lines = summaryLines(parseSmartDeployOutput(VALIDATE_OK));
+    expect(lines).toContain('Org: devorg');
+    expect(lines).toContain('Delta: 3 additive, 1 destructive component(s)');
+    expect(lines).toContain('Test level: RunSpecifiedTests (FooTest, BarTest) — only Apex test classes changed');
+    expect(lines).toContain('Overwrite-protected (skipped): 2 component(s)');
+    expect(lines).toContain('Unmapped changed files (skipped): 2');
+  });
+  it('marks production orgs loudly', () => {
+    const lines = summaryLines(parseSmartDeployOutput(VALIDATE_PROD));
+    expect(lines[0]).toContain('PRODUCTION');
+  });
+  it('short-circuits on an empty delta', () => {
+    const lines = summaryLines(parseSmartDeployOutput('  No metadata changes detected between refs — nothing to deploy.'));
+    expect(lines).toEqual(['No metadata changes detected — nothing to deploy.']);
+  });
+});
+
+describe('isValidationJobId', () => {
+  it('accepts 15- and 18-char 0Af ids', () => {
+    expect(isValidationJobId('0Af5g00000KxYzD')).toBe(true);
+    expect(isValidationJobId('0Af5g00000KxYzDcAB')).toBe(true);
+  });
+  it('rejects wrong prefixes, lengths, and characters', () => {
+    expect(isValidationJobId('0055g00000KxYzD')).toBe(false);
+    expect(isValidationJobId('0Af5g00000KxYz')).toBe(false);
+    expect(isValidationJobId('0Af5g00000KxYzDc')).toBe(false);
+    expect(isValidationJobId('0Af5g00000KxYzD; rm -rf /')).toBe(false);
+    expect(isValidationJobId(' 0Af5g00000KxYzD')).toBe(false);
+    expect(isValidationJobId('')).toBe(false);
+  });
+});
+
+describe('buildQuickDeployCommand', () => {
+  it('builds the env-prefixed non-interactive command', () => {
+    expect(buildQuickDeployCommand({ jobId: '0Af5g00000KxYzD', org: 'dev' })).toBe(
+      'SFDT_VALIDATION_JOB_ID=0Af5g00000KxYzD SFDT_TARGET_ORG=dev sfdt deploy --org dev < /dev/null',
+    );
+  });
+  it('quotes an org alias with spaces', () => {
+    expect(buildQuickDeployCommand({ jobId: '0Af5g00000KxYzD', org: 'My Org' })).toBe(
+      `SFDT_VALIDATION_JOB_ID=0Af5g00000KxYzD SFDT_TARGET_ORG='My Org' sfdt deploy --org 'My Org' < /dev/null`,
+    );
+  });
+  it('omits the org when not given and honors cliPath', () => {
+    expect(buildQuickDeployCommand({ jobId: '0Af5g00000KxYzD', cliPath: '/usr/local/bin/sfdt' })).toBe(
+      'SFDT_VALIDATION_JOB_ID=0Af5g00000KxYzD /usr/local/bin/sfdt deploy < /dev/null',
+    );
+  });
+});

--- a/vscode/test/smart-deploy-output.test.ts
+++ b/vscode/test/smart-deploy-output.test.ts
@@ -153,19 +153,27 @@ describe('isValidationJobId', () => {
 });
 
 describe('buildQuickDeployCommand', () => {
-  it('builds the env-prefixed non-interactive command', () => {
+  // The command targets the sf CLI directly: the sfdt deployment-assistant
+  // path can't promote a smart-deploy validation job (its quick-deploy
+  // confirm read is not SFDT_NON_INTERACTIVE-gated and its non-interactive
+  // branch requires — and would archive/tag — a manifest/release manifest).
+  it('builds the direct sf quick-deploy command', () => {
     expect(buildQuickDeployCommand({ jobId: '0Af5g00000KxYzD', org: 'dev' })).toBe(
-      'SFDT_VALIDATION_JOB_ID=0Af5g00000KxYzD SFDT_TARGET_ORG=dev sfdt deploy --org dev < /dev/null',
+      'sf project deploy quick --job-id 0Af5g00000KxYzD --target-org dev',
     );
   });
   it('quotes an org alias with spaces', () => {
     expect(buildQuickDeployCommand({ jobId: '0Af5g00000KxYzD', org: 'My Org' })).toBe(
-      `SFDT_VALIDATION_JOB_ID=0Af5g00000KxYzD SFDT_TARGET_ORG='My Org' sfdt deploy --org 'My Org' < /dev/null`,
+      `sf project deploy quick --job-id 0Af5g00000KxYzD --target-org 'My Org'`,
     );
   });
-  it('omits the org when not given and honors cliPath', () => {
-    expect(buildQuickDeployCommand({ jobId: '0Af5g00000KxYzD', cliPath: '/usr/local/bin/sfdt' })).toBe(
-      'SFDT_VALIDATION_JOB_ID=0Af5g00000KxYzD /usr/local/bin/sfdt deploy < /dev/null',
+  it('omits the org when not given', () => {
+    expect(buildQuickDeployCommand({ jobId: '0Af5g00000KxYzD' })).toBe(
+      'sf project deploy quick --job-id 0Af5g00000KxYzD',
     );
+  });
+  it('contains no shell redirects or env prefixes (PowerShell-safe)', () => {
+    const cmd = buildQuickDeployCommand({ jobId: '0Af5g00000KxYzD', org: 'dev' });
+    expect(cmd).not.toMatch(/[<>]|SFDT_/);
   });
 });

--- a/vscode/test/snapshots.test.ts
+++ b/vscode/test/snapshots.test.ts
@@ -58,6 +58,26 @@ describe('buildHealthTree', () => {
     expect(mfaNode?.children?.[0].label).toContain('a@x.com');
   });
 
+  it('gives each check a tooltip carrying title, status, and summary', () => {
+    const [diag] = buildHealthTree(snap(), null);
+    const mfaNode = diag.children?.find((c) => c.label === 'MFA coverage');
+    expect(mfaNode?.tooltip).toContain('MFA coverage');
+    expect(mfaNode?.tooltip).toContain('[warn]');
+    expect(mfaNode?.tooltip).toContain('2 users without MFA');
+    expect(mfaNode?.tooltip).toContain('sfdt audit mfa');
+  });
+
+  it('tags rendered sections with their snapshot type for snapshot actions', () => {
+    const [diag, mon] = buildHealthTree(snap(), snap());
+    expect(diag.snapshotType).toBe('audit');
+    expect(mon.snapshotType).toBe('monitor');
+  });
+
+  it('omits snapshotType on placeholder sections (no snapshot to send)', () => {
+    const [, mon] = buildHealthTree(snap(), null);
+    expect(mon.snapshotType).toBeUndefined();
+  });
+
   it('appends a scan section only when the scan arg is supplied', () => {
     expect(buildHealthTree(snap(), null)).toHaveLength(2);
     const tree = buildHealthTree(snap(), null, null);


### PR DESCRIPTION
## Summary

Sprint 2 of the gap-remediation plan (items 3.1, 3.2, 3.3, 3.5): turns the VS Code extension from a terminal launcher + read-only trees into a first-class surface. Implemented in four sequential agent stages, each adversarially reviewed with all confirmed findings fixed. Extension-only — the CLI is untouched.

### Native result capture & rendering (3.1)
- New vscode-free `run-json.ts`: spawns the CLI with `--json`, parses the sf-envelope defensively (brace-matched scan tolerant of stray subprocess output; envelope status trusted over exit code), typed result, timeout with process-group kill so `sf` children can't outlive a cancelled run.
- Audit, monitor, coverage, quality, and preflight run natively from **every** entry point (palette, Commands tree, search) under a progress notification; results refresh the SFDT trees and render as markdown in a new **SFDT Results** output channel, with a "Run in Terminal" fallback on any failure. Interactive commands keep the terminal.
- Windows: `.cmd` shim spawning works (shell on win32).

### Problems-pane diagnostics (3.2)
- Quality violations map to native `vscode.Diagnostic`s (severity 1→Error, 2→Warning, 3+→Info) sourced from the authoritative `logs/quality-latest.json` snapshot envelope; a SKIPPED scan (scanner not installed) produces no false-clean diagnostics. `SFDT: Clear Diagnostics` empties the collection.

### Smart deploy & quick deploy (3.3)
- **SFDT: Smart Deploy — Validate & Review**: captures `deploy --smart --dry-run`, parses the delta summary (components, test level, overwrite protections) via a unit-tested parser, then offers Deploy now / Re-validate / Cancel behind a modal, org-named confirmation that warns extra-loudly on `[PRODUCTION]`.
- **SFDT: Quick Deploy**: promotes a validated `0Af…` job via `sf project deploy quick` in the integrated terminal (org picker + modal confirm). Review-driven redesign: the sfdt script path was unusable non-interactively (ungated confirmation `read` under `set -euo pipefail`; validation manifest is a deleted temp file), so the extension calls the sf command directly — also fixing Windows shell compatibility.

### Onboarding & catalog (3.5)
- "Get started with SFDT" walkthrough (check CLI → init → first audit → smart-deploy validate → open dashboard), with prereq context keys that also refresh on window focus so external installs/init are picked up without a reload.
- Catalog gains the missing families: `ci init`, `feature-flags`, `config get/set`, `notify <event>`, `pr-description`, `ai prompt`; commands that accept no `--org` no longer get one injected (run and copy paths).
- Org-health tree: per-check tooltips and a "Send snapshot to channels" action.

## Review-loop catches worth noting
The per-stage adversarial reviews found and fixed, pre-merge: quality violations could never reach the Problems pane from a real run (the CLI doesn't print scanner JSON — switched to the snapshot); Quick Deploy could never complete through the script path; the walkthrough's first step ran `sfdt doctor`, which fails on exactly the fresh machines onboarding targets; `--org` injection broke `config`/`feature-flags`/`ai prompt`.

## Test plan
- vscode workspace: `tsc --noEmit`, 198 vitest tests (13 files, incl. new suites for envelope parsing, renderers, diagnostics mapping, smart-deploy output parsing), eslint, esbuild — all green.
- Root suite: 3239 tests / 213 files passing.
- Suggested manual check: install the `.vsix` in a real workspace and run the walkthrough end-to-end (fresh-machine path), one native audit, and a smart-deploy validate against a sandbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K8gwZpdRU1BRrNGfYAyvAH

---
_Generated by [Claude Code](https://claude.ai/code/session_01K8gwZpdRU1BRrNGfYAyvAH)_