### PR TITLE
Sprint 4: unified logic tests, Code Analyzer v5, MCP read-only tools + CI cleanup

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -33,10 +33,6 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_REF: ${{ github.repository }}/pull/${{ github.event.pull_request.number }}
         with:
-          # TEMPORARY (remove after one PR): surface which tool calls get
-          # permission-denied so the allowlist can be tuned with data — the
-          # narrowed list still produced 6 denials on PR #172's re-review.
-          show_full_output: true
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # The code-review plugin is installed unpinned from the marketplace on
@@ -44,8 +40,13 @@ jobs:
           # allowlist (the reviewer ran but every posting call was
           # permission-denied — 50 denials, "No buffered inline comments" — so
           # reviews silently stopped appearing while the job reported success).
-          # Keep BOTH comment MCP tools listed, and if reviews go silent again,
-          # rerun once with `show_full_output: true` to see what's being denied.
+          # A one-run `show_full_output: true` diagnostic (PR #176) confirmed the
+          # allowlist below now covers posting: the only residual denials were
+          # the model exploring paths it doesn't need — the `Skill` tool and a
+          # broad `Bash(find /)` — NOT comment posting. So the list is complete
+          # as-is; do not add `Skill`/`Bash(find …)` (over-permissioning). If
+          # reviews ever go silent again, re-add `show_full_output: true` for one
+          # run to re-diagnose.
           # Deliberately least-privilege: enumerated read/comment subcommands,
           # not `gh pr:*` (which would also grant merge/close/edit).
           claude_args: "--allowedTools 'mcp__github_inline_comment__create_inline_comment,mcp__github_comment__update_claude_comment,Bash(gh pr comment:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr list:*),Bash(gh pr checks:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*),Bash(gh api:*),Bash(git diff:*),Bash(git log:*),Read,Glob,Grep'"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **`sfdt test --logic`** — run Apex and Flow tests together in one pass via Salesforce's Spring '26 `sf logic run test` (Flow tests named `FlowTesting.<name>`; requires the org "View All Data" permission). Flags: `--org`, `--test-level`, `--tests`, `--category Apex|Flow`, `--code-coverage`, `--wait` (default 30 min; the underlying command is async and sfdt waits for results). Arg building lives in the pure, unit-tested `src/lib/logic-test.js`. AI failure analysis still applies to the Apex-only runner for now.
