### PR TITLE
4.7 tail: warn on cross-org Salesforce release mismatch in compare/retrofit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Cross-org release-version warning.** `sfdt compare` and `sfdt retrofit` now detect when the two orgs run different Salesforce releases (best-effort via each org's REST version list) and print a heads-up before comparing/deploying — metadata valid on one release may not deploy cleanly to another. Non-fatal and skipped for org↔local comparisons or when a release can't be determined; `retrofit --json` reports it as `releaseMismatch`. The release-detection helper (`expectedGaApiVersion`/`detectOrgRelease`, previously private to the monitor runner) moved to a shared `src/lib/org-release.js`.
+
+### Added
+
 - **`sfdt quality --api67`** — API v67 (Summer '26 user-mode-by-default) readiness scan of local Apex: flags `WITH SECURITY_ENFORCED` (no longer compiles at v67), classes with no sharing declaration, and `without sharing` classes doing DML/SOQL; `--json` emits the sf envelope; exit code 1 only when blocking errors exist and `sourceApiVersion` ≥ 67. Comment/string-sanitized scanning avoids false positives.
 - **`sfdt quality --test-hints`** — advisory check flagging `@IsTest` classes that carry no `@IsTest(testFor=...)` annotation (invisible to Spring '26 RunRelevantTests selection and to smart deploy's annotation-aware widening).
 - **Annotation-aware smart-deploy test selection.** When smart deploy picks `RunSpecifiedTests`, it now also includes test classes whose `@IsTest(testFor='Type:Name')` targets a changed component and every `@IsTest(critical=true)` class, merged with the existing name-heuristic selection.

--- a/docs/plans/2026-07-03-gap-remediation-and-release-research.md
+++ b/docs/plans/2026-07-03-gap-remediation-and-release-research.md
@@ -133,7 +133,9 @@ Wrap `sf logic run test` so `sfdt test` can run Apex + Flow tests in one pass (F
 #### 4.6 Code Analyzer v5 integration — **M**
 Run `sf code-analyzer` (PMD 7, `--include-fixes`) inside `sfdt quality`; merge findings into the snapshot/PR comment; optionally feed fixes to the AI fix loop. Replaces the 1.5 stub path.
 
-#### 4.7 New audit/monitor checks — **S each** — **MOSTLY DONE (sprint-3 branch: mfa-readiness, soap-logins, connected-apps note, elastic async limits, release version in org-info; DEFERRED: Release Manager channel + retrofit/compare cross-org release-version warning)**
+#### 4.7 New audit/monitor checks — **S each** — **DONE (sprint-3 PR #174 + follow-up branch)**
+
+> **Status:** mfa-readiness, soap-logins, connected-apps migration note, elastic async limits, and release-version/preview in `monitor org-info` shipped in PR #174. The **cross-org release-version warning** for `compare`/`retrofit` shipped on the follow-up branch (shared `src/lib/org-release.js`). The **Release Manager *channel*** sub-piece (Standard/Accelerated/Dev) is **intentionally not implemented**: the Summer '26 Release Manager is Beta and exposes no stable, queryable public field for the channel — inventing a SOQL field would fail in every org (the exact anti-pattern earlier adversarial reviews caught). Revisit once Salesforce ships a documented API for it.
 - **MFA readiness** (July 1, 2026 phishing-resistant MFA enforcement; hardis parity).
 - **SOAP `login()` retirement** (Summer '27; flags API versions 31–64 auth flows).
 - **Connected Apps default-off migration** (recommend External Client Apps — extends the existing `connected-apps` check).

--- a/src/commands/compare.js
+++ b/src/commands/compare.js
@@ -7,6 +7,7 @@ import { fetchInventory } from '../lib/org-inventory.js';
 import { diffInventories } from '../lib/org-diff.js';
 import { renderPackageXml } from '../lib/metadata-mapper.js';
 import { safeResolvePath } from '../lib/project-detect.js';
+import { compareOrgReleases, releaseMismatchWarning } from '../lib/org-release.js';
 
 export function registerCompareCommand(program) {
   program
@@ -24,6 +25,12 @@ export function registerCompareCommand(program) {
 
         print.header(`Comparing ${source} → ${target}`);
         print.info('Fetching source inventory…');
+
+        // Heads-up when comparing two orgs on different Salesforce releases —
+        // best-effort, never fatal (skips org↔local and undetectable orgs).
+        const releaseCmp = await compareOrgReleases(source, target);
+        const releaseWarning = releaseMismatchWarning(releaseCmp, source, target);
+        if (releaseWarning) print.warning(releaseWarning);
 
         const [sourceMap, targetMap] = await Promise.all([
           fetchInventory(source, config),

--- a/src/commands/retrofit.js
+++ b/src/commands/retrofit.js
@@ -6,6 +6,7 @@ import { resolveExitCode } from '../lib/exit-codes.js';
 import { fetchOrgInventory } from '../lib/org-inventory.js';
 import { parallelRetrieve } from '../lib/parallel-retrieve.js';
 import { runSmartDeploy } from './deploy.js';
+import { compareOrgReleases, releaseMismatchWarning } from '../lib/org-release.js';
 
 // Metadata commonly changed directly in an upstream org (e.g. admins in prod)
 // that teams want to "retrofit" back into source control / lower orgs. Override
@@ -113,6 +114,13 @@ async function runRetrofit(options) {
 
     // Deploy the just-committed delta to the target via the smart-deploy path.
     // Defaults to validate-only; pass --execute for a real deploy.
+    // Heads-up when source and target run different Salesforce releases —
+    // retrofitting from a preview org into a GA target (or vice-versa) can carry
+    // metadata the other release won't accept. Best-effort, never fatal.
+    const releaseCmp = await compareOrgReleases(source, target);
+    const releaseWarning = releaseMismatchWarning(releaseCmp, source, target);
+    if (releaseWarning && !jsonMode) print.warning(releaseWarning);
+
     if (!jsonMode) print.header(`Deploying retrofit delta to ${target}${options.execute ? '' : ' [validate]'}`);
     await runSmartDeploy(config, {
       smart: true,
@@ -124,7 +132,7 @@ async function runRetrofit(options) {
       agent: jsonMode,
     });
 
-    if (jsonMode) process.stdout.write(JSON.stringify({ ok: true, retrieved, changed: changed.length, committed: true, deployed: true, validateOnly: !options.execute }) + '\n');
+    if (jsonMode) process.stdout.write(JSON.stringify({ ok: true, retrieved, changed: changed.length, committed: true, deployed: true, validateOnly: !options.execute, releaseMismatch: releaseCmp?.differ === true }) + '\n');
   } catch (err) {
     if (jsonMode) process.stdout.write(JSON.stringify({ ok: false, error: err.message }) + '\n');
     else print.error(`Retrofit failed: ${err.message}`);

--- a/src/lib/monitor-runner.js
+++ b/src/lib/monitor-runner.js
@@ -5,6 +5,11 @@ import { ORG_HEALTH_THRESHOLDS } from '@sfdt/flow-core';
 import { query, safeParse, toSoqlDate } from './org-query.js';
 import { fetchOrgInventory } from './org-inventory.js';
 import { parallelRetrieve } from './parallel-retrieve.js';
+import { expectedGaApiVersion, detectOrgRelease } from './org-release.js';
+
+// Re-exported for back-compat: `expectedGaApiVersion` moved to org-release.js
+// (shared with compare/retrofit) but was previously imported from here.
+export { expectedGaApiVersion };
 
 /**
  * Org monitoring & backup runner.
@@ -147,50 +152,6 @@ export async function checkHealth(orgAlias, { minScore = MONITOR_DEFAULTS.health
       [{ score: rounded, floor: minScore }]);
   } catch (err) {
     return errored(id, title, err);
-  }
-}
-
-/**
- * The API version Salesforce's currently-GA release should expose, derived from
- * the fixed three-releases-a-year cadence (Spring GA ~Feb, Summer GA ~June,
- * Winter GA ~Oct; anchor: Spring '23 = v57.0). Used to spot preview instances:
- * a preview org's max supported REST API version is ahead of the GA release.
- */
-export function expectedGaApiVersion(date = new Date()) {
-  const y = date.getUTCFullYear();
-  const m = date.getUTCMonth() + 1;
-  const spring = 57 + (y - 2023) * 3; // Spring '23 = v57
-  if (m >= 10) return spring + 2; // Winter '(y+1)'
-  if (m >= 6) return spring + 1; // Summer 'y'
-  if (m >= 2) return spring; // Spring 'y'
-  return spring - 1; // January: still the prior year's Winter release
-}
-
-/**
- * Best-effort release detection: read the org's REST version list
- * (`/services/data` via `sf api request rest` — no auth plumbing or new
- * dependencies needed) and take the newest entry. Its `label` is the release
- * name (e.g. "Summer '26") and its version, compared against the expected GA
- * version, tells us whether the instance is on a preview release. Returns null
- * on any failure — release info is informational and must degrade gracefully
- * (older sf CLIs lack `sf api request`).
- */
-async function detectOrgRelease(orgAlias) {
-  try {
-    const resp = await execa('sf', ['api', 'request', 'rest', '/services/data', '--target-org', orgAlias]);
-    const versions = safeParse(resp.stdout);
-    if (!Array.isArray(versions) || versions.length === 0) return null;
-    const latest = versions.reduce((a, b) =>
-      Number.parseFloat(b?.version) > Number.parseFloat(a?.version) ? b : a);
-    const apiVersion = Number.parseFloat(latest?.version);
-    if (!Number.isFinite(apiVersion)) return null;
-    return {
-      release: latest.label ?? `API v${apiVersion}`,
-      apiVersion,
-      preview: apiVersion > expectedGaApiVersion(),
-    };
-  } catch {
-    return null;
   }
 }
 

--- a/src/lib/org-release.js
+++ b/src/lib/org-release.js
@@ -1,0 +1,86 @@
+import { execa } from 'execa';
+import { safeParse } from './org-query.js';
+
+/**
+ * The API version Salesforce's currently-GA release should expose, derived from
+ * the fixed three-releases-a-year cadence (Spring GA ~Feb, Summer GA ~June,
+ * Winter GA ~Oct; anchor: Spring '23 = v57.0). Used to spot preview instances:
+ * a preview org's max supported REST API version is ahead of the GA release.
+ */
+export function expectedGaApiVersion(date = new Date()) {
+  const y = date.getUTCFullYear();
+  const m = date.getUTCMonth() + 1;
+  const spring = 57 + (y - 2023) * 3; // Spring '23 = v57
+  if (m >= 10) return spring + 2; // Winter '(y+1)'
+  if (m >= 6) return spring + 1; // Summer 'y'
+  if (m >= 2) return spring; // Spring 'y'
+  return spring - 1; // January: still the prior year's Winter release
+}
+
+/**
+ * Best-effort release detection for an org: read its REST version list
+ * (`/services/data` via `sf api request rest` — no auth plumbing or new
+ * dependencies needed) and take the newest entry. Its `label` is the release
+ * name (e.g. "Summer '26") and its version, compared against the expected GA
+ * version, tells us whether the instance is on a preview release. Returns null
+ * on any failure — release info is informational and must degrade gracefully
+ * (older sf CLIs lack `sf api request`, orgs may be unreachable, etc.).
+ */
+export async function detectOrgRelease(orgAlias) {
+  try {
+    const resp = await execa('sf', ['api', 'request', 'rest', '/services/data', '--target-org', orgAlias]);
+    const versions = safeParse(resp.stdout);
+    if (!Array.isArray(versions) || versions.length === 0) return null;
+    const latest = versions.reduce((a, b) =>
+      Number.parseFloat(b?.version) > Number.parseFloat(a?.version) ? b : a);
+    const apiVersion = Number.parseFloat(latest?.version);
+    if (!Number.isFinite(apiVersion)) return null;
+    return {
+      release: latest.label ?? `API v${apiVersion}`,
+      apiVersion,
+      preview: apiVersion > expectedGaApiVersion(),
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Compare the release versions of two orgs. Returns:
+ *   - `null` when the comparison is not applicable (missing/identical aliases,
+ *     or either alias is the sentinel `"local"`);
+ *   - `{ source, target, differ }` otherwise, where `source`/`target` are the
+ *     `detectOrgRelease` results (either may be `null` when undetectable) and
+ *     `differ` is `true`/`false` when both releases are known, or `null` when
+ *     either could not be detected (so callers don't warn on unknowns).
+ *
+ * Best-effort and non-fatal: a release mismatch between a retrofit/compare
+ * source and target is a heads-up (metadata valid on one release may not deploy
+ * cleanly to another), never a hard failure.
+ */
+export async function compareOrgReleases(sourceAlias, targetAlias) {
+  if (!sourceAlias || !targetAlias) return null;
+  if (sourceAlias === 'local' || targetAlias === 'local') return null;
+  if (sourceAlias === targetAlias) return null;
+  const [source, target] = await Promise.all([
+    detectOrgRelease(sourceAlias),
+    detectOrgRelease(targetAlias),
+  ]);
+  const differ = source && target ? source.apiVersion !== target.apiVersion : null;
+  return { source, target, differ };
+}
+
+/**
+ * Human-readable one-line warning for a `compareOrgReleases` result, or null
+ * when there is nothing to warn about (comparison N/A, releases match, or a
+ * release could not be determined). Shared by `compare` and `retrofit` so the
+ * wording stays identical.
+ */
+export function releaseMismatchWarning(cmp, sourceAlias, targetAlias) {
+  if (!cmp || cmp.differ !== true) return null;
+  return (
+    `Release mismatch: ${sourceAlias} is on ${cmp.source.release} (API v${cmp.source.apiVersion}) ` +
+    `but ${targetAlias} is on ${cmp.target.release} (API v${cmp.target.apiVersion}). ` +
+    `Metadata valid on one release may not deploy cleanly to the other.`
+  );
+}

--- a/test/lib/org-release.test.js
+++ b/test/lib/org-release.test.js
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('execa', () => ({ execa: vi.fn() }));
+vi.mock('../../src/lib/org-query.js', () => ({
+  safeParse: (t) => { try { return JSON.parse(t); } catch { return null; } },
+}));
+
+import { execa } from 'execa';
+import {
+  expectedGaApiVersion,
+  detectOrgRelease,
+  compareOrgReleases,
+  releaseMismatchWarning,
+} from '../../src/lib/org-release.js';
+
+beforeEach(() => vi.resetAllMocks());
+
+/** Build a `sf api request rest /services/data` response body. */
+const versionList = (...vs) =>
+  ({ stdout: JSON.stringify(vs.map((v) => ({ version: String(v.toFixed(1)), label: `Release v${v}` }))) });
+
+describe('expectedGaApiVersion', () => {
+  it('follows the three-release cadence anchored at Spring 23 = v57', () => {
+    expect(expectedGaApiVersion(new Date('2023-03-01T00:00:00Z'))).toBe(57); // Spring '23
+    expect(expectedGaApiVersion(new Date('2023-07-01T00:00:00Z'))).toBe(58); // Summer '23
+    expect(expectedGaApiVersion(new Date('2023-11-01T00:00:00Z'))).toBe(59); // Winter '24
+    expect(expectedGaApiVersion(new Date('2024-01-15T00:00:00Z'))).toBe(59); // Jan: prior Winter
+    expect(expectedGaApiVersion(new Date('2026-07-01T00:00:00Z'))).toBe(67); // Summer '26
+  });
+});
+
+describe('detectOrgRelease', () => {
+  it('returns the newest version entry and flags a preview instance', async () => {
+    const ga = expectedGaApiVersion();
+    execa.mockResolvedValueOnce(versionList(ga - 1, ga + 1)); // ahead of GA -> preview
+    const r = await detectOrgRelease('dev');
+    expect(r).toMatchObject({ apiVersion: ga + 1, preview: true });
+  });
+
+  it('is not preview when the max version matches GA', async () => {
+    const ga = expectedGaApiVersion();
+    execa.mockResolvedValueOnce(versionList(ga - 2, ga));
+    const r = await detectOrgRelease('dev');
+    expect(r).toMatchObject({ apiVersion: ga, preview: false });
+  });
+
+  it('degrades to null on any failure (old CLI, unreachable org, junk output)', async () => {
+    execa.mockRejectedValueOnce(new Error('unknown command "api"'));
+    expect(await detectOrgRelease('dev')).toBeNull();
+    execa.mockResolvedValueOnce({ stdout: 'not json' });
+    expect(await detectOrgRelease('dev')).toBeNull();
+    execa.mockResolvedValueOnce({ stdout: '[]' });
+    expect(await detectOrgRelease('dev')).toBeNull();
+  });
+});
+
+describe('compareOrgReleases', () => {
+  it('is not applicable for missing, identical, or local aliases', async () => {
+    expect(await compareOrgReleases(null, 'b')).toBeNull();
+    expect(await compareOrgReleases('a', undefined)).toBeNull();
+    expect(await compareOrgReleases('a', 'a')).toBeNull();
+    expect(await compareOrgReleases('local', 'b')).toBeNull();
+    expect(await compareOrgReleases('a', 'local')).toBeNull();
+    expect(execa).not.toHaveBeenCalled();
+  });
+
+  it('differ=true when the two orgs report different API versions', async () => {
+    const ga = expectedGaApiVersion();
+    execa
+      .mockResolvedValueOnce(versionList(ga))       // source: GA
+      .mockResolvedValueOnce(versionList(ga + 1));  // target: preview
+    const cmp = await compareOrgReleases('src', 'tgt');
+    expect(cmp.differ).toBe(true);
+    expect(cmp.source.apiVersion).toBe(ga);
+    expect(cmp.target.apiVersion).toBe(ga + 1);
+  });
+
+  it('differ=false when both orgs are on the same release', async () => {
+    const ga = expectedGaApiVersion();
+    execa.mockResolvedValueOnce(versionList(ga)).mockResolvedValueOnce(versionList(ga));
+    expect((await compareOrgReleases('src', 'tgt')).differ).toBe(false);
+  });
+
+  it('differ=null (no false warning) when either release is undetectable', async () => {
+    const ga = expectedGaApiVersion();
+    execa.mockResolvedValueOnce(versionList(ga)).mockRejectedValueOnce(new Error('x'));
+    const cmp = await compareOrgReleases('src', 'tgt');
+    expect(cmp.differ).toBeNull();
+    expect(cmp.target).toBeNull();
+  });
+});
+
+describe('releaseMismatchWarning', () => {
+  const src = { release: "Summer '26", apiVersion: 67 };
+  const tgt = { release: "Winter '27", apiVersion: 68 };
+
+  it('produces a message only when differ === true', () => {
+    expect(releaseMismatchWarning(null, 'a', 'b')).toBeNull();
+    expect(releaseMismatchWarning({ differ: false, source: src, target: tgt }, 'a', 'b')).toBeNull();
+    expect(releaseMismatchWarning({ differ: null, source: src, target: null }, 'a', 'b')).toBeNull();
+    const msg = releaseMismatchWarning({ differ: true, source: src, target: tgt }, 'prod', 'sandbox');
+    expect(msg).toContain('prod');
+    expect(msg).toContain('sandbox');
+    expect(msg).toContain("Summer '26");
+    expect(msg).toContain("Winter '27");
+  });
+});


### PR DESCRIPTION
## Summary
Completes the deferred tail of plan item 4.7. Extracts the release-detection
helpers into a shared `src/lib/org-release.js` and adds a best-effort,
non-fatal warning to `sfdt compare` and `sfdt retrofit` when the two orgs run
different Salesforce releases (metadata valid on one release may not deploy
cleanly to another). Skips org↔local and undetectable orgs; `retrofit --json`
reports it as `releaseMismatch`. `monitor-runner` re-exports
`expectedGaApiVersion` for back-compat.

The Release Manager **channel** (Standard/Accelerated/Dev) half of 4.7e is
intentionally not implemented: the Summer '26 Release Manager is Beta with no
stable queryable public field for the channel, and inventing a SOQL field
would fail in every org. Documented in the plan; revisit when a real API ships.

## Test plan
- New `test/lib/org-release.test.js` (cadence anchoring, preview detection,
  not-applicable/degrade paths, `differ: null` no-false-warning case).
- Full suite: 217 files / 3379 tests passing; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)