### PR TITLE
perf(docs): concurrent Apex file reads in doc generation

### DIFF
--- a/src/lib/doc-generator.js
+++ b/src/lib/doc-generator.js
@@ -131,19 +131,24 @@ async function collectObjects(base) {
 
 async function collectApex(base) {
   const files = await glob('classes/*.cls', { cwd: base, absolute: true });
-  const out = [];
-  for (const file of files) {
+
+  const processFile = async (file) => {
     const name = path.basename(file).replace(/\.cls$/, '');
-    const body = await fs.readFile(file, 'utf8').catch(() => '');
-    const metaXml = await fs.readFile(`${file}-meta.xml`, 'utf8').catch(() => '');
-    out.push({
+    const [body, metaXml] = await Promise.all([
+      fs.readFile(file, 'utf8').catch(() => ''),
+      fs.readFile(`${file}-meta.xml`, 'utf8').catch(() => ''),
+    ]);
+
+    return {
       name,
       apiVersion: parseApexMeta(metaXml).apiVersion,
       isTest: /@isTest/i.test(body),
       methods: extractApexMethods(body),
       doc: extractLeadingComment(body),
-    });
-  }
+    };
+  };
+
+  const out = await Promise.all(files.map(processFile));
   return out.sort((a, b) => a.name.localeCompare(b.name));
 }
 


### PR DESCRIPTION
Recreates #173 against `develop` (the original targeted `main` directly, so full CI never ran, and it went CONFLICTING on a stale 0.14.0 base).

**Change:** `collectApex` in `src/lib/doc-generator.js` now reads Apex files concurrently via `Promise.all`, with an inner `Promise.all` for each class's `.cls` + `.cls-meta.xml`.

**Behavior-preserving:** output order unchanged (final `.sort()` retained), `.catch(() => '')` read guards retained. `npm test` doc-generator suite passes locally.

Closes #173.