+- **`sfdt test --logic`** — run Apex and Flow tests together in one pass via Salesforce's Spring '26 `sf logic run test` (Flow tests named `FlowTesting.<name>`; requires the org "View All Data" permission). Flags: `--org`, `--test-level`, `--tests`, `--category Apex|Flow`, `--code-coverage`, `--wait` (default 30 min; the underlying command is async and sfdt waits for results). Arg building lives in the pure, unit-tested `src/lib/logic-test.js`. On failure (with `features.ai`) sfdt offers AI failure analysis for logic runs too — the shared analyzer feeds it the captured run output (logic results aren't written to the standard result dir), and every provider gets the context injected.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Salesforce Code Analyzer v5 in `sfdt quality`.** The static scan now runs `sf code-analyzer run` (the v5 just-in-time plugin — PMD 7, ESLint, RetireJS) instead of the retired v4 `sf scanner run`, falling back to v4 only if that's the only plugin present and otherwise reporting the scan as SKIPPED (never a fabricated clean result). New `--include-fixes` requests actionable fixes/suggestions (`--include-fixes --include-suggestions`), enriching the output that `--fix-plan` feeds to the AI. The result parser handles the v5 flat `violations[]`/`locations[]` shape in addition to v4 and the skip marker.
+
 - **`sfdt test --logic`** — run Apex and Flow tests together in one pass via Salesforce's Spring '26 `sf logic run test` (Flow tests named `FlowTesting.<name>`; requires the org "View All Data" permission). Flags: `--org`, `--test-level`, `--tests`, `--category Apex|Flow`, `--code-coverage`, `--wait` (default 30 min; the underlying command is async and sfdt waits for results). Arg building lives in the pure, unit-tested `src/lib/logic-test.js`. On failure (with `features.ai`) sfdt offers AI failure analysis for logic runs too — the shared analyzer feeds it the captured run output (logic results aren't written to the standard result dir), and every provider gets the context injected.
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Four new read-only MCP tools** — `sfdt_coverage` (Apex coverage), `sfdt_scan` (org metadata inventory), `sfdt_dependencies` (component references), and `sfdt_flow_scan` (Flow quality analysis), each wrapping the existing `--json` CLI command. Brings the MCP surface to 21 tools.
+
 - **Salesforce Code Analyzer v5 in `sfdt quality`.** The static scan now runs `sf code-analyzer run` (the v5 just-in-time plugin — PMD 7, ESLint, RetireJS) instead of the retired v4 `sf scanner run`, falling back to v4 only if that's the only plugin present and otherwise reporting the scan as SKIPPED (never a fabricated clean result). New `--include-fixes` requests actionable fixes/suggestions (`--include-fixes --include-suggestions`), enriching the output that `--fix-plan` feeds to the AI. The result parser handles the v5 flat `violations[]`/`locations[]` shape in addition to v4 and the skip marker.
 
 - **`sfdt test --logic`** — run Apex and Flow tests together in one pass via Salesforce's Spring '26 `sf logic run test` (Flow tests named `FlowTesting.<name>`; requires the org "View All Data" permission). Flags: `--org`, `--test-level`, `--tests`, `--category Apex|Flow`, `--code-coverage`, `--wait` (default 30 min; the underlying command is async and sfdt waits for results). Arg building lives in the pure, unit-tested `src/lib/logic-test.js`. On failure (with `features.ai`) sfdt offers AI failure analysis for logic runs too — the shared analyzer feeds it the captured run output (logic results aren't written to the standard result dir), and every provider gets the context injected.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`sfdt test --logic`** — run Apex and Flow tests together in one pass via Salesforce's Spring '26 `sf logic run test` (Flow tests named `FlowTesting.<name>`; requires the org "View All Data" permission). Flags: `--org`, `--test-level`, `--tests`, `--category Apex|Flow`, `--code-coverage`, `--wait` (default 30 min; the underlying command is async and sfdt waits for results). Arg building lives in the pure, unit-tested `src/lib/logic-test.js`. AI failure analysis still applies to the Apex-only runner for now.
+
+### Added
+
 - **Cross-org release-version warning.** `sfdt compare` and `sfdt retrofit` now detect when the two orgs run different Salesforce releases (best-effort via each org's REST version list) and print a heads-up before comparing/deploying — metadata valid on one release may not deploy cleanly to another. Non-fatal and skipped for org↔local comparisons or when a release can't be determined; `retrofit --json` reports it as `releaseMismatch`. The release-detection helper (`expectedGaApiVersion`/`detectOrgRelease`, previously private to the monitor runner) moved to a shared `src/lib/org-release.js`.
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,7 @@ Dockerfile      Official Docker image definition
 | `SFDT_PARALLEL_DELAY` | Seconds between parallel batch launches, from `config.testConfig.parallelDelay` when set (a user-exported env value wins); shell-script default `1` otherwise |
 | `SFDT_DEFAULT_BRANCH` | `config.defaultBranch` (default: `"main"`); a user-exported env value wins. Used by `deployment-assistant.sh` for PR base branch |
 | `SFDT_SMOKE_TESTS` | Per-invocation: comma-joined `config.smokeTests.testClasses`, set by `smoke.js` (a user-exported env value wins) |
+| `SFDT_ANALYZER_INCLUDE_FIXES` | Per-invocation: `"true"` from `quality --include-fixes`; `scripts/quality/code-analyzer.sh` adds `--include-fixes --include-suggestions` to the Code Analyzer v5 run |
 | `SFDT_TAG_RELEASE` / `SFDT_CREATE_PR` / `SFDT_NOTIFY_SLACK` | Per-invocation: `"true"` from `deploy --tag/--create-pr/--notify` (or the GUI Release Hub toggles); drive post-deploy tagging, PR creation, and notifications in `deployment-assistant.sh` |
 | `SFDT_PACKAGE_DIRS` | JSON array of all package paths from `config.packageDirectories`, e.g. `["force-app/main/default","force-app/feature-a"]` |
 | `SFDT_MANIFEST_LAYOUT` | `config.manifestLayout` (`"flat"` or `"subpath"`); default `"flat"` |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -61,7 +61,7 @@
 
 ### Since v0.14.0 (previously unlisted here)
 - **`sfdt plugin create`** — scaffolds a new `sfdt-plugin-*` package with example `register(program)` wiring, test, and README
-- **MCP server shipped** — `sfdt mcp start` exposes 17 tools (`sfdt_deploy`, `sfdt_audit`, `sfdt_monitor`, `sfdt_retrofit`, …) with `confirmExecution` gating on mutating operations
+- **MCP server shipped** — `sfdt mcp start` exposes 21 tools (`sfdt_deploy`, `sfdt_audit`, `sfdt_monitor`, `sfdt_retrofit`, `sfdt_coverage`, `sfdt_scan`, `sfdt_dependencies`, `sfdt_flow_scan`, …) with `confirmExecution` gating on mutating operations
 - **Generic `http` AI provider** — any OpenAI-compatible `/chat/completions` gateway (Ollama, OpenRouter, MiniMax); secrets referenced by env-var name only
 - **New install methods** — `install.sh`, Homebrew tap (auto-bumped by the publish job once `HOMEBREW_TAP_TOKEN` is set), public GHCR Docker image (built from the published npm package on Node 22)
 - **VS Code extension live** — `sfdt.sfdt-devtools` on the Marketplace + Open VSX (v0.3.x): command catalog, org-health/status trees, embedded GUI dashboard webview
@@ -101,7 +101,7 @@ Remaining Sprint 4/5 queue from the 2026-07-03 audit + Summer '26 / Spring '26 r
 - **Agentforce support** — Agent metadata (`GenAiFunction`, `GenAiPlannerBundle`, scorers, Agent Script) in smart-deploy deltas; `sfdt agent-test` quality gate over `sf agent test run-eval` / the Testing API
 - **Code Analyzer v5 integration** in `sfdt quality` (PMD 7, `--include-fixes` feeding the AI fix loop)
 - **Agent-skills pack** compatible with `npx skills add`
-- **MCP coverage expansion** — read-only tools for test/coverage/scan/dependencies/flow first; gated mutating tools after
+- **MCP coverage expansion** — ✅ read-only tools added for coverage/scan/dependencies/flow (test results already via `sfdt_logs`); gated mutating tools (release/scratch/data) still to do
 - **Release Manager channel awareness** — *blocked:* the Summer '26 Release Manager Beta exposes no stable queryable public field for the channel; revisit when Salesforce ships a documented API (release version/preview already reported by `monitor org-info`)
 
 ### Chrome extension

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -131,6 +131,26 @@ Generates MkDocs-compatible documentation (custom objects + fields, Apex classes
 * **Arguments:**
   * `action` (enum, optional): `generate` (default) | `diagram`.
 
+#### `sfdt_coverage`
+Reports Apex code coverage for an org — org-wide percentage plus per-class coverage. Read-only.
+* **Arguments:**
+  * `org` (string, optional): org alias; defaults to `config.defaultOrg`.
+
+#### `sfdt_scan`
+Fetches the complete metadata inventory of an org (all component types and members). Read-only.
+* **Arguments:**
+  * `org` (string, optional): org alias; defaults to `config.defaultOrg`.
+
+#### `sfdt_dependencies`
+Shows a component's metadata dependencies — what it references and what references it. Read-only.
+* **Arguments:**
+  * `name` (string, **required**): component name (e.g. an Apex class or field API name).
+  * `org` (string, optional): org alias; defaults to `config.defaultOrg`.
+
+#### `sfdt_flow_scan`
+Analyzes the project's Flows for quality issues and anti-patterns (via `@sfdt/flow-core`). Read-only.
+* **Arguments:** none.
+
 ---
 
 ### 4. Context Budget Governance & Parking

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -148,8 +148,9 @@ Shows a component's metadata dependencies — what it references and what refere
   * `org` (string, optional): org alias; defaults to `config.defaultOrg`.
 
 #### `sfdt_flow_scan`
-Analyzes the project's Flows for quality issues and anti-patterns (via `@sfdt/flow-core`). Read-only.
-* **Arguments:** none.
+Analyzes a Salesforce org's Flows for quality issues and anti-patterns (via `@sfdt/flow-core`) — lists FlowDefinitions and fetches each active version from the org, then runs the health checks. Read-only.
+* **Arguments:**
+  * `org` (string, optional): org alias; defaults to `config.defaultOrg`.
 
 ---
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -395,8 +395,11 @@ sfdt quality --generate-stubs --dry-run  # preview stubs without writing files
 | `--tests` | Run `quality/test-analyzer.sh` only |
 | `--all` | Run both `quality/code-analyzer.sh` and `quality/test-analyzer.sh` |
 | `--fix-plan` | After analysis, send the output to AI for a prioritized, file-specific fix plan |
+| `--include-fixes` | Ask **Code Analyzer v5** for actionable fixes/suggestions in the scan output (`--include-fixes --include-suggestions`); the richer output feeds `--fix-plan` |
 | `--generate-stubs` | Generate `@IsTest` stub classes for Apex classes that have no test class |
 | `--dry-run` | Preview `--generate-stubs` output without writing any files |
+
+**Code Analyzer engine:** `sfdt quality` runs **Salesforce Code Analyzer v5** (`sf code-analyzer run`, a just-in-time plugin that auto-installs on a modern `sf` CLI). It falls back to the retired v4 (`sf scanner run`) if only that is present, and otherwise reports the scan as **SKIPPED** (never a fabricated clean result). Install manually with `sf plugins install code-analyzer` if needed.
 
 **AI fix plan:** The fix plan groups issues by severity (critical, high, medium, low) and provides file locations, descriptions, and concrete code suggestions. It focuses on Salesforce-specific concerns: governor limits, CRUD/FLS enforcement, bulk-safe patterns, and test coverage gaps.
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -339,6 +339,8 @@ Runs Apex tests against the configured org using the enhanced test runner. If te
 sfdt test
 sfdt test --analyze
 sfdt test --legacy
+sfdt test --logic                                   # Apex + Flow tests in one pass
+sfdt test --logic --tests FooTest,FlowTesting.MyFlow --code-coverage
 ```
 
 **Options:**
@@ -347,6 +349,15 @@ sfdt test --legacy
 |---|---|
 | `--legacy` | Use `run-tests.sh` instead of the enhanced runner |
 | `--analyze` | Run the test analyzer (`quality/test-analyzer.sh`) after tests complete, regardless of pass/fail |
+| `--logic` | Run Apex **and** Flow tests together via `sf logic run test` (Salesforce Spring '26 beta). Requires the org **"View All Data"** permission. Waits for async results (`--wait`, default 30 min). |
+| `--org <alias>` | Target org for `--logic` (default: `config.defaultOrg`) |
+| `--test-level <level>` | For `--logic`: `RunLocalTests` \| `RunAllTestsInOrg` \| `RunSpecifiedTests` |
+| `--tests <list>` | For `--logic`: comma-separated test names — Apex classes and Flow tests as `FlowTesting.<name>` |
+| `--category <cat>` | For `--logic`: restrict to `Apex` or `Flow` |
+| `--code-coverage` | For `--logic`: retrieve code coverage results |
+| `--wait <minutes>` | For `--logic`: streaming wait timeout (default 30) |
+
+> `--logic` is a thin pass-through to `sf logic run test`; AI failure analysis currently applies to the Apex-only runner (a follow-up will extend it to logic runs).
 
 **AI behavior on failure:** If tests fail and `features.ai` is `true` and the configured AI provider is available, sfdt prompts:
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -357,7 +357,7 @@ sfdt test --logic --tests FooTest,FlowTesting.MyFlow --code-coverage
 | `--code-coverage` | For `--logic`: retrieve code coverage results |
 | `--wait <minutes>` | For `--logic`: streaming wait timeout (default 30) |
 
-> `--logic` is a thin pass-through to `sf logic run test`; AI failure analysis currently applies to the Apex-only runner (a follow-up will extend it to logic runs).
+> `--logic` is a thin pass-through to `sf logic run test`. On failure (with `features.ai` enabled) sfdt offers the same AI failure analysis as the Apex runner, feeding it the captured logic-test output.
 
 **AI behavior on failure:** If tests fail and `features.ai` is `true` and the configured AI provider is available, sfdt prompts:
 

--- a/docs/plans/2026-07-03-gap-remediation-and-release-research.md
+++ b/docs/plans/2026-07-03-gap-remediation-and-release-research.md
@@ -82,7 +82,7 @@ Each item lists: what's wrong / what's new, the fix approach, files to touch, an
 ### 2.3 Chrome Web Store publishing stub — **S** (blocked on secrets)
 `.github/workflows/extension.yml:118-145` is commented out pending `CWS_*` secrets. Un-comment behind a `secrets`-present guard (same pattern as the Homebrew tap job) so it activates when the secrets are added and skips cleanly until then.
 
-### 2.4 MCP coverage — **M**
+### 2.4 MCP coverage — **M** — **DONE (sprint-4 branch: sfdt_coverage/scan/dependencies/flow_scan)**
 Missing tools for: `test`, `coverage`, `scan`, `dependencies`, `flow`, `explain`, `review`, `release`/`changelog`, `pull`, `scratch`, `data`. Add read-only ones first (`sfdt_test_results`, `sfdt_coverage`, `sfdt_scan`, `sfdt_dependencies`, `sfdt_flow_scan`); gate mutating ones (`sfdt_release`, `sfdt_scratch_create`) behind `confirmExecution` like `sfdt_deploy`/`sfdt_retrofit`.
 
 ### 2.5 Test gaps — **S** — **DONE (PR #171)**
@@ -127,13 +127,13 @@ Since sf CLI 2.136.8 (May 2026), tokens are redacted from `sf org display --json
 #### 4.3 RunRelevantTests follow-through — **M** — **DONE (sprint-3 branch: testFor/critical selection + `quality --test-hints`; GA detection intentionally deferred — no reliable GA signal yet; annotation widening fires only on RunSpecifiedTests by design)**
 Detect GA (drop the non-prod gate when appropriate); recognise Spring '26 `@IsTest(testFor='...')` / `@IsTest(critical=true)` annotations; add a quality check flagging test classes without `testFor` hints; keep surfacing the known CLI bug (forcedotcom/cli#3565) in docs.
 
-#### 4.4 Unified logic tests — **M**
+#### 4.4 Unified logic tests — **M** — **DONE (sprint-4 branch: `test --logic` + AI analysis)**
 Wrap `sf logic run test` so `sfdt test` can run Apex + Flow tests in one pass (Flow tests as `FlowTesting.<name>`); include Flow-test outcomes in AI test analysis.
 
 #### 4.5 Agentforce support — **L**
 (a) Metadata-mapper coverage for `GenAiFunction`, `GenAiPlannerBundle`, `aiAgentScorerDefinitions`, Agent Script/authoring bundles so smart-deploy deltas include agents. (b) `sfdt agent-test`: wrap `sf agent test run-eval` / the Agentforce Testing REST API with pass/fail thresholds, notifier dispatch, and PR decoration (Gearset sells exactly this).
 
-#### 4.6 Code Analyzer v5 integration — **M**
+#### 4.6 Code Analyzer v5 integration — **M** — **DONE (sprint-4 branch: v5 migration + `--include-fixes`)**
 Run `sf code-analyzer` (PMD 7, `--include-fixes`) inside `sfdt quality`; merge findings into the snapshot/PR comment; optionally feed fixes to the AI fix loop. Replaces the 1.5 stub path.
 
 #### 4.7 New audit/monitor checks — **S each** — **DONE (PR #174 + PR #175)**
@@ -153,10 +153,10 @@ Make `sfdt skills export` emit an `npx skills add`-compatible pack (mirroring `f
 
 ### Chrome extension
 
-#### 4.10 Summer '26 setup deep links — **S**
+#### 4.10 Summer '26 setup deep links — **S** — **PARKED: setup-node URLs for the new Summer '26 pages (Field Access Summary is per-object; Security Center / Release Manager are new Beta nodes) can't be verified without a real org — guessing would ship broken deep links. Do with org access to confirm URLs.**
 Add Field Access Summary, enhanced profile UI, Security Center Essentials, and Release Manager pages to the setup-tabs/nav features.
 
-#### 4.11 Org release/channel badge — **S**
+#### 4.11 Org release/channel badge — **S** — **PARTIALLY BLOCKED: release version + preview are derivable (as `monitor org-info` does), but the Release Manager *channel* has no queryable Beta API (see 4.7). Ship the version/preview badge; omit channel until an API exists.**
 Show release version, preview vs non-preview instance, and Release Manager channel in the extension header (pairs with 4.7's release-channel check).
 
 #### 4.12 Flow Scanner surface — **L**

--- a/gui/src/pages/Quality.jsx
+++ b/gui/src/pages/Quality.jsx
@@ -120,7 +120,7 @@ export default function QualityPage() {
                 </div>
                 {/(not installed|unavailable)/i.test(qualityData.unavailableMessage) && (
                   <div style={{ fontSize: 12, color: '#9a3412', fontFamily: 'monospace' }}>
-                    sf plugins install @salesforce/sfdx-scanner
+                    sf plugins install code-analyzer
                   </div>
                 )}
                 <div style={{ fontSize: 12, color: 'var(--fg-muted)', marginTop: 4 }}>

--- a/scripts/quality/code-analyzer.sh
+++ b/scripts/quality/code-analyzer.sh
@@ -153,14 +153,40 @@ fi
 # downstream consumer can mistake the absence of a scan for a passing one.
 # "result": [] plus "_sfdt_unavailable" are kept for existing consumers
 # (gui-server parseQualityLines); "status"/"reason" are additive.
-_SCANNER_PLUGIN=""
+# Prefer Salesforce Code Analyzer v5 (`sf code-analyzer run`, a just-in-time
+# plugin on a modern sf CLI). Fall back to the retired v4 (`sf scanner run`)
+# when only that is present, and otherwise emit the skipped marker — never
+# fabricate a clean scan. Set SFDT_ANALYZER_INCLUDE_FIXES=true to request
+# actionable fixes/suggestions in the output (v5 only).
+_INCLUDE_FIXES=()
+if [[ "${SFDT_ANALYZER_INCLUDE_FIXES:-}" == "true" ]]; then
+    _INCLUDE_FIXES=(--include-fixes --include-suggestions)
+fi
+
+_SCANNER_V4=""
 if command -v sf &>/dev/null; then
-    _SCANNER_PLUGIN=$(sf plugins --json 2>/dev/null | \
+    _SCANNER_V4=$(sf plugins --json 2>/dev/null | \
         jq -r '.[] | select(.name == "@salesforce/sfdx-scanner") | .name' 2>/dev/null || true)
 fi
 
-if [[ -n "$_SCANNER_PLUGIN" ]]; then
-    log_info "Running Salesforce Code Analyzer (sf scanner)..."
+if command -v sf &>/dev/null && sf code-analyzer --help &>/dev/null; then
+    log_info "Running Salesforce Code Analyzer v5 (sf code-analyzer run)..."
+    _ANALYZER_TMP=$(mktemp -t sfdt-analyzer-XXXXXX.json)
+    # --severity-threshold is deliberately omitted: sfdt applies its own
+    # thresholds, and a non-zero analyzer exit must not abort this script.
+    # v5 writes JSON to --output-file (by extension); cat it to stdout so the
+    # existing stdout-JSON contract (parseQualityLines) is preserved.
+    if sf code-analyzer run \
+        --workspace "$FORCE_APP_DIR" \
+        "${_INCLUDE_FIXES[@]}" \
+        --output-file "$_ANALYZER_TMP" &>/dev/null && [[ -s "$_ANALYZER_TMP" ]]; then
+        cat "$_ANALYZER_TMP"
+    else
+        printf '{"status":"skipped","reason":"sf code-analyzer run failed","result":[],"_sfdt_unavailable":"sf code-analyzer run failed — no violation data available for this run"}\n'
+    fi
+    rm -f "$_ANALYZER_TMP"
+elif [[ -n "$_SCANNER_V4" ]]; then
+    log_info "Running Salesforce Code Analyzer v4 (legacy sf scanner run)..."
     sf scanner run \
         --format json \
         --target "$FORCE_APP_DIR" \
@@ -168,9 +194,9 @@ if [[ -n "$_SCANNER_PLUGIN" ]]; then
         2>/dev/null || \
         printf '{"status":"skipped","reason":"sf scanner run failed","result":[],"_sfdt_unavailable":"sf scanner run failed — no violation data available for this run"}\n'
 else
-    log_warning "sf scanner not installed — static violation analysis SKIPPED (not run)."
-    log_warning "Install with:  sf plugins install @salesforce/sfdx-scanner"
-    printf '{"status":"skipped","reason":"sf code-analyzer not installed","result":[],"_sfdt_unavailable":"sf scanner plugin not installed. Run: sf plugins install @salesforce/sfdx-scanner"}\n'
+    log_warning "Salesforce Code Analyzer not available — static violation analysis SKIPPED (not run)."
+    log_warning "It auto-installs with a modern sf CLI, or run:  sf plugins install code-analyzer"
+    printf '{"status":"skipped","reason":"sf code-analyzer not installed","result":[],"_sfdt_unavailable":"sf code-analyzer not available. It auto-installs with a modern sf CLI, or run: sf plugins install code-analyzer"}\n'
 fi
 
 # Exit with appropriate code

--- a/src/commands/quality.js
+++ b/src/commands/quality.js
@@ -164,6 +164,7 @@ export function registerQualityCommand(program) {
     .option('--all', 'Run both code-analyzer and test-analyzer')
     .option('--fix-plan', 'Generate an AI-powered fix plan from quality output')
     .option('--generate-stubs', 'Generate @IsTest stub classes for untested Apex classes')
+    .option('--include-fixes', 'Ask Code Analyzer v5 for actionable fixes/suggestions in the scan output (feeds the AI fix plan)')
     .option('--dry-run', 'Preview --generate-stubs output without writing files')
     .option('--agent', 'Non-interactive agent mode (do not block waiting on the AI fix-plan session)')
     .option('--api67', "Run only the API v67 (Summer '26) user-mode readiness scan of local Apex sources")
@@ -186,19 +187,24 @@ export function registerQualityCommand(program) {
 
         let qualityOutput = '';
 
-        const runAnalyzer = async (scriptPath, label) => {
+        // --include-fixes only affects the Code Analyzer v5 run (test-analyzer
+        // ignores it); the shell script reads SFDT_ANALYZER_INCLUDE_FIXES.
+        const analyzerEnv = options.includeFixes ? { SFDT_ANALYZER_INCLUDE_FIXES: 'true' } : {};
+
+        const runAnalyzer = async (scriptPath, label, extraEnv = {}) => {
           print.info(`Running ${label}...`);
           try {
             const result = await runScript(scriptPath, config, {
               cwd: projectRoot,
               interactive: false,
+              env: extraEnv,
             });
             const output = result.stdout || '';
             qualityOutput += `\n--- ${label} ---\n${output}\n`;
             const skippedReason = detectSkippedScan(output);
             if (skippedReason) {
               print.warning(`${label}: static violation scan was SKIPPED — ${skippedReason}.`);
-              print.warning('No scan was performed; this is NOT a clean result. Install the scanner with: sf plugins install @salesforce/sfdx-scanner');
+              print.warning('No scan was performed; this is NOT a clean result. Code Analyzer auto-installs with a modern sf CLI, or run: sf plugins install code-analyzer');
               print.success(`${label} completed (scan skipped).`);
             } else {
               print.success(`${label} completed.`);
@@ -209,7 +215,7 @@ export function registerQualityCommand(program) {
             qualityOutput += `\n--- ${label} ---\n${output}\n`;
             const skippedReason = detectSkippedScan(output);
             if (skippedReason) {
-              print.warning(`${label}: static violation scan was SKIPPED — ${skippedReason}. Install the scanner with: sf plugins install @salesforce/sfdx-scanner`);
+              print.warning(`${label}: static violation scan was SKIPPED — ${skippedReason}. Code Analyzer auto-installs with a modern sf CLI, or run: sf plugins install code-analyzer`);
             }
             print.warning(`${label} found issues: ${err.message}`);
             return output;
@@ -219,10 +225,10 @@ export function registerQualityCommand(program) {
         if (options.tests) {
           await runAnalyzer('quality/test-analyzer.sh', 'Test Analyzer');
         } else if (options.all) {
-          await runAnalyzer('quality/code-analyzer.sh', 'Code Analyzer');
+          await runAnalyzer('quality/code-analyzer.sh', 'Code Analyzer', analyzerEnv);
           await runAnalyzer('quality/test-analyzer.sh', 'Test Analyzer');
         } else {
-          await runAnalyzer('quality/code-analyzer.sh', 'Code Analyzer');
+          await runAnalyzer('quality/code-analyzer.sh', 'Code Analyzer', analyzerEnv);
         }
 
         // AI fix plan

--- a/src/commands/test.js
+++ b/src/commands/test.js
@@ -1,4 +1,5 @@
 import inquirer from 'inquirer';
+import { execa } from 'execa';
 import { loadConfig } from '../lib/config.js';
 import { runScript } from '../lib/script-runner.js';
 import { isAiAvailable, runAiPrompt, providerSupportsAgenticTools } from '../lib/ai.js';
@@ -6,18 +7,54 @@ import { gatherLatestTestResults, frameProvidedContext } from '../lib/ai-context
 import { getPrompt } from '../lib/prompts.js';
 import { print } from '../lib/output.js';
 import { ExitCode, resolveExitCode } from '../lib/exit-codes.js';
+import { buildLogicTestArgs } from '../lib/logic-test.js';
+
+/**
+ * Run the Spring '26 unified test runner (`sf logic run test`) — Apex classes
+ * and Flow tests in one pass. Thin wrapper over the CLI; the arg building lives
+ * in `src/lib/logic-test.js`. Requires the org "View All Data" permission.
+ */
+async function runLogicTests(config, options) {
+  const org = options.org || config.defaultOrg;
+  const args = buildLogicTestArgs(options, org); // throws on missing org / bad flags
+  print.header(`Unified logic tests (Apex + Flow) → ${org}${options.dryRun ? ' [dry-run]' : ''}`);
+  if (options.dryRun) {
+    print.info(`Would run: sf ${args.join(' ')}`);
+    return;
+  }
+  try {
+    await execa('sf', args, { stdio: 'inherit' });
+    print.success('All logic tests passed.');
+  } catch (err) {
+    print.error('Logic tests failed.');
+    print.info('Note: `sf logic run test` is Beta and requires the "View All Data" org permission.');
+    process.exitCode = resolveExitCode(err);
+  }
+}
 
 export function registerTestCommand(program) {
   program
     .command('test')
-    .description('Run Apex tests with the enhanced test runner')
+    .description('Run Apex tests with the enhanced test runner (or --logic for unified Apex + Flow tests)')
     .option('--legacy', 'Use run-tests.sh instead of enhanced-test-runner.sh')
     .option('--analyze', 'Run test-analyzer after tests complete')
     .option('--dry-run', 'Show what would be executed without running')
+    .option('--logic', 'Run Apex + Flow tests together via `sf logic run test` (Spring \'26 beta; needs "View All Data")')
+    .option('--org <alias>', 'Target org for --logic (default: config.defaultOrg)')
+    .option('--test-level <level>', 'For --logic: RunLocalTests | RunAllTestsInOrg | RunSpecifiedTests')
+    .option('--tests <list>', 'For --logic: comma-separated test names (Apex classes and FlowTesting.<name>)')
+    .option('--category <cat>', 'For --logic: restrict to Apex or Flow')
+    .option('--code-coverage', 'For --logic: retrieve code coverage results')
+    .option('--wait <minutes>', 'For --logic: streaming wait timeout in minutes (default: 30)')
     .action(async (options) => {
       try {
         const config = await loadConfig();
         const projectRoot = config._projectRoot;
+
+        if (options.logic) {
+          await runLogicTests(config, options);
+          return;
+        }
 
         const scriptPath = options.legacy ? 'core/run-tests.sh' : 'core/enhanced-test-runner.sh';
 

--- a/src/commands/test.js
+++ b/src/commands/test.js
@@ -10,6 +10,55 @@ import { ExitCode, resolveExitCode } from '../lib/exit-codes.js';
 import { buildLogicTestArgs } from '../lib/logic-test.js';
 
 /**
+ * On a test failure, offer AI failure analysis (when `features.ai` is on and a
+ * provider is available). Shared by the Apex runner and the `--logic` runner.
+ *
+ * `providedContext` is the captured test output to inject into the prompt. The
+ * `--logic` path always passes it (logic results aren't written to the standard
+ * `logs/test-results/` dir that an agentic provider would Read); the Apex path
+ * leaves it null so agentic providers Read the files themselves, and only http
+ * providers get the gathered results injected.
+ */
+async function offerAiFailureAnalysis(config, projectRoot, { providedContext = null } = {}) {
+  if (!config.features?.ai || !(await isAiAvailable(config))) return;
+  const { analyzeFailure } = await inquirer.prompt([
+    { type: 'confirm', name: 'analyzeFailure', message: 'Tests failed. Analyze failures with AI?', default: true },
+  ]);
+  if (!analyzeFailure) return;
+
+  print.info('Analyzing test failures...');
+  let prompt = await getPrompt('test-failure', config._configDir);
+  const httpMode = !providerSupportsAgenticTools(config);
+  if (providedContext) {
+    prompt += frameProvidedContext('Test results', providedContext);
+  } else if (httpMode) {
+    const results = await gatherLatestTestResults(config);
+    if (results) {
+      prompt += frameProvidedContext('Test results', results);
+    } else {
+      print.warning('HTTP AI provider has no test-result files to analyze; results may be incomplete.');
+    }
+  }
+
+  const analysis = await runAiPrompt(prompt, {
+    config,
+    allowedTools: ['Read', 'Grep', 'Bash(sf apex test:*)'],
+    cwd: projectRoot,
+    aiEnabled: true,
+    interactive: !httpMode,
+  });
+
+  // CLI providers stream interactively; the http provider returns on stdout.
+  if (httpMode) {
+    if (analysis?.exitCode !== 0) {
+      print.error(analysis?.stderr?.trim() || 'AI analysis failed.');
+    } else if (analysis?.stdout?.trim()) {
+      console.log(`\n${analysis.stdout.trim()}\n`);
+    }
+  }
+}
+
+/**
  * Run the Spring '26 unified test runner (`sf logic run test`) — Apex classes
  * and Flow tests in one pass. Thin wrapper over the CLI; the arg building lives
  * in `src/lib/logic-test.js`. Requires the org "View All Data" permission.
@@ -22,12 +71,21 @@ async function runLogicTests(config, options) {
     print.info(`Would run: sf ${args.join(' ')}`);
     return;
   }
+
+  // Capture the run output when AI analysis is possible, so a failure can be
+  // fed to the AI (logic results aren't written to the standard result dir);
+  // otherwise stream straight to the terminal.
+  const canAnalyze = !!config.features?.ai;
   try {
-    await execa('sf', args, { stdio: 'inherit' });
+    const res = await execa('sf', args, canAnalyze ? { all: true } : { stdio: 'inherit' });
+    if (canAnalyze && res.all) console.log(res.all);
     print.success('All logic tests passed.');
   } catch (err) {
+    if (canAnalyze && err.all) console.log(err.all);
     print.error('Logic tests failed.');
     print.info('Note: `sf logic run test` is Beta and requires the "View All Data" org permission.');
+    const output = String(err.all || err.stderr || err.stdout || err.message || '').slice(0, 12000);
+    await offerAiFailureAnalysis(config, config._projectRoot, { providedContext: output });
     process.exitCode = resolveExitCode(err);
   }
 }
@@ -87,55 +145,7 @@ export function registerTestCommand(program) {
 
         // Offer AI analysis on failure (skip in dry-run)
         if (testFailed && !options.dryRun) {
-          const aiEnabled = config.features?.ai;
-          if (aiEnabled && (await isAiAvailable(config))) {
-            const { analyzeFailure } = await inquirer.prompt([
-              {
-                type: 'confirm',
-                name: 'analyzeFailure',
-                message: 'Tests failed. Analyze failures with AI?',
-                default: true,
-              },
-            ]);
-
-            if (analyzeFailure) {
-              print.info('Analyzing test failures...');
-
-              let prompt = await getPrompt('test-failure', config._configDir);
-
-              // HTTP providers can't Read the result files — inject them.
-              const httpMode = !providerSupportsAgenticTools(config);
-              if (httpMode) {
-                const results = await gatherLatestTestResults(config);
-                if (results) {
-                  prompt += frameProvidedContext('Test results', results);
-                } else {
-                  print.warning(
-                    'HTTP AI provider has no test-result files to analyze; results may be incomplete.',
-                  );
-                }
-              }
-
-              const analysis = await runAiPrompt(prompt, {
-                config,
-                allowedTools: ['Read', 'Grep', 'Bash(sf apex test:*)'],
-                cwd: projectRoot,
-                aiEnabled: true,
-                interactive: !httpMode,
-              });
-
-              // CLI providers stream their analysis interactively; the http
-              // provider returns it on stdout, so print it (or surface an error).
-              if (httpMode) {
-                if (analysis?.exitCode !== 0) {
-                  print.error(analysis?.stderr?.trim() || 'AI analysis failed.');
-                } else if (analysis?.stdout?.trim()) {
-                  console.log(`\n${analysis.stdout.trim()}\n`);
-                }
-              }
-            }
-          }
-
+          await offerAiFailureAnalysis(config, projectRoot);
           process.exitCode = ExitCode.ERROR;
         }
       } catch (err) {

--- a/src/lib/gui-server/parsers.js
+++ b/src/lib/gui-server/parsers.js
@@ -54,22 +54,49 @@ export function parseTestRunLines(lines) {
 }
 
 export function parseQualityLines(lines) {
+  // Accept three analyzer output shapes on stdout:
+  //   - Code Analyzer v5: `{ violations: [ { rule, engine, severity, message,
+  //     primaryLocationIndex, locations: [{ file, startLine, … }] } ], … }`
+  //   - Code Analyzer v4 (legacy sf scanner): `{ result: [ { fileName,
+  //     violations: [{ line, ruleName, severity, message }] } ] }` or a bare array
+  //   - skipped marker: `{ status: "skipped", result: [], _sfdt_unavailable }`
   const jsonLine = lines.find((l) => {
-    try { const p = JSON.parse(l); return p && (Array.isArray(p.result) || Array.isArray(p)); }
-    catch { return false; }
+    try {
+      const p = JSON.parse(l);
+      return p && (Array.isArray(p.violations) || Array.isArray(p.result) || Array.isArray(p));
+    } catch { return false; }
   });
   if (!jsonLine) return { status: 'PASS', summary: { critical: 0, high: 0, medium: 0, low: 0 }, violations: [] };
   const raw = JSON.parse(jsonLine);
-  const rawViolations = Array.isArray(raw.result) ? raw.result : Array.isArray(raw) ? raw : [];
-  const violations = rawViolations.flatMap((file) =>
-    (file.violations ?? []).map((v) => ({
-      file: file.fileName ?? '',
-      line: v.line ?? 0,
-      rule: v.ruleName ?? v.rule ?? '',
-      severity: v.severity ?? 3,
-      message: v.message ?? '',
-    }))
-  );
+
+  let violations;
+  if (Array.isArray(raw.violations)) {
+    // Code Analyzer v5 — flat violations, location in `locations[primaryLocationIndex]`.
+    violations = raw.violations.map((v) => {
+      const idx = Number.isInteger(v.primaryLocationIndex) ? v.primaryLocationIndex : 0;
+      const loc = (Array.isArray(v.locations) && (v.locations[idx] || v.locations[0])) || {};
+      return {
+        file: loc.file ?? '',
+        line: loc.startLine ?? 0,
+        rule: v.rule ?? '',
+        engine: v.engine ?? '',
+        severity: typeof v.severity === 'number' ? v.severity : 3,
+        message: v.message ?? '',
+      };
+    });
+  } else {
+    // Code Analyzer v4 / legacy — file-grouped violations.
+    const rawViolations = Array.isArray(raw.result) ? raw.result : Array.isArray(raw) ? raw : [];
+    violations = rawViolations.flatMap((file) =>
+      (file.violations ?? []).map((v) => ({
+        file: file.fileName ?? '',
+        line: v.line ?? 0,
+        rule: v.ruleName ?? v.rule ?? '',
+        severity: v.severity ?? 3,
+        message: v.message ?? '',
+      }))
+    );
+  }
   const summary = violations.reduce(
     (acc, v) => {
       if (v.severity === 1) acc.critical++;

--- a/src/lib/logic-test.js
+++ b/src/lib/logic-test.js
@@ -1,0 +1,50 @@
+/**
+ * Builder for `sf logic run test` — Salesforce's Spring '26 unified test runner
+ * that executes Apex classes and Flow tests in a single request (Flow tests are
+ * named `FlowTesting.<name>`). Requires the org "View All Data" system
+ * permission. Kept as a pure, unit-testable function; the `test` command wires
+ * it to execa.
+ *
+ * @see https://developer.salesforce.com/docs/platform/salesforce-cli-reference/guide/cli_reference_logic_run_test.html
+ */
+
+/** Valid `--test-level` values for `sf logic run test`. */
+export const LOGIC_TEST_LEVELS = ['RunLocalTests', 'RunAllTestsInOrg', 'RunSpecifiedTests'];
+/** Valid `--test-category` values. */
+export const LOGIC_TEST_CATEGORIES = ['Apex', 'Flow'];
+
+/**
+ * Build the argv (after `sf`) for a unified logic test run.
+ *
+ * @param {object} opts - parsed command options (`testLevel`, `tests`,
+ *   `category`, `codeCoverage`, `wait`).
+ * @param {string} org - resolved target-org alias (required).
+ * @returns {string[]} argv to pass to `execa('sf', argv)`.
+ * @throws {Error} when no org is resolved, or a test level / category is invalid.
+ */
+export function buildLogicTestArgs(opts = {}, org) {
+  if (!org) {
+    throw new Error(
+      'No org specified for logic tests — pass --org <alias> or set defaultOrg in .sfdt/config.json',
+    );
+  }
+  if (opts.testLevel && !LOGIC_TEST_LEVELS.includes(opts.testLevel)) {
+    throw new Error(`Invalid --test-level "${opts.testLevel}". Valid: ${LOGIC_TEST_LEVELS.join(', ')}`);
+  }
+  if (opts.category && !LOGIC_TEST_CATEGORIES.includes(opts.category)) {
+    throw new Error(`Invalid --category "${opts.category}". Valid: ${LOGIC_TEST_CATEGORIES.join(', ')}`);
+  }
+
+  // `sf logic run test` is async by default (returns a run id); wait for
+  // results so `sfdt test --logic` is usable in CI without a separate poll.
+  const wait = opts.wait != null && opts.wait !== '' ? String(opts.wait) : '30';
+  const args = ['logic', 'run', 'test', '--target-org', org, '--wait', wait];
+
+  if (opts.testLevel) args.push('--test-level', opts.testLevel);
+  // The CLI accepts a comma-separated list on a single `--tests`; pass the
+  // user's value through verbatim so `FlowTesting.<name>` entries aren't split.
+  if (opts.tests) args.push('--tests', opts.tests);
+  if (opts.category) args.push('--test-category', opts.category);
+  if (opts.codeCoverage) args.push('--code-coverage');
+  return args;
+}

--- a/src/lib/mcp-server.js
+++ b/src/lib/mcp-server.js
@@ -216,6 +216,46 @@ const TOOLS = [
     }
   },
   {
+    name: 'sfdt_coverage',
+    description: 'Report Apex code coverage for a Salesforce org — org-wide percentage plus per-class coverage. Read-only.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        org: { type: 'string', description: 'Salesforce org alias. Defaults to config defaultOrg.' }
+      }
+    }
+  },
+  {
+    name: 'sfdt_scan',
+    description: 'Fetch the complete metadata inventory of a Salesforce org (all component types and members). Read-only.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        org: { type: 'string', description: 'Salesforce org alias. Defaults to config defaultOrg.' }
+      }
+    }
+  },
+  {
+    name: 'sfdt_dependencies',
+    description: 'Show the metadata dependencies of a component — what it references and what references it. Read-only.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        name: { type: 'string', description: 'Metadata component name (e.g. an Apex class or field API name).' },
+        org: { type: 'string', description: 'Salesforce org alias. Defaults to config defaultOrg.' }
+      },
+      required: ['name']
+    }
+  },
+  {
+    name: 'sfdt_flow_scan',
+    description: 'Analyze the project\'s Flows for quality issues and anti-patterns (via @sfdt/flow-core). Returns the flow-scan report. Read-only.',
+    inputSchema: {
+      type: 'object',
+      properties: {}
+    }
+  },
+  {
     name: 'sfdt_get_parked_result',
     description: 'Retrieve the full payload of a previously parked tool result.',
     inputSchema: {
@@ -355,6 +395,32 @@ export class SfdtMcpServer {
         if (args.org) cmdArgs.push('--org', args.org);
 
         const { stdout } = await this.#runCliCommand(cmdArgs);
+        return this.#parseCliJson(stdout);
+      }
+
+      case 'sfdt_coverage': {
+        const cmdArgs = ['coverage', '--json'];
+        if (args.org) cmdArgs.push('--org', args.org);
+        const { stdout } = await this.#runCliCommand(cmdArgs);
+        return this.#parseCliJson(stdout);
+      }
+
+      case 'sfdt_scan': {
+        const cmdArgs = ['scan', '--json'];
+        if (args.org) cmdArgs.push('--org', args.org);
+        const { stdout } = await this.#runCliCommand(cmdArgs);
+        return this.#parseCliJson(stdout);
+      }
+
+      case 'sfdt_dependencies': {
+        const cmdArgs = ['dependencies', args.name, '--json'];
+        if (args.org) cmdArgs.push('--org', args.org);
+        const { stdout } = await this.#runCliCommand(cmdArgs);
+        return this.#parseCliJson(stdout);
+      }
+
+      case 'sfdt_flow_scan': {
+        const { stdout } = await this.#runCliCommand(['flow', 'scan', '--json']);
         return this.#parseCliJson(stdout);
       }
 

--- a/src/lib/mcp-server.js
+++ b/src/lib/mcp-server.js
@@ -249,10 +249,12 @@ const TOOLS = [
   },
   {
     name: 'sfdt_flow_scan',
-    description: 'Analyze the project\'s Flows for quality issues and anti-patterns (via @sfdt/flow-core). Returns the flow-scan report. Read-only.',
+    description: 'Analyze a Salesforce org\'s Flows for quality issues and anti-patterns (via @sfdt/flow-core) — lists FlowDefinitions and fetches each active version from the org, then runs the health checks. Returns the flow-scan report. Read-only.',
     inputSchema: {
       type: 'object',
-      properties: {}
+      properties: {
+        org: { type: 'string', description: 'Salesforce org alias. Defaults to config defaultOrg.' }
+      }
     }
   },
   {
@@ -420,7 +422,9 @@ export class SfdtMcpServer {
       }
 
       case 'sfdt_flow_scan': {
-        const { stdout } = await this.#runCliCommand(['flow', 'scan', '--json']);
+        const cmdArgs = ['flow', 'scan', '--json'];
+        if (args.org) cmdArgs.push('--org', args.org);
+        const { stdout } = await this.#runCliCommand(cmdArgs);
         return this.#parseCliJson(stdout);
       }
 

--- a/test/commands/quality.test.js
+++ b/test/commands/quality.test.js
@@ -68,6 +68,20 @@ describe('quality command', () => {
       expect.any(Object),
       expect.objectContaining({ interactive: false }),
     );
+    // no fixes requested → no SFDT_ANALYZER_INCLUDE_FIXES in the env
+    expect(runScript.mock.calls[0][2].env).toEqual({});
+  });
+
+  it('passes SFDT_ANALYZER_INCLUDE_FIXES with --include-fixes (code-analyzer only)', async () => {
+    runScript.mockResolvedValue({ exitCode: 0, stdout: 'ok' });
+
+    await createProgram().parseAsync(['node', 'sfdt', 'quality', '--include-fixes']);
+
+    expect(runScript).toHaveBeenCalledWith(
+      'quality/code-analyzer.sh',
+      expect.any(Object),
+      expect.objectContaining({ env: { SFDT_ANALYZER_INCLUDE_FIXES: 'true' } }),
+    );
   });
 
   it('runs only test-analyzer with --tests', async () => {
@@ -148,7 +162,7 @@ describe('quality command', () => {
       expect.stringContaining('sf code-analyzer not installed'),
     );
     expect(print.warning).toHaveBeenCalledWith(
-      expect.stringContaining('sf plugins install @salesforce/sfdx-scanner'),
+      expect.stringContaining('sf plugins install code-analyzer'),
     );
     // Skipped is not a failure — exit code must stay 0
     expect(process.exitCode).toBeUndefined();

--- a/test/commands/test.test.js
+++ b/test/commands/test.test.js
@@ -9,6 +9,8 @@ vi.mock('../../src/lib/script-runner.js', () => ({
   runScript: vi.fn(),
 }));
 
+vi.mock('execa', () => ({ execa: vi.fn() }));
+
 vi.mock('../../src/lib/ai.js', () => ({
   isAiAvailable: vi.fn(),
   runAiPrompt: vi.fn(),
@@ -36,6 +38,7 @@ vi.mock('../../src/lib/output.js', () => ({
 }));
 
 import { loadConfig } from '../../src/lib/config.js';
+import { execa } from 'execa';
 import { runScript } from '../../src/lib/script-runner.js';
 import { isAiAvailable, runAiPrompt, providerSupportsAgenticTools } from '../../src/lib/ai.js';
 import { gatherLatestTestResults } from '../../src/lib/ai-context.js';
@@ -168,6 +171,61 @@ describe('test command', () => {
 
     expect(print.error).toHaveBeenCalledWith(expect.stringContaining('no config'));
     expect(process.exitCode).toBe(1);
+  });
+
+  describe('--logic (unified Apex + Flow tests)', () => {
+    it('runs `sf logic run test` and never touches the shell test runner', async () => {
+      execa.mockResolvedValue({ exitCode: 0 });
+
+      await createProgram().parseAsync([
+        'node', 'sfdt', 'test', '--logic', '--org', 'qa', '--test-level', 'RunSpecifiedTests',
+        '--tests', 'FooTest,FlowTesting.MyFlow', '--code-coverage',
+      ]);
+
+      expect(runScript).not.toHaveBeenCalled();
+      expect(execa).toHaveBeenCalledWith(
+        'sf',
+        [
+          'logic', 'run', 'test', '--target-org', 'qa', '--wait', '30',
+          '--test-level', 'RunSpecifiedTests', '--tests', 'FooTest,FlowTesting.MyFlow', '--code-coverage',
+        ],
+        { stdio: 'inherit' },
+      );
+      expect(print.success).toHaveBeenCalled();
+      expect(process.exitCode).toBeUndefined();
+    });
+
+    it('falls back to config.defaultOrg when --org is omitted', async () => {
+      execa.mockResolvedValue({ exitCode: 0 });
+
+      await createProgram().parseAsync(['node', 'sfdt', 'test', '--logic']);
+
+      expect(execa).toHaveBeenCalledWith('sf', expect.arrayContaining(['--target-org', 'dev']), expect.any(Object));
+    });
+
+    it('prints the command and does not run it in --dry-run', async () => {
+      await createProgram().parseAsync(['node', 'sfdt', 'test', '--logic', '--dry-run']);
+
+      expect(execa).not.toHaveBeenCalled();
+      expect(print.info).toHaveBeenCalledWith(expect.stringContaining('sf logic run test'));
+    });
+
+    it('sets the error exit code when logic tests fail', async () => {
+      execa.mockRejectedValue(Object.assign(new Error('failing tests'), { exitCode: 1 }));
+
+      await createProgram().parseAsync(['node', 'sfdt', 'test', '--logic']);
+
+      expect(print.error).toHaveBeenCalledWith(expect.stringContaining('Logic tests failed'));
+      expect(process.exitCode).toBe(1);
+    });
+
+    it('errors clearly on an invalid --test-level (no execa call)', async () => {
+      await createProgram().parseAsync(['node', 'sfdt', 'test', '--logic', '--test-level', 'Bogus']);
+
+      expect(execa).not.toHaveBeenCalled();
+      expect(print.error).toHaveBeenCalledWith(expect.stringContaining('Invalid --test-level'));
+      expect(process.exitCode).toBe(1);
+    });
   });
 
   describe('http AI provider (non-agentic)', () => {

--- a/test/commands/test.test.js
+++ b/test/commands/test.test.js
@@ -189,7 +189,9 @@ describe('test command', () => {
           'logic', 'run', 'test', '--target-org', 'qa', '--wait', '30',
           '--test-level', 'RunSpecifiedTests', '--tests', 'FooTest,FlowTesting.MyFlow', '--code-coverage',
         ],
-        { stdio: 'inherit' },
+        // AI is enabled in the default test config → capture mode (all: true)
+        // so a failure can be fed to the AI; the argv is what matters here.
+        { all: true },
       );
       expect(print.success).toHaveBeenCalled();
       expect(process.exitCode).toBeUndefined();
@@ -224,6 +226,38 @@ describe('test command', () => {
 
       expect(execa).not.toHaveBeenCalled();
       expect(print.error).toHaveBeenCalledWith(expect.stringContaining('Invalid --test-level'));
+      expect(process.exitCode).toBe(1);
+    });
+
+    it('captures output and offers AI analysis on failure, injecting the captured run output', async () => {
+      // AI enabled (default config) → capture mode; agentic provider by default.
+      execa.mockRejectedValue(Object.assign(new Error('failed'), { exitCode: 1, all: 'LOGIC RUN OUTPUT: 1 failure' }));
+      isAiAvailable.mockResolvedValue(true);
+      inquirer.prompt.mockResolvedValue({ analyzeFailure: true });
+      runAiPrompt.mockResolvedValue({ stdout: '', exitCode: 0 });
+
+      await createProgram().parseAsync(['node', 'sfdt', 'test', '--logic']);
+
+      // capture mode → execa called with { all: true }, not stdio inherit
+      expect(execa).toHaveBeenCalledWith('sf', expect.any(Array), { all: true });
+      // the captured run output is injected as context for every provider
+      expect(gatherLatestTestResults).not.toHaveBeenCalled();
+      expect(runAiPrompt).toHaveBeenCalledWith(
+        expect.stringContaining('[context]'),
+        expect.any(Object),
+      );
+      expect(process.exitCode).toBe(1);
+    });
+
+    it('streams (no capture) and skips AI when features.ai is off', async () => {
+      loadConfig.mockResolvedValue({ _projectRoot: '/project', defaultOrg: 'dev', features: { ai: false } });
+      execa.mockRejectedValue(Object.assign(new Error('failed'), { exitCode: 1 }));
+
+      await createProgram().parseAsync(['node', 'sfdt', 'test', '--logic']);
+
+      expect(execa).toHaveBeenCalledWith('sf', expect.any(Array), { stdio: 'inherit' });
+      expect(inquirer.prompt).not.toHaveBeenCalled();
+      expect(runAiPrompt).not.toHaveBeenCalled();
       expect(process.exitCode).toBe(1);
     });
   });

--- a/test/lib/gui-server-parsers.test.js
+++ b/test/lib/gui-server-parsers.test.js
@@ -202,6 +202,45 @@ describe('parseQualityLines', () => {
     expect(result.summary.medium).toBe(1);
   });
 
+  it('parses the Code Analyzer v5 flat-violations shape (locations[primaryLocationIndex])', () => {
+    const payload = {
+      runDir: '/proj',
+      violationCounts: { total: 2 },
+      versions: { 'code-analyzer': '5.0.0' },
+      violations: [
+        {
+          rule: 'ApexCRUDViolation', engine: 'pmd', severity: 1, message: 'Check FLS', tags: ['Security'],
+          primaryLocationIndex: 1,
+          locations: [
+            { file: 'force-app/Other.cls', startLine: 5 },
+            { file: 'force-app/MyClass.cls', startLine: 42, startColumn: 3 },
+          ],
+        },
+        {
+          rule: 'no-unused-vars', engine: 'eslint', severity: 4, message: 'Unused',
+          locations: [{ file: 'force-app/lwc/x/x.js', startLine: 8 }],
+        },
+      ],
+    };
+    const result = parseQualityLines([JSON.stringify(payload)]);
+    expect(result.status).toBe('FAIL');
+    expect(result.violations).toHaveLength(2);
+    // primary location (index 1) is used, not the first
+    expect(result.violations[0]).toMatchObject({
+      file: 'force-app/MyClass.cls', line: 42, rule: 'ApexCRUDViolation', engine: 'pmd', severity: 1,
+    });
+    // missing primaryLocationIndex falls back to locations[0]
+    expect(result.violations[1]).toMatchObject({ file: 'force-app/lwc/x/x.js', line: 8, engine: 'eslint' });
+    expect(result.summary.critical).toBe(1); // severity 1
+    expect(result.summary.low).toBe(1); // severity 4
+  });
+
+  it('returns PASS for a v5 run with an empty violations array', () => {
+    const result = parseQualityLines([JSON.stringify({ violations: [], violationCounts: { total: 0 } })]);
+    expect(result.status).toBe('PASS');
+    expect(result.violations).toEqual([]);
+  });
+
   it('accumulates summary counts across severity levels', () => {
     const payload = [
       {

--- a/test/lib/logic-test.test.js
+++ b/test/lib/logic-test.test.js
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { buildLogicTestArgs, LOGIC_TEST_LEVELS, LOGIC_TEST_CATEGORIES } from '../../src/lib/logic-test.js';
+
+describe('buildLogicTestArgs', () => {
+  it('builds a minimal run with the required org and a default 30-minute wait', () => {
+    expect(buildLogicTestArgs({}, 'dev')).toEqual([
+      'logic', 'run', 'test', '--target-org', 'dev', '--wait', '30',
+    ]);
+  });
+
+  it('throws when no org is resolved', () => {
+    expect(() => buildLogicTestArgs({}, undefined)).toThrow(/No org specified/);
+    expect(() => buildLogicTestArgs({}, '')).toThrow(/No org specified/);
+  });
+
+  it('honours an explicit --wait (including 0)', () => {
+    expect(buildLogicTestArgs({ wait: '5' }, 'dev')).toContain('5');
+    // 0 is a legitimate caller-provided value, not "unset".
+    const args = buildLogicTestArgs({ wait: 0 }, 'dev');
+    expect(args[args.indexOf('--wait') + 1]).toBe('0');
+  });
+
+  it('appends test level, tests, category, and code-coverage when provided', () => {
+    const args = buildLogicTestArgs(
+      { testLevel: 'RunSpecifiedTests', tests: 'FooTest,FlowTesting.MyFlow', category: 'Flow', codeCoverage: true },
+      'dev',
+    );
+    expect(args).toEqual([
+      'logic', 'run', 'test', '--target-org', 'dev', '--wait', '30',
+      '--test-level', 'RunSpecifiedTests',
+      '--tests', 'FooTest,FlowTesting.MyFlow',
+      '--test-category', 'Flow',
+      '--code-coverage',
+    ]);
+  });
+
+  it('passes a comma-separated --tests value through verbatim (no splitting)', () => {
+    const args = buildLogicTestArgs({ tests: 'A,FlowTesting.B,C' }, 'dev');
+    expect(args[args.indexOf('--tests') + 1]).toBe('A,FlowTesting.B,C');
+  });
+
+  it('rejects an invalid test level', () => {
+    expect(() => buildLogicTestArgs({ testLevel: 'RunAllTests' }, 'dev')).toThrow(/Invalid --test-level/);
+    // every advertised level is accepted
+    for (const level of LOGIC_TEST_LEVELS) {
+      expect(() => buildLogicTestArgs({ testLevel: level }, 'dev')).not.toThrow();
+    }
+  });
+
+  it('rejects an invalid category', () => {
+    expect(() => buildLogicTestArgs({ category: 'Trigger' }, 'dev')).toThrow(/Invalid --category/);
+    for (const cat of LOGIC_TEST_CATEGORIES) {
+      expect(() => buildLogicTestArgs({ category: cat }, 'dev')).not.toThrow();
+    }
+  });
+});

--- a/test/lib/mcp-server.test.js
+++ b/test/lib/mcp-server.test.js
@@ -156,15 +156,24 @@ describe('SfdtMcpServer', () => {
       );
     });
 
-    it('executes sfdt_flow_scan (local, no org)', async () => {
+    it('executes sfdt_flow_scan and threads the optional org (flow scan queries the org)', async () => {
+      execa.mockResolvedValueOnce({ exitCode: 0, stdout: JSON.stringify({ flows: [] }), stderr: '' });
+
+      await callTool('sfdt_flow_scan', { org: 'dev' });
+      expect(execa).toHaveBeenCalledWith(
+        'node',
+        expect.arrayContaining(['flow', 'scan', '--json', '--org', 'dev']),
+        expect.anything()
+      );
+    });
+
+    it('executes sfdt_flow_scan without org (falls back to config defaultOrg)', async () => {
       execa.mockResolvedValueOnce({ exitCode: 0, stdout: JSON.stringify({ flows: [] }), stderr: '' });
 
       await callTool('sfdt_flow_scan', {});
-      expect(execa).toHaveBeenCalledWith(
-        'node',
-        expect.arrayContaining(['flow', 'scan', '--json']),
-        expect.anything()
-      );
+      const call = execa.mock.calls.at(-1);
+      expect(call[1]).toContain('flow');
+      expect(call[1]).not.toContain('--org');
     });
 
     it('executes sfdt_validate as a dry-run deploy (passes --dry-run)', async () => {

--- a/test/lib/mcp-server.test.js
+++ b/test/lib/mcp-server.test.js
@@ -122,6 +122,51 @@ describe('SfdtMcpServer', () => {
       expect(result.content[0].text).toContain('driftStatus');
     });
 
+    it('executes sfdt_coverage (read-only, --json, optional org)', async () => {
+      execa.mockResolvedValueOnce({ exitCode: 0, stdout: JSON.stringify({ orgWide: 82 }), stderr: '' });
+
+      const result = await callTool('sfdt_coverage', { org: 'prod' });
+      expect(execa).toHaveBeenCalledWith(
+        'node',
+        expect.arrayContaining(['coverage', '--json', '--org', 'prod']),
+        expect.anything()
+      );
+      expect(result.content[0].text).toContain('orgWide');
+    });
+
+    it('executes sfdt_scan (read-only metadata inventory)', async () => {
+      execa.mockResolvedValueOnce({ exitCode: 0, stdout: JSON.stringify({ types: [] }), stderr: '' });
+
+      await callTool('sfdt_scan', {});
+      expect(execa).toHaveBeenCalledWith(
+        'node',
+        expect.arrayContaining(['scan', '--json']),
+        expect.anything()
+      );
+    });
+
+    it('executes sfdt_dependencies with the required component name', async () => {
+      execa.mockResolvedValueOnce({ exitCode: 0, stdout: JSON.stringify({ references: [] }), stderr: '' });
+
+      await callTool('sfdt_dependencies', { name: 'MyClass', org: 'dev' });
+      expect(execa).toHaveBeenCalledWith(
+        'node',
+        expect.arrayContaining(['dependencies', 'MyClass', '--json', '--org', 'dev']),
+        expect.anything()
+      );
+    });
+
+    it('executes sfdt_flow_scan (local, no org)', async () => {
+      execa.mockResolvedValueOnce({ exitCode: 0, stdout: JSON.stringify({ flows: [] }), stderr: '' });
+
+      await callTool('sfdt_flow_scan', {});
+      expect(execa).toHaveBeenCalledWith(
+        'node',
+        expect.arrayContaining(['flow', 'scan', '--json']),
+        expect.anything()
+      );
+    });
+
     it('executes sfdt_validate as a dry-run deploy (passes --dry-run)', async () => {
       execa.mockResolvedValueOnce({ exitCode: 0, stdout: 'validated', stderr: '' });
 


### PR DESCRIPTION
## Summary

Sprint 4 core (items 4.4, 4.6, 2.4) plus carried-over CI cleanup. Each feature was built after **verifying the external contract first** (fetched the `sf logic run test` reference, the Code Analyzer v5 command + JSON-output schema, and confirmed `--json`/`--org` support per command) — one reviewable commit each with tests + docs. Full suite green (3400 tests); lint clean.

### 4.4 — `sfdt test --logic` (unified Apex + Flow tests)
- Runs Apex classes and Flow tests in one pass via Salesforce's Spring '26 `sf logic run test` (Flow tests as `FlowTesting.<name>`; needs org "View All Data"). Flags: `--org`, `--test-level`, `--tests`, `--category`, `--code-coverage`, `--wait` (async → waits for results). Arg building is the pure, unit-tested `src/lib/logic-test.js`.
- AI failure analysis is wired for logic runs too: a shared `offerAiFailureAnalysis` helper feeds the captured run output as context (logic results aren't written to the standard result dir). Apex-path behaviour unchanged.

### 4.6 — Salesforce Code Analyzer v5
- `sfdt quality` now runs `sf code-analyzer run` (v5 JIT plugin: PMD 7 / ESLint / RetireJS) instead of the retired v4 `sf scanner run`, falling back to v4 only if that's the only plugin present, else reporting SKIPPED (never a fabricated clean scan — preserves the Sprint-1 guarantee).
- New `--include-fixes` → `SFDT_ANALYZER_INCLUDE_FIXES` → `--include-fixes --include-suggestions`, enriching what `--fix-plan` feeds the AI.
- `parseQualityLines` extended to handle v5's flat `violations[]`/`locations[primaryLocationIndex]` shape alongside v4 and the skip marker — the old line-finder would have silently missed v5's shape. Install guidance updated everywhere (CLI, GUI banner, USAGE, CLAUDE.md env table).

### 2.4 — MCP read-only tools (17 → 21)
- `sfdt_coverage`, `sfdt_scan`, `sfdt_dependencies` (required `name`), `sfdt_flow_scan` — thin wrappers over the existing `--json` CLI commands following the `sfdt_drift` template. Test results are already reachable via `sfdt_logs`; mutating tools (release/scratch/data) remain deferred behind `confirmExecution`.

### CI cleanup
- Removed the temporary `show_full_output` debug flag on the claude-review workflow. The diagnostic did its job: the residual permission-denials were the model exploring paths it doesn't need (the `Skill` tool + a broad `Bash(find /)`), **not** comment posting — so no allowlist change is warranted (recorded in the workflow comment).

### Parked (documented in the plan, not in this PR)
- **4.10** Summer '26 setup deep links — the new pages' Lightning setup-node URLs can't be verified without a real org (guessing = broken links).
- **4.11** org **channel** badge — Release Manager channel has no queryable Beta API (per 4.7); the release/preview half is buildable when revisited.

## Test plan
- Full suite: 218 files / 3400 tests passing; `npm run lint` clean; shell scripts pass `bash -n`; GUI builds.
- New/extended tests: `logic-test`, `test --logic` (incl. AI analysis + capture mode), v5 parser fixtures, `quality --include-fixes`, and the four new MCP tools.
- Manual checks worth doing against a sandbox: `sfdt test --logic` (needs View All Data), `sfdt quality --include-fixes` (v5 plugin auto-installs), and one MCP `sfdt_coverage` call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K8gwZpdRU1BRrNGfYAyvAH

---
_Generated by [Claude Code](https://claude.ai/code/session_01K8gwZpdRU1BRrNGfYAyvAH)_