### PR TITLE
Audit and refresh the bundled agent skills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,9 +35,11 @@ npm-debug.log*
 # Package tarballs
 *.tgz
 
-# Skill eval workspaces
+# Skill eval workspaces and results — the evals.json prompt seeds ARE tracked
 sfdt-cli-workspace/
-skills/*/evals/
+skills/*-workspace/
+skills/*/evals/*
+!skills/*/evals/evals.json
 
 # Git worktrees
 .worktrees/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`skills export --target claude` now installs native Claude Code project skills.** Each bundled skill is copied to `.claude/skills/<name>/` (the real Claude Code convention, discovered automatically with frontmatter-driven triggering) instead of only writing flattened rules files; the legacy `.clauderules` / `.claudecode.json` outputs are still written for older tooling.
+- **Skill eval prompt seeds.** Every bundled skill now carries committed `evals/evals.json` test prompts (skill-creator schema) so revisions can be benchmarked; eval files are filtered out of all exports (packs, manifests, `.claude/skills` installs).
+- **Skills drift guard.** A new content-invariant test (`test/commands/skills-content.test.js`) fails CI when a CLI command is added or renamed without updating the `sfdt-cli` skill, and enforces frontmatter (name/description/license) and eval-seed presence for every skill.
+- **Skills publishing guide.** `docs/skills-publishing.md` documents distributing the pack to skill libraries (standalone `npx skills` repo, claude.ai `.skill` uploads) with a per-release checklist; `docs/sfdt-site-drafts/skills.mdx` is a ready-to-copy docs-site page.
+
+### Changed
+
+- **Bundled skills audited and refreshed** (see `docs/skills-audit-2026-07-12.md`): the `sfdt-cli` skill now documents all 42 commands (was ~18) including `deploy --smart` and the multi-provider AI system; fixed wrong CLI syntax in `sf-data` (`sf data import bulk`), `sf-pmd-scan` (Code Analyzer v5 `--config-file`/`--target`), and `sf-flow-review` (scanner flags, contradictory `$Label` guidance); removed project-specific leftovers; descriptions made more assertive about trigger contexts; every skill now declares `license: Apache-2.0`.
+
 ## [0.16.1] - 2026-07-09
 
 ### Security

--- a/docs/sfdt-site-drafts/skills.mdx
+++ b/docs/sfdt-site-drafts/skills.mdx
@@ -1,0 +1,63 @@
+---
+title: Agent Skills
+description: Ten bundled agent skills that teach AI coding assistants Salesforce DX workflows — install them into Claude Code, Cursor, Codex, or Windsurf with one command.
+---
+
+# Agent Skills
+
+`@sfdt/cli` ships an **agent skills pack** — ten curated instruction sets that
+teach AI coding assistants (Claude Code, Cursor, Codex, Windsurf) how to work
+on Salesforce DX projects: reviewing Apex and Flows, deploying safely, writing
+tests, running static analysis, and driving the sfdt CLI itself.
+
+Skills follow the [Agent Skills](https://code.claude.com/docs/en/skills)
+format: a `SKILL.md` with `name` + `description` frontmatter (which drives
+automatic triggering) plus optional bundled references. All skills are
+Apache-2.0 licensed.
+
+## Install into your project
+
+From any project where `@sfdt/cli` is installed:
+
+```bash
+# Claude Code — installs native project skills under .claude/skills/<name>/
+sfdt skills export --target claude
+
+# Cursor / Codex / Windsurf — flattened rules files
+sfdt skills export --target cursor     # .cursorrules
+sfdt skills export --target codex      # .codexrules
+sfdt skills export --target windsurf   # .windsurfrules
+
+# Portable pack (manifest.json + skill folders, npx-skills compatible)
+sfdt skills export --target pack --out ./sfdt-skills-pack
+```
+
+With the `claude` target, Claude Code discovers the skills automatically — no
+configuration needed. Each skill activates when its trigger contexts match
+what you're working on.
+
+## The skills
+
+| Skill | What it teaches |
+|-------|-----------------|
+| `sfdt-cli` | Using **and extending** the sfdt CLI — all commands, config system, `SFDT_` env vars, development guide |
+| `sf-apex-review` | Production-grade Apex review: SOQL/DML in loops, CRUD/FLS, bulkification, batch idempotency, severity-tiered output with a deploy verdict |
+| `sf-flow-review` | Flow metadata review: fault paths, bulk safety, hardcoded IDs, auto-layout, Flow-vs-Apex decisions |
+| `sf-test` | Apex testing: running tests, coverage analysis, test-class standards, coverage-gap hunting, TestDataFactory pattern |
+| `sf-deploy` | `sf project deploy` workflows: validate + quick deploy, destructive changes, test levels, troubleshooting |
+| `sf-data` | SOQL best practices, bulk import/export, tree data seeding, governor limits |
+| `sf-pmd-scan` | Salesforce Code Analyzer v5: scans, custom PMD rulesets, CI quality gates |
+| `sf-org-audit` | Whole-project health audit with a structured remediation report |
+| `sf-scratch-org` | Scratch org lifecycle: create, push/pull, conflicts, users, limits |
+| `sf-lwc` | Lightning Web Components: wire adapters, events, SLDS, template rules, anti-patterns |
+
+The Salesforce skills work in **any** SFDX project — they don't require sfdt
+to be configured, but they know to prefer sfdt's native commands (smart
+deploys, flow analysis, org audits) when a `.sfdt/` directory is present.
+
+## Keeping skills current
+
+The `sfdt-cli` skill is guarded by a CI test that fails whenever a CLI command
+is added or renamed without updating the skill — so the documented command
+surface can't silently drift. Each skill also carries committed eval prompts
+(`evals/evals.json`) used to benchmark revisions.

--- a/docs/skills-audit-2026-07-12.md
+++ b/docs/skills-audit-2026-07-12.md
@@ -1,0 +1,124 @@
+# Skills Audit — 2026-07-12
+
+Audit of the 10 bundled agent skills under `skills/`, performed against the
+skill-creator authoring methodology (frontmatter/description triggering
+quality, progressive disclosure, imperative style, generality across
+projects) and verified against the actual CLI (`node bin/sfdt.js --help` and
+per-command help output). All fixes listed below were applied in the same
+change.
+
+## Context
+
+The skills are shipped package assets (`"skills/"` in `package.json` `files`)
+distributed to end-user Salesforce projects via `sfdt skills export
+--target claude|cursor|codex|windsurf|pack`. Two consequences drove the audit
+criteria:
+
+- **The non-standard `triggers:` frontmatter field is intentional** — it is
+  parsed by `src/commands/skills.js` and rendered into the exported rules
+  files. It was kept (and added to `sfdt-cli`, the one skill missing it).
+- **Skills must be project-generic** (CLAUDE.md rule). Any leftover
+  project-specific value is a bug.
+
+## Findings and fixes by skill
+
+### sfdt-cli — severely stale (worst finding)
+
+| Finding | Severity | Fix |
+|---------|----------|-----|
+| Quick reference covered ~18 of the CLI's 42 registered commands — `audit`, `monitor`, `docs`, `data`, `scratch`, `flow`, `history`, `coverage`, `dependencies`, `ui`, `mcp`, `pr`, `retrofit`, `ci`, `explain`, `agent-test`, `skills` and more were absent | HIGH | Rewrote the quick reference as grouped tables covering every command |
+| AI docs said "Claude CLI required" — the CLI supports `claude` \| `gemini` \| `openai` \| `http` providers (`ai.provider`) | HIGH | Updated SKILL.md AI section, troubleshooting, and `references/commands.md` requirement lines |
+| `deploy` documented without `--smart` (the CI-facing delta-deploy mode) or its companion flags | HIGH | Documented smart mode in SKILL.md and the full flag table in `references/commands.md` |
+| `references/commands.md` `notify` section described the legacy Slack-only shape (`notifications.slack.webhookUrl`) — the notifier is provider-agnostic (Slack/Teams/Google Chat/webhook/Loki/email) with env-var-name secrets and a `snapshot` event | HIGH | Rewrote the section |
+| `references/config.md` config.json example predated the `ai` block, channel-based `notifications`, and `deployment.smart`; it also omitted the AJV `config-schema.json` lockstep rule and ~9 newer `SFDT_` env vars | MEDIUM | Updated example, added schema-validation note, added missing env vars, aligned "adding config" steps with CLAUDE.md's three-places-in-lockstep rule |
+| `references/development.md` scripts layout listed `new/` — the directory is `ops/` (plus `ci/`, `integration/`, `lib/` were missing); pre-commit checklist lacked the config-schema and docs-site steps | MEDIUM | Corrected layout; extended checklist |
+| Only skill without a `triggers:` list (inconsistent with export rendering) | LOW | Added |
+
+### sf-pmd-scan
+
+| Finding | Severity | Fix |
+|---------|----------|-----|
+| Project-specific leftover: ruleset `<description>TWU-556 / SF-Rebuild Custom Salesforce Ruleset</description>` | HIGH | Genericized |
+| `--pmd-ruleset` is not a Code Analyzer v5 flag — custom PMD rulesets are wired via `code-analyzer.yml` (`engines.pmd.custom_rulesets`) + `--config-file` | HIGH | Corrected with a working config example |
+| `--path-filter` is not a v5 flag; file subsetting uses `--target` | MEDIUM | Corrected |
+| No mention that `sfdt quality` wraps Code Analyzer in sfdt projects | LOW | Added cross-reference |
+
+### sf-flow-review
+
+| Finding | Severity | Fix |
+|---------|----------|-----|
+| Contradictory guidance: `{!$Label.*}` listed as a *hardcoded-ID smell* while the fix line recommended Custom Labels | HIGH | Rewrote: literal IDs are the smell; labels/metadata are the fix |
+| `sf flow scan --format json --output <file>` — the Lightning Flow Scanner plugin uses `--json`, `--files`, `--failon` | MEDIUM | Corrected |
+| No mention of the CLI's native `sfdt flow scan` / `sfdt flow conflicts` | MEDIUM | Added as the preferred path |
+
+### sf-data
+
+| Finding | Severity | Fix |
+|---------|----------|-----|
+| `sf data import legacy` is not a valid command for CSV inserts; flag name `--sobject-type` should be `--sobject` on the bulk commands | HIGH | Replaced with `sf data import bulk` / corrected flags; added single-record commands |
+| No mention of `sfdt data export/import <set>` (named, repeatable data sets) | LOW | Added cross-reference |
+
+### sf-test
+
+| Finding | Severity | Fix |
+|---------|----------|-----|
+| Hardcoded "this project targets 90%" — project-specific; the CLI default threshold is 75 and the real value lives in `.sfdt/config.json` `deployment.coverageThreshold` | MEDIUM | Points to Salesforce's 75% floor + the configured threshold |
+| No mention of `sfdt test` / `sfdt coverage` wrappers | LOW | Added |
+| Only legacy `System.assert*` taught; modern `Assert` class absent | LOW | Added preference note |
+
+### sf-deploy
+
+| Finding | Severity | Fix |
+|---------|----------|-----|
+| "(project target: 90%)" hardcoded in checklist | MEDIUM | Points to configured threshold |
+| Destructive-changes section labeled `sf project generate manifest` as "create a destructive package" (it generates a regular package.xml) | MEDIUM | Rewrote with the actual two-file mechanics + `sfdt manifest --destructive` |
+| No mention of `sfdt preflight` / `deploy --smart` / `rollback` | LOW | Added as preferred flow in sfdt projects |
+
+### sf-org-audit
+
+| Finding | Severity | Fix |
+|---------|----------|-----|
+| Assertion grep missed the modern `Assert` class (false positives on well-tested code) | LOW | Grep now covers `System.assert*` and `Assert.` |
+| Fast-path `sfdt audit all` / `monitor all` / `docs generate --ai` commands verified accurate against the CLI | — | No change needed |
+
+### sf-scratch-org
+
+| Finding | Severity | Fix |
+|---------|----------|-----|
+| "Default: 6 active scratch orgs per Dev Hub" — allocations vary by Dev Hub edition | LOW | Points to `sf limits api display` (`ActiveScratchOrgs`/`DailyScratchOrgs`) |
+| No mention of `sfdt scratch` / `scratch pool` | LOW | Added cross-reference |
+
+### sf-lwc
+
+| Finding | Severity | Fix |
+|---------|----------|-----|
+| Example taught `@track` for a reassigned array — fields are reactive by default; `@track` is only for in-place mutation | MEDIUM | Example modernized + explanatory note |
+| `apiVersion` example lacked "match `sourceApiVersion`" guidance | LOW | Comment added |
+
+### sf-apex-review
+
+Strongest skill of the set — pushy description, scope-expansion step,
+severity-tiered checklist, strict output contract. Only change: noted the
+modern `Assert` class in the test-quality section.
+
+## Description (triggering) pass
+
+Per skill-creator guidance, descriptions are the primary trigger mechanism and
+should state what the skill does *and* push on when to use it (models tend to
+under-trigger). Descriptions rewritten to be more assertive with concrete
+trigger contexts: `sf-data`, `sf-deploy`, `sf-flow-review`, `sf-scratch-org`,
+`sf-test`, `sf-lwc`, `sf-org-audit`, `sf-pmd-scan`. Already strong:
+`sf-apex-review`; extended with org-health vocabulary: `sfdt-cli`.
+
+## Recommendations (not done in this pass)
+
+1. **Eval harness**: `.gitignore` excludes `skills/*/evals/` — the intended
+   home for skill-creator-style eval prompts. None exist yet. Worth seeding
+   2-3 realistic test prompts per skill locally and benchmarking with/without
+   the skill before the next major skill revision.
+2. **Staleness guard**: the `sfdt-cli` skill drifted badly because nothing
+   ties command changes to it. Consider adding "update `skills/sfdt-cli/`"
+   to the development checklist (done in this pass) *and* a CI check that
+   diffs the command list in SKILL.md against `createCli()` registrations.
+3. **Docs site**: skills content ships in the npm package; if sfdt.dev
+   documents the skills pack, mirror the corrected command syntax there.

--- a/docs/skills-publishing.md
+++ b/docs/skills-publishing.md
@@ -1,0 +1,97 @@
+# Publishing the SFDT Skills Pack
+
+How to distribute the bundled agent skills (`skills/`) beyond the npm package,
+plus the checklist of items each publishing channel needs. Follows the
+2026-07-12 skills audit (`docs/skills-audit-2026-07-12.md`).
+
+## What already ships
+
+- **npm**: `skills/` is in `package.json` `files`, so every `@sfdt/cli` install
+  carries the skills. Users materialize them with `sfdt skills export`.
+- **`sfdt skills export --target claude`**: installs the skills natively into
+  the target project as `.claude/skills/<name>/` folders (Claude Code's real
+  project-skill convention — name + description frontmatter drive triggering).
+  Legacy `.clauderules` / `.claudecode.json` are still written for older tooling.
+- **`--target cursor|codex|windsurf`**: flattened rules files.
+- **`--target pack`**: an `npx skills add`-compatible pack (`manifest.json` +
+  `skills/` folders, same layout as `forcedotcom/sf-skills`).
+
+Eval prompt seeds (`skills/<name>/evals/evals.json`) are authoring assets: they
+are committed to git and ship in the npm tarball, but are **filtered out of
+every export** (pack manifests, pack copies, and `.claude/skills` installs).
+
+## Channel 1 — a standalone skills repo (`npx skills add`)
+
+`npx skills add <github-slug>` resolves `manifest.json` + `skills/` at the
+**repo root** of a published GitHub repo. This monorepo's root is the CLI
+package, so the pack must live in a dedicated repo (e.g.
+`scoobydrew83/sfdt-skills`), regenerated on each release:
+
+```bash
+sfdt skills export --target pack --out ../sfdt-skills
+cd ../sfdt-skills && git add -A && git commit -m "Sync skills from @sfdt/cli vX.Y.Z" && git push
+```
+
+To automate: add a release-job step in `ci.yml` that runs the export and pushes
+to the skills repo with a deploy token. Users then install with:
+
+```bash
+npx skills add scoobydrew83/sfdt-skills          # all skills
+npx skills add scoobydrew83/sfdt-skills --skill sf-apex-review
+```
+
+## Channel 2 — claude.ai skills library (`.skill` files)
+
+claude.ai accepts uploaded `.skill` bundles (a zip of the skill folder,
+`SKILL.md` first). Each skill folder here is already structurally valid:
+frontmatter carries `name`, `description`, and `license`, and bundled
+resources live under `references/`. To package one:
+
+```bash
+cd skills && zip -r ../sf-apex-review.skill sf-apex-review -x "*/evals/*"
+```
+
+(or use Anthropic's skill-creator `package_skill.py` if available). Upload via
+claude.ai → Settings → Capabilities → Skills. Org admins can distribute to a
+whole workspace.
+
+## Channel 3 — the docs site (sfdt.dev)
+
+The skills pack should have its own page on https://sfdt.dev/. A ready-to-use
+MDX draft is at `docs/sfdt-site-drafts/skills.mdx` — copy it into the
+`sfdt-site` repo under `content/` (add a `_meta.js` entry) the next time that
+repo is touched. Until that page exists, the pack is undiscoverable outside
+the CLI's help output.
+
+## Per-skill metadata checklist (before publishing to any library)
+
+All items below are enforced by `test/commands/skills-content.test.js`:
+
+- [x] `name` frontmatter matches the folder name (registries key installs off it)
+- [x] `description` present, ≤ 1024 chars, states what the skill does **and**
+      when to use it (skills under-trigger; be assertive)
+- [x] `license: Apache-2.0` frontmatter (registries and marketplaces require it)
+- [x] Eval seeds committed (`evals/evals.json`, ≥ 2 realistic prompts) so any
+      future revision can be benchmarked with skill-creator
+- [x] `sfdt-cli` documents every registered CLI command (drift guard)
+
+Not enforced, check manually per release:
+
+- [ ] Version-sensitive content still true (Code Analyzer v5 flags, sf CLI
+      command names, Salesforce release-gated features like `sf logic run test`)
+- [ ] No project-specific values (org aliases, ticket numbers, coverage targets)
+- [ ] Regenerate + push the standalone skills repo (Channel 1)
+- [ ] Re-package any `.skill` uploads whose source changed (Channel 2)
+
+## Benchmarking skill revisions (skill-creator loop)
+
+The committed eval seeds are the input to the skill-creator improvement loop.
+To benchmark a revision locally:
+
+1. Snapshot the current skill (`cp -r skills/<name> skills/<name>-workspace/skill-snapshot`)
+2. For each prompt in `skills/<name>/evals/evals.json`, run the task once with
+   the revised skill and once with the snapshot (subagents if available)
+3. Compare against `expected_output`; keep the revision only if it wins
+
+Workspaces (`skills/*-workspace/`) and any eval outputs are gitignored — only
+the `evals.json` seeds are tracked.

--- a/skills/sf-apex-review/SKILL.md
+++ b/skills/sf-apex-review/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: sf-apex-review
+license: Apache-2.0
 description: Production-grade Apex code review for this Salesforce project. Catches SOQL/DML in loops, CRUD/FLS gaps, missing bulkification, hardcoded IDs, empty catches, stale API versions, deprecated testMethod, Trigger.oldMap omissions, Datetime/Date type mismatches, unbounded @AuraEnabled queries, null relationship traversals, Database.Stateful waste, global vs public misuse, constant expressions inside loops, and missing batch idempotency guards. Use whenever reviewing or writing any .cls or .trigger file, or when asked to audit, review, check, or security-scan any Apex code — even if the user does not explicitly say "apex review".
 triggers:
   - apex review

--- a/skills/sf-apex-review/SKILL.md
+++ b/skills/sf-apex-review/SKILL.md
@@ -131,7 +131,7 @@ if (!alreadyProcessed.contains(invoice.Id)) {
 - No bulk test (200+ records) — the governor limit batch size
 - Missing negative/error path tests
 - No `@testSetup` when setup data is shared
-- Test methods with no meaningful assertions (`System.assert(true)`, asserting non-null only)
+- Test methods with no meaningful assertions (`System.assert(true)`, asserting non-null only); prefer the modern `Assert` class (`Assert.areEqual`, `Assert.isTrue`) with a failure message in new code
 - Hardcoded org-specific IDs (Record Type IDs, User IDs) — these break in scratch orgs and sandboxes; use `Schema.SObjectType.Obj__c.getRecordTypeInfosByDeveloperName().get('DeveloperName').getRecordTypeId()`
 
 **SOQL Results Not Cached in Static Variables**

--- a/skills/sf-apex-review/evals/evals.json
+++ b/skills/sf-apex-review/evals/evals.json
@@ -1,0 +1,23 @@
+{
+  "skill_name": "sf-apex-review",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "can you review OpportunityTriggerHandler.cls before I merge? it's in force-app/main/default/classes. my tech lead keeps complaining about our trigger patterns and I want this one to be clean",
+      "expected_output": "Structured review that also reads the trigger, test class, and -meta.xml; findings grouped CRITICAL/HIGH/MEDIUM/LOW with a summary table and a Deploy Safe verdict",
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "we had a prod incident last night — the nightly batch job double-credited a bunch of member accounts when someone re-ran it manually. here's the batch class, can you check if it's safe to re-run and what else might be wrong with it",
+      "expected_output": "Identifies missing batch idempotency guard as the root issue, checks finish() visibility, Database.insert error handling, and Database.Stateful usage; concrete fix code",
+      "files": []
+    },
+    {
+      "id": 3,
+      "prompt": "is this safe to deploy? MyAuraController.cls has a few @AuraEnabled methods the new LWC calls",
+      "expected_output": "Checks CRUD/FLS (WITH USER_MODE / SECURITY_ENFORCED), unbounded queries, input validation on parameters, AuraHandledException wrapping; explicit YES/NO deploy verdict",
+      "files": []
+    }
+  ]
+}

--- a/skills/sf-data/SKILL.md
+++ b/skills/sf-data/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sf-data
-description: SOQL query writing, data export/import, upsert operations, and data management for this Salesforce project. Activates when writing SOQL, managing data, or running data operations with SF CLI.
+description: SOQL query writing, data export/import, bulk upsert/delete, and data management for this Salesforce project. Use whenever writing or reviewing any SOQL query, loading or extracting org data, seeding sandboxes, running anonymous Apex for data fixes, or when the user mentions CSV loads, tree exports, aggregate queries, or governor limits on queries.
 triggers:
   - soql
   - SELECT
@@ -99,28 +99,36 @@ sf data query \
 
 ### Insert / Update / Upsert records
 ```bash
-# Insert from CSV
-sf data import legacy \
-  --sobject-type Account \
+# Bulk insert from CSV (Bulk API 2.0)
+sf data import bulk \
+  --sobject Account \
   --file data/accounts.csv \
-  --target-org <alias>
+  --target-org <alias> \
+  --wait 10
 
 # Upsert using external ID
 sf data upsert bulk \
-  --sobject-type Account \
+  --sobject Account \
   --file data/accounts.csv \
   --external-id External_Id__c \
   --target-org <alias> \
   --wait 10
 
-# Delete records
+# Delete records (CSV of record IDs)
 sf data delete bulk \
-  --sobject-type Account \
+  --sobject Account \
   --file data/accounts-to-delete.csv \
   --target-org <alias>
+
+# Single record operations
+sf data create record --sobject Account --values "Name='Test Co'" --target-org <alias>
+sf data update record --sobject Account --record-id <id> --values "Phone='555-0100'" --target-org <alias>
 ```
 
 ### Export / Import with relationships (tree format)
+
+If the project uses the sfdt CLI (`.sfdt/` directory present), `sfdt data export` / `sfdt data import` wrap these tree commands with named, reusable data-set definitions — prefer them for repeatable sandbox/scratch seeding.
+
 ```bash
 # Export with related records
 sf data export tree \

--- a/skills/sf-data/SKILL.md
+++ b/skills/sf-data/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: sf-data
+license: Apache-2.0
 description: SOQL query writing, data export/import, bulk upsert/delete, and data management for this Salesforce project. Use whenever writing or reviewing any SOQL query, loading or extracting org data, seeding sandboxes, running anonymous Apex for data fixes, or when the user mentions CSV loads, tree exports, aggregate queries, or governor limits on queries.
 triggers:
   - soql

--- a/skills/sf-data/evals/evals.json
+++ b/skills/sf-data/evals/evals.json
@@ -1,0 +1,23 @@
+{
+  "skill_name": "sf-data",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "i need to pull all accounts created in the last 90 days with their primary contacts into a csv for the marketing team, org alias is uat-full. what's the fastest way",
+      "expected_output": "A parent-child SOQL tree/CSV export using sf data query --result-format csv (or export tree for relationships), with correct date literal LAST_N_DAYS:90",
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "our sandbox refresh wiped the test data again. I have accounts.csv (about 8k rows) with an External_Id__c column — load it into the partial sandbox without creating dupes",
+      "expected_output": "sf data upsert bulk --sobject Account --external-id External_Id__c with --wait; mentions verifying results / failed records",
+      "files": []
+    },
+    {
+      "id": 3,
+      "prompt": "why does this apex keep hitting 'Too many SOQL queries: 101' — it queries contacts for each account in the trigger loop",
+      "expected_output": "Explains the governor limit, shows the bulkified map-based pattern querying once outside the loop",
+      "files": []
+    }
+  ]
+}

--- a/skills/sf-deploy/SKILL.md
+++ b/skills/sf-deploy/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sf-deploy
-description: Salesforce CLI deployment skill for this project — deploy metadata to sandbox or scratch org, retrieve metadata, run tests, cancel stuck deploys. Activates when discussing deploy, retrieve, push, or sf project commands.
+description: Salesforce CLI deployment skill for this project — deploy metadata to any org, retrieve metadata, validate, quick-deploy, and cancel stuck deploys. Use whenever the user wants to deploy, push, retrieve, validate, or promote Salesforce metadata, mentions package.xml or destructive changes, or asks "how do I get this to the sandbox/production" — even if they don't say "deploy".
 triggers:
   - deploy
   - retrieve
@@ -13,6 +13,17 @@ triggers:
 # Salesforce Deployment Skill
 
 You assist with all Salesforce CLI (sf) deployment operations for this project. Always use the modern `sf` CLI (not deprecated `sfdx`).
+
+If the project uses the sfdt CLI (`.sfdt/` directory present), prefer its deployment flow — it adds preflight checks, delta computation, smart test selection, and rollback:
+
+```bash
+sfdt preflight              # pre-deploy validation gates
+sfdt deploy --smart         # delta deploy: only changed metadata, minimal safe test level
+sfdt deploy --smart --dry-run   # validate-only
+sfdt rollback               # roll back a deployment
+```
+
+Use the raw `sf` commands below when sfdt is not configured or for one-off operations.
 
 ## Before Deploying — Always Confirm
 
@@ -109,18 +120,17 @@ sf project retrieve start --target-org <scratchAlias>
 
 ## Destructive Changes
 
-```bash
-# Create a destructive package
-sf project generate manifest \
-  --source-dir force-app \
-  --output-dir manifest
+A destructive deploy needs two files: a (possibly empty) `package.xml` and a `destructiveChangesPre.xml` or `destructiveChangesPost.xml` listing the members to delete (same XML format as package.xml).
 
-# Deploy with destructive changes
+```bash
+# Deploy with destructive changes applied after the deploy
 sf project deploy start \
   --manifest manifest/package.xml \
   --post-destructive-changes manifest/destructiveChangesPost.xml \
   --target-org <alias>
 ```
+
+With sfdt: `sfdt manifest --destructive <path>` generates the destructive manifest from the git diff (deleted files).
 
 ## Test Levels Explained
 
@@ -135,7 +145,7 @@ sf project deploy start \
 
 Before deploying to Production:
 - [ ] Validate first with `--dry-run` or `deploy validate`
-- [ ] Test coverage >= 75% (project target: 90%)
+- [ ] Test coverage >= 75% (or the project's configured threshold — `.sfdt/config.json` → `deployment.coverageThreshold`)
 - [ ] Run local tests pass cleanly
 - [ ] No pending scratch org-only config (permsets, test data)
 - [ ] Review destructive changes manifest if deleting metadata

--- a/skills/sf-deploy/SKILL.md
+++ b/skills/sf-deploy/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: sf-deploy
+license: Apache-2.0
 description: Salesforce CLI deployment skill for this project — deploy metadata to any org, retrieve metadata, validate, quick-deploy, and cancel stuck deploys. Use whenever the user wants to deploy, push, retrieve, validate, or promote Salesforce metadata, mentions package.xml or destructive changes, or asks "how do I get this to the sandbox/production" — even if they don't say "deploy".
 triggers:
   - deploy

--- a/skills/sf-deploy/evals/evals.json
+++ b/skills/sf-deploy/evals/evals.json
@@ -1,0 +1,23 @@
+{
+  "skill_name": "sf-deploy",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "I changed 3 apex classes and a flow, get them into the QA sandbox (alias qa2) but don't run the whole test suite, it takes 40 min",
+      "expected_output": "Confirms target org and scope, uses sf project deploy start with the specific paths and an appropriate non-prod test level (or sfdt deploy --smart when .sfdt/ exists)",
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "prod deploy is friday. we validated everything yesterday and got a job id back — how do I promote that validation without re-running all the tests?",
+      "expected_output": "Quick Deploy: sf project deploy quick --job-id <id> against the validated deploy; notes the validation expiry window",
+      "files": []
+    },
+    {
+      "id": 3,
+      "prompt": "we're deleting the old Region__c field and two obsolete classes as part of this release. how do I structure the deploy so nothing breaks?",
+      "expected_output": "Destructive changes flow: package.xml + destructiveChangesPost.xml (or Pre), deploy ordering considerations, validate first",
+      "files": []
+    }
+  ]
+}

--- a/skills/sf-flow-review/SKILL.md
+++ b/skills/sf-flow-review/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: sf-flow-review
+license: Apache-2.0
 description: Review Salesforce Flow metadata for best practices — fault paths, bulk safety, element naming, auto-layout, duplicate automation, and Flow vs Apex decision guidance. Use whenever reviewing, writing, or debugging any .flow-meta.xml file, or when the user asks about flows, record-triggered automation, process builder migration, or "why is my flow failing" — even if they don't say "review".
 triggers:
   - flow review

--- a/skills/sf-flow-review/SKILL.md
+++ b/skills/sf-flow-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sf-flow-review
-description: Review Salesforce Flow metadata for best practices — fault paths, bulk safety, element naming, auto-layout, duplicate automation, and Flow vs Apex decision guidance. Activates when discussing flows, flow-meta.xml files, or automation.
+description: Review Salesforce Flow metadata for best practices — fault paths, bulk safety, element naming, auto-layout, duplicate automation, and Flow vs Apex decision guidance. Use whenever reviewing, writing, or debugging any .flow-meta.xml file, or when the user asks about flows, record-triggered automation, process builder migration, or "why is my flow failing" — even if they don't say "review".
 triggers:
   - flow review
   - review flow
@@ -46,7 +46,7 @@ Record-Triggered flows fire on every record in a transaction. Avoid:
 - Multiple Get Records on the same object — consolidate with filters
 
 #### Hardcoded IDs in Flows
-Any `{!$Label.*}` or literal ID values (`00Q...`, `005...`) in text templates or assignments — use Custom Metadata or Custom Labels instead.
+Literal record ID values (`00Q...`, `005...`, or any 15/18-character ID) in decision criteria, assignments, or text templates break on sandbox refresh and between environments. Replace with Custom Metadata, Custom Labels (`{!$Label.x}`), or a Get Records lookup by DeveloperName.
 
 ### HIGH Priority
 
@@ -95,22 +95,29 @@ Check that flows have exactly ONE active version. Multiple versions waste org li
 #### Schedule-Triggered Flows
 Verify batch size is considered — schedule flows process records in batches of 200.
 
-## Running Lightning Flow Scanner
+## Automated Scanners
 
-If the sf CLI plugin is installed:
+If the project uses the sfdt CLI (`.sfdt/` directory present), it has native flow analysis built in — prefer it:
+```bash
+# Health analysis of every Flow with an active version (writes logs/flow-scan-latest.json)
+sfdt flow scan --org <alias> --json
+
+# Find record-triggered flows that collide on the same object + timing + event
+sfdt flow conflicts --org <alias> --json
+```
+
+Alternatively, the Lightning Flow Scanner sf plugin:
 ```bash
 # Install flow scanner plugin
 sf plugins install lightning-flow-scanner
 
-# Scan all flows
-sf flow scan \
-  --directory force-app/main/default/flows \
-  --format json \
-  --output flow-scan-results.json
+# Scan all flows in the default directory (JSON output for parsing)
+sf flow scan --json
 
-# Scan specific flow
+# Scan specific flows and fail CI on errors
 sf flow scan \
-  --directory force-app/main/default/flows/MyFlow.flow-meta.xml
+  --files force-app/main/default/flows/MyFlow.flow-meta.xml \
+  --failon error
 ```
 
 ## Flow Metadata Quick Reference

--- a/skills/sf-flow-review/evals/evals.json
+++ b/skills/sf-flow-review/evals/evals.json
@@ -1,0 +1,23 @@
+{
+  "skill_name": "sf-flow-review",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "review Case_Escalation_Flow.flow-meta.xml — support says users sometimes get an 'unhandled fault' error banner when they close cases",
+      "expected_output": "Finds missing faultConnector on DML elements as the likely cause; full checklist pass with CRITICAL/HIGH/MEDIUM findings and the standard output format",
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "we have like 6 record-triggered flows on Opportunity and updates feel slow, plus two of them seem to fight over the Stage field. can you untangle this?",
+      "expected_output": "Reviews trigger order/timing collisions (same object + event), recommends consolidation or orchestration; suggests sfdt flow conflicts / a scanner when available",
+      "files": []
+    },
+    {
+      "id": 3,
+      "prompt": "admin built a flow with 45 elements and 4 loops that scores leads. should this stay a flow or become apex? she really doesn't want to lose the ability to tweak it",
+      "expected_output": "Applies the Flow vs Apex decision guide (element count, loops, performance) with a balanced recommendation acknowledging admin maintainability",
+      "files": []
+    }
+  ]
+}

--- a/skills/sf-lwc/SKILL.md
+++ b/skills/sf-lwc/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sf-lwc
-description: Lightning Web Component development guidance — component structure, wire adapters, event patterns, SLDS styling, accessibility, and common pitfalls. Activates when working on LWC files (.js-meta.xml, .html, .js for LWC).
+description: Lightning Web Component development guidance — component structure, wire adapters, event patterns, SLDS styling, accessibility, and common pitfalls. Use whenever creating, editing, or reviewing any file in an lwc/ bundle (.html template, .js controller, .js-meta.xml), or when the user mentions Lightning components, wire adapters, App Builder properties, or component events — even if they just say "build me a component".
 triggers:
   - lwc
   - lightning web component
@@ -33,6 +33,7 @@ force-app/main/default/lwc/
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <!-- Match the project's sourceApiVersion in sfdx-project.json -->
     <apiVersion>63.0</apiVersion>
     <isExposed>true</isExposed>
     <!-- Where the component can be used -->
@@ -53,9 +54,12 @@ force-app/main/default/lwc/
 
 ## JavaScript Controller Patterns
 
-### Basic component with @api, @track, @wire
+### Basic component with @api and @wire
+
+All fields are reactive by default — `@track` is only needed when you mutate the *contents* of an object or array in place (and even then, prefer reassigning a new object/array instead).
+
 ```javascript
-import { LightningElement, api, wire, track } from 'lwc';
+import { LightningElement, api, wire } from 'lwc';
 import { getRecord, getFieldValue } from 'lightning/uiRecordApi';
 import { ShowToastEvent } from 'lightning/platformShowToastEvent';
 import getContacts from '@salesforce/apex/ContactController.getContacts';
@@ -63,7 +67,7 @@ import NAME_FIELD from '@salesforce/schema/Account.Name';
 
 export default class MyComponent extends LightningElement {
     @api recordId;          // Passed from parent or page
-    @track contacts = [];   // Reactive internal state
+    contacts = [];          // Reactive by default — no @track needed for reassignment
 
     error;
     isLoading = false;

--- a/skills/sf-lwc/SKILL.md
+++ b/skills/sf-lwc/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: sf-lwc
+license: Apache-2.0
 description: Lightning Web Component development guidance — component structure, wire adapters, event patterns, SLDS styling, accessibility, and common pitfalls. Use whenever creating, editing, or reviewing any file in an lwc/ bundle (.html template, .js controller, .js-meta.xml), or when the user mentions Lightning components, wire adapters, App Builder properties, or component events — even if they just say "build me a component".
 triggers:
   - lwc

--- a/skills/sf-lwc/evals/evals.json
+++ b/skills/sf-lwc/evals/evals.json
@@ -1,0 +1,23 @@
+{
+  "skill_name": "sf-lwc",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "build me a component for the account record page that lists the account's open cases in a table with a refresh button. should look native, our org is very SLDS-strict",
+      "expected_output": "Complete bundle (html/js/js-meta.xml) with @wire Apex, lightning-datatable or SLDS markup, lightning__RecordPage target, error toast handling",
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "my child component fires a CustomEvent('rowSelected') but the parent's onrowselected handler never runs, been stuck on this for an hour",
+      "expected_output": "Explains lowercase event-name rule (rowselected or better a short verb like select), listener naming on+event, bubbles/composed guidance",
+      "files": []
+    },
+    {
+      "id": 3,
+      "prompt": "code review this lwc js file — I used if:true in the template and querySelector to hide a div, works fine locally but reviewer flagged it",
+      "expected_output": "Flags deprecated if:true (use lwc:if) and direct DOM manipulation (use reactive property + conditional template); notes @track is rarely needed",
+      "files": []
+    }
+  ]
+}

--- a/skills/sf-org-audit/SKILL.md
+++ b/skills/sf-org-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sf-org-audit
-description: Full health audit of this Salesforce project — summarizes Apex class count, test coverage gaps, trigger patterns, flow inventory, LWC count, CI/CD status, and generates a prioritized remediation report. Run this for a top-level health check.
+description: Full health audit of this Salesforce project — summarizes Apex class count, test coverage gaps, trigger patterns, flow inventory, LWC count, CI/CD status, and generates a prioritized remediation report. Use whenever the user asks for a health check, audit, project analysis, technical-debt assessment, or "how bad is this org/codebase" — anything that calls for a whole-project view rather than a single-file review.
 triggers:
   - org audit
   - project audit
@@ -73,8 +73,8 @@ grep -rn "catch.*{" force-app --include="*.cls" -A 1 | grep -B 1 "^--$\|^}"
 # Logic in triggers (high — triggers should be 1-3 lines)
 wc -l force-app/main/default/triggers/*.trigger 2>/dev/null | sort -rn | head -10
 
-# Test classes without assertions (medium)
-grep -rL "System.assert\|System.assertEquals\|System.assertNotEquals" \
+# Test classes without assertions (medium) — covers legacy System.assert* and modern Assert class
+grep -rL "System.assert\|Assert\." \
   $(grep -rl "@isTest" force-app --include="*.cls") 2>/dev/null
 
 # Missing @testSetup (medium)

--- a/skills/sf-org-audit/SKILL.md
+++ b/skills/sf-org-audit/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: sf-org-audit
+license: Apache-2.0
 description: Full health audit of this Salesforce project — summarizes Apex class count, test coverage gaps, trigger patterns, flow inventory, LWC count, CI/CD status, and generates a prioritized remediation report. Use whenever the user asks for a health check, audit, project analysis, technical-debt assessment, or "how bad is this org/codebase" — anything that calls for a whole-project view rather than a single-file review.
 triggers:
   - org audit

--- a/skills/sf-org-audit/evals/evals.json
+++ b/skills/sf-org-audit/evals/evals.json
@@ -1,0 +1,17 @@
+{
+  "skill_name": "sf-org-audit",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "just inherited this salesforce codebase from an agency, no docs, no handover. give me a full health check so I know how much technical debt I'm sitting on",
+      "expected_output": "Runs all static phases (structure discovery, anti-patterns, flow analysis, CI/CD, security) and produces the structured JSON audit report with prioritized actions",
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "boss wants a one-pager on the state of our org before the budget meeting — connected org alias is prod-readonly. what can you pull together?",
+      "expected_output": "Uses the fast path (sfdt audit all / monitor all with --json when available) plus source-tree stats; summarizes into overall health + immediate/short/long-term actions",
+      "files": []
+    }
+  ]
+}

--- a/skills/sf-pmd-scan/SKILL.md
+++ b/skills/sf-pmd-scan/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: sf-pmd-scan
+license: Apache-2.0
 description: Run Salesforce Code Analyzer v5 (PMD + ESLint + Graph Engine) against this project, parse results, prioritize findings, and generate fix recommendations. Use whenever the user asks about static analysis, PMD, linting, code scanning, code quality gates, or CI quality checks for Apex/LWC — even if they just say "scan my code" or "is my code clean".
 triggers:
   - pmd

--- a/skills/sf-pmd-scan/SKILL.md
+++ b/skills/sf-pmd-scan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sf-pmd-scan
-description: Run Salesforce Code Analyzer (PMD + ESLint + Graph Engine) against this project, parse results, prioritize findings, and generate fix recommendations. Activates when asked about static analysis, PMD, code scanner, or code quality audit.
+description: Run Salesforce Code Analyzer v5 (PMD + ESLint + Graph Engine) against this project, parse results, prioritize findings, and generate fix recommendations. Use whenever the user asks about static analysis, PMD, linting, code scanning, code quality gates, or CI quality checks for Apex/LWC — even if they just say "scan my code" or "is my code clean".
 triggers:
   - pmd
   - code analyzer
@@ -14,6 +14,8 @@ triggers:
 # Salesforce Code Analyzer / PMD Scan Skill
 
 Run comprehensive static analysis against this project using Salesforce Code Analyzer v5.
+
+> If the project uses the sfdt CLI (`.sfdt/` directory present), prefer `sfdt quality` — it wraps Code Analyzer with project config, and `sfdt quality --include-fixes --fix-plan` adds analyzer fix suggestions plus an AI-generated remediation plan. Use the raw commands below when sfdt is not configured or you need custom selectors.
 
 ## Setup (if not installed)
 
@@ -68,11 +70,11 @@ sf code-analyzer run \
 
 ### Scan only changed files (for PR reviews)
 ```bash
-# Get changed files from git
+# Get changed files from git; --target selects files within the workspace
 CHANGED=$(git diff --name-only HEAD~1 HEAD | grep -E '\.(cls|trigger|js)$' | tr '\n' ',')
 sf code-analyzer run \
   --workspace . \
-  --path-filter "$CHANGED" \
+  --target "$CHANGED" \
   --output-file docs/scans/changed-results.json
 ```
 
@@ -107,7 +109,7 @@ This project can use a custom ruleset at `config/pmd-ruleset.xml`:
          xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0
                              https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
 
-    <description>TWU-556 / SF-Rebuild Custom Salesforce Ruleset</description>
+    <description>Project custom Salesforce ruleset</description>
 
     <!-- Always enforce these -->
     <rule ref="category/apex/security.xml"/>
@@ -137,12 +139,21 @@ This project can use a custom ruleset at `config/pmd-ruleset.xml`:
 </ruleset>
 ```
 
-Run with custom ruleset:
+Wire the ruleset in via the Code Analyzer v5 config file (there is no per-run ruleset flag in v5). Create `code-analyzer.yml` at the project root:
+
+```yaml
+engines:
+  pmd:
+    custom_rulesets:
+      - config/pmd-ruleset.xml
+```
+
+Then run with the config file:
 ```bash
 sf code-analyzer run \
+  --config-file code-analyzer.yml \
   --workspace . \
   --rule-selector "engine=pmd" \
-  --pmd-ruleset config/pmd-ruleset.xml \
   --output-file docs/scans/custom-results.json
 ```
 

--- a/skills/sf-pmd-scan/evals/evals.json
+++ b/skills/sf-pmd-scan/evals/evals.json
@@ -1,0 +1,23 @@
+{
+  "skill_name": "sf-pmd-scan",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "run static analysis on our apex and tell me what to fix first — we've never scanned this codebase and I'm bracing for the worst",
+      "expected_output": "Installs/verifies Code Analyzer v5, runs a full scan (or sfdt quality when .sfdt/ exists), parses by severity and frequency, produces the prioritized summary format",
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "add a code quality gate to our github actions so PRs fail on any critical PMD violation and more than 5 highs",
+      "expected_output": "Uses the official forcedotcom/run-code-analyzer@v2 action with num-sev1/num-sev2 outputs for the gate, not a hand-rolled shell step",
+      "files": []
+    },
+    {
+      "id": 3,
+      "prompt": "our team wants to relax ExcessiveClassLength to 1000 lines and drop the FieldDeclarationsShouldBeAtStart rule but keep everything else strict. how do I set that up with code analyzer v5?",
+      "expected_output": "Custom PMD ruleset XML wired in via code-analyzer.yml custom_rulesets + --config-file (not a per-run ruleset flag)",
+      "files": []
+    }
+  ]
+}

--- a/skills/sf-scratch-org/SKILL.md
+++ b/skills/sf-scratch-org/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sf-scratch-org
-description: Create and manage Salesforce scratch orgs — create, push source, pull changes, run tests, open browser, manage lifecycle. Activates when discussing scratch orgs, dev orgs, or local development setup.
+description: Create and manage Salesforce scratch orgs — create, push source, pull changes, assign permsets, seed data, and manage lifecycle. Use whenever the user mentions scratch orgs, Dev Hub, spinning up a dev/test environment, source push/pull conflicts, or setting up local Salesforce DX development — even if they just say "give me a fresh org".
 triggers:
   - scratch org
   - create org
@@ -13,6 +13,8 @@ triggers:
 # Scratch Org Management Skill
 
 You manage the full scratch org lifecycle for this Salesforce DX project.
+
+If the project uses the sfdt CLI (`.sfdt/` directory present), `sfdt scratch create|delete|list` wraps the commands below with the project's configured definition file, and `sfdt scratch pool` maintains a pool of pre-created orgs so developers don't wait on org creation. Prefer those; use the raw `sf` commands for one-offs.
 
 ## Prerequisites Check
 
@@ -176,7 +178,7 @@ sf project retrieve start --target-org dev-scratch --ignore-conflicts
 
 ## Scratch Org Limits
 
-- Default: 6 active scratch orgs per Dev Hub
+- Active-org and daily-creation allocations vary by Dev Hub edition (e.g. Developer Edition allows far fewer than Enterprise/Unlimited)
+- Check the actual allocation: `sf limits api display --target-org <devHubAlias>` (look for `ActiveScratchOrgs` and `DailyScratchOrgs`)
 - Max scratch org duration: 30 days
 - Always delete expired/unused orgs: `sf org delete scratch`
-- Check remaining allocation: `sf limits api display --target-org <devHubAlias>`

--- a/skills/sf-scratch-org/SKILL.md
+++ b/skills/sf-scratch-org/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: sf-scratch-org
+license: Apache-2.0
 description: Create and manage Salesforce scratch orgs — create, push source, pull changes, assign permsets, seed data, and manage lifecycle. Use whenever the user mentions scratch orgs, Dev Hub, spinning up a dev/test environment, source push/pull conflicts, or setting up local Salesforce DX development — even if they just say "give me a fresh org".
 triggers:
   - scratch org

--- a/skills/sf-scratch-org/evals/evals.json
+++ b/skills/sf-scratch-org/evals/evals.json
@@ -1,0 +1,23 @@
+{
+  "skill_name": "sf-scratch-org",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "new dev starting monday — spin up a scratch org for them with our source, the Sales_User permset, and the sample data plan in data/sample-data-plan.json",
+      "expected_output": "Create from the project definition file, deploy source, assign permset, import tree data, open org; sensible alias and duration",
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "sf org create scratch is failing with a limit error and I can't make new orgs anymore, what do I do",
+      "expected_output": "Checks ActiveScratchOrgs/DailyScratchOrgs via sf limits api display on the Dev Hub, lists and deletes expired/unused orgs",
+      "files": []
+    },
+    {
+      "id": 3,
+      "prompt": "I changed a validation rule and a page layout in the scratch org UI, and also edited two classes locally — now push says there are conflicts. help me not lose either side",
+      "expected_output": "Uses deploy/retrieve preview to inspect both sides, then targeted retrieve of the declarative changes before pushing local code; explains --ignore-conflicts direction semantics",
+      "files": []
+    }
+  ]
+}

--- a/skills/sf-test/SKILL.md
+++ b/skills/sf-test/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: sf-test
+license: Apache-2.0
 description: Run Apex tests, analyze code coverage, find untested paths, and generate test classes for this Salesforce project. Use whenever writing or reviewing any @isTest class, running tests, investigating coverage gaps or test failures, or when the user asks "why is coverage low", "write a test for this", or mentions deployment test requirements.
 triggers:
   - run tests

--- a/skills/sf-test/SKILL.md
+++ b/skills/sf-test/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sf-test
-description: Run Apex tests, analyze code coverage, find untested paths, and generate test classes for this Salesforce project. Activates when discussing tests, coverage, test classes, or @isTest.
+description: Run Apex tests, analyze code coverage, find untested paths, and generate test classes for this Salesforce project. Use whenever writing or reviewing any @isTest class, running tests, investigating coverage gaps or test failures, or when the user asks "why is coverage low", "write a test for this", or mentions deployment test requirements.
 triggers:
   - run tests
   - apex test
@@ -16,6 +16,16 @@ triggers:
 You are an expert in Salesforce Apex testing strategy and test class authorship.
 
 ## Running Tests
+
+If the project uses the sfdt CLI (`.sfdt/` directory present), prefer its wrappers — they apply the project's configured test classes and coverage threshold:
+
+```bash
+sfdt test                      # run configured Apex tests
+sfdt test --analyze            # run tests + failure/quality analysis
+sfdt coverage --org <alias>    # org-wide + per-class coverage, exits non-zero below threshold
+```
+
+Otherwise (or for one-off runs), use the raw `sf` commands below.
 
 ### Run all tests in org
 ```bash
@@ -134,7 +144,7 @@ private class MyClassTest {
 When asked to analyze coverage:
 
 1. Run tests with `--code-coverage` flag
-2. Identify classes below 90% threshold
+2. Identify classes below the project's coverage threshold (see below)
 3. For each low-coverage class, read the class and identify uncovered branches:
    - Null checks
    - Empty collection guards
@@ -196,4 +206,6 @@ public class TestDataFactory {
 
 ## Coverage Target
 
-This project targets **90%** org-wide code coverage. Flag any class below 75% as CRITICAL.
+Salesforce requires **75%** org-wide coverage to deploy to production — treat any class below 75% as CRITICAL. Many teams set a higher bar: check the project's configured threshold first (`.sfdt/config.json` → `deployment.coverageThreshold`, or `sfdt config get deployment.coverageThreshold`) and flag classes below it.
+
+Prefer `Assert.areEqual(expected, actual, msg)` / `Assert.isTrue(...)` (the modern `Assert` class) over the legacy `System.assert*` methods in new test code.

--- a/skills/sf-test/evals/evals.json
+++ b/skills/sf-test/evals/evals.json
@@ -1,0 +1,23 @@
+{
+  "skill_name": "sf-test",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "write a test class for InvoiceService.cls — it has a processInvoices(List<Invoice__c>) method with null guards and a catch block that logs errors. we need bulk coverage too",
+      "expected_output": "Test class with @testSetup, happy path, 200-record bulk test, negative/null cases, exception path; meaningful Assert.areEqual assertions with messages",
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "deployment to prod failed at 72% coverage. figure out which classes are dragging us down and write tests for the worst one, org alias is uat",
+      "expected_output": "Runs tests with --code-coverage (or sfdt coverage), identifies lowest classes vs the configured threshold, reads uncovered branches, generates targeted test methods",
+      "files": []
+    },
+    {
+      "id": 3,
+      "prompt": "reviewer says my tests are 'assertion-free theatre'. they all do System.assert(true) at the end so coverage passes. can you fix TestOrderHelper.cls properly",
+      "expected_output": "Replaces meaningless assertions with real state verification per method, flags the anti-pattern list, keeps coverage while adding actual verification",
+      "files": []
+    }
+  ]
+}

--- a/skills/sfdt-cli/SKILL.md
+++ b/skills/sfdt-cli/SKILL.md
@@ -1,11 +1,19 @@
 ---
 name: sfdt-cli
-description: "Guide for using AND contributing to the @sfdt/cli (Salesforce DevTools) CLI. Use when: (1) the user mentions sfdt commands, deployment, testing, Apex coverage, org drift, or release manifests; (2) you see a .sfdt/ directory or sfdx-project.json and the user wants CLI-driven workflows; (3) the user says sfdt should/could support something, wants to add a command, extend config, or suggests sfdt can help with a task — this means implementing the feature in the CLI itself."
+description: "Guide for using AND contributing to the @sfdt/cli (Salesforce DevTools) CLI. Use when: (1) the user mentions sfdt commands, deployment, testing, Apex coverage, org drift, org health audits/monitoring, docs generation, or release manifests; (2) you see a .sfdt/ directory or sfdx-project.json and the user wants CLI-driven workflows; (3) the user says sfdt should/could support something, wants to add a command, extend config, or suggests sfdt can help with a task — this means implementing the feature in the CLI itself."
+triggers:
+  - sfdt
+  - ".sfdt/"
+  - salesforce devtools
+  - deploy salesforce
+  - org drift
+  - org audit
+  - release manifest
 ---
 
 # sfdt CLI — Salesforce DevTools
 
-`@sfdt/cli` is a Node.js CLI that wraps Salesforce DX workflows into opinionated, configurable commands. It handles deployment, testing, quality analysis, release management, metadata pulls, rollback, drift detection, and AI-powered code review for any Salesforce DX project.
+`@sfdt/cli` is a Node.js CLI that wraps Salesforce DX workflows into opinionated, configurable commands. It handles deployment (including smart delta deploys), testing, quality analysis, release management, metadata pulls, rollback, drift detection, org health audits and monitoring, documentation generation, data seeding, scratch-org pooling, notifications, and AI-powered code review for any Salesforce DX project. It also ships a web dashboard (`sfdt ui`), an MCP server (`sfdt mcp`), a VS Code extension, and an `sf` CLI plugin (`sf sfdt <command>`).
 
 ## When to use this skill
 
@@ -23,34 +31,75 @@ sfdt is a **generic tool** — it contains no project-specific values. All confi
 User runs command → Load .sfdt/ config → Set SFDT_* env vars → Execute shell script
 ```
 
-**Prerequisites**: Node.js >= 18, Salesforce CLI (`sf`), and optionally the Claude CLI (for AI features).
+**Prerequisites**: Node.js >= 18, Salesforce CLI (`sf`), and optionally an AI provider (see "AI features" below).
 
 ## Commands quick reference
+
+**Deploy & release**
+
+| Command | What it does |
+|---------|-------------|
+| `sfdt deploy [--managed] [--smart] [--source-dir <path>]` | Deploy to an org; `--smart` computes a git delta with smart test selection; `--source-dir` deploys a folder without a manifest |
+| `sfdt preflight [--strict]` | Pre-deployment validation gates |
+| `sfdt rollback [--org <alias>] [--json]` | Roll back a deployment |
+| `sfdt smoke [--org <alias>]` | Post-deploy smoke tests |
+| `sfdt manifest [--package <name\|all>] [--name <label>] [--destructive <path>]` | Generate scoped `package.xml` (and destructive manifest) from git diff |
+| `sfdt release [--package <name\|all>] [--name <label>]` | Release manifest + optional AI release notes |
+| `sfdt changelog generate\|release\|check` | AI-generate entries, cut a version section, verify vs git |
+| `sfdt retrofit --source <a> --target <b> [--execute]` | Retrieve from source org → commit → smart-deploy to target |
+| `sfdt explain [file]` | AI analysis of a deployment error log |
+
+**Test & quality**
+
+| Command | What it does |
+|---------|-------------|
+| `sfdt test [--analyze] [--logic] [--class-names <list>]` | Run Apex tests (`--logic`: unified Apex + Flow tests) |
+| `sfdt coverage [--org <alias>] [--threshold <pct>]` | Org-wide + per-class coverage; non-zero exit below threshold |
+| `sfdt quality [--all] [--fix-plan] [--include-fixes]` | Code Analyzer + test quality; optional AI fix plan |
+| `sfdt review [--base <branch>]` | AI-powered code review of branch diff |
+| `sfdt agent-test` | Run an Agentforce agent test as a CI gate |
+
+**Org health & inspection**
+
+| Command | What it does |
+|---------|-------------|
+| `sfdt audit [all\|<check>] [--org] [--json] [--notify]` | Org health audit: licenses, MFA, unused Apex, inactive users/flows/validations, API versions, FLS, … |
+| `sfdt monitor [all\|<check>] [--org] [--json] [--notify]` | Org monitoring: limits, Apex failures, security score, deploy history, legacy API usage, backup |
+| `sfdt drift [--org <alias>] [--json]` | Detect org metadata drift vs local source |
+| `sfdt compare [--source <alias\|local>] [--target <alias>]` | Diff two orgs or local vs org; `--output` writes package.xml |
+| `sfdt scan [--org <alias>] [--format json\|table]` | Full metadata inventory from an org |
+| `sfdt dependencies <name> [--gaps]` | What a component references / is referenced by (Tooling API + source parsing) |
+| `sfdt flow scan\|conflicts [--org] [--json]` | Flow health analysis; record-triggered flow collision detection |
+| `sfdt history [--type <t>] [--limit <n>] [--json]` | Recent run history from the local index |
+| `sfdt pull` | Pull metadata from default org |
+
+**Project & data**
 
 | Command | What it does |
 |---------|-------------|
 | `sfdt init` | Initialize `.sfdt/` config (interactive prompts) |
-| `sfdt deploy [--managed] [--source-dir <path>]` | Deploy to default org; `--source-dir` deploys a folder directly without a manifest |
-| `sfdt test [--legacy] [--analyze]` | Run Apex tests with coverage |
-| `sfdt quality [--tests] [--all] [--fix-plan]` | Code/test quality analysis |
-| `sfdt manifest [--package <name\|all>] [--name <label>]` | Generate scoped `package.xml` from git diff; `--name today` uses date stamp |
-| `sfdt release [--package <name\|all>] [--name <label>]` | Generate release manifest + optional AI release notes |
-| `sfdt pull` | Pull metadata from default org |
-| `sfdt preflight [--strict]` | Pre-deployment validation |
-| `sfdt rollback [--org <alias>] [--json]` | Rollback a deployment |
-| `sfdt smoke [--org <alias>]` | Post-deploy smoke tests |
-| `sfdt review [--base <branch>]` | AI-powered Salesforce code review |
-| `sfdt drift [--org <alias>] [--json]` | Detect org metadata drift |
-| `sfdt compare [--source <alias\|local>] [--target <alias>]` | Diff two orgs or local source vs org; optional `--output` writes `package.xml` |
-| `sfdt scan [--org <alias>] [--format json\|table]` | Fetch complete metadata inventory from an org |
-| `sfdt config get <key>` | Print a config value using dot notation |
-| `sfdt config set <key> <value>` | Set a config value using dot notation (with type coercion) |
-| `sfdt notify <event> [--version] [--org] [--message]` | Slack notifications |
-| `sfdt changelog generate [--limit <n>]` | AI-generate changelog entries |
-| `sfdt changelog release <version>` | Move [Unreleased] to version section |
-| `sfdt changelog check` | Verify changelog vs git changes |
+| `sfdt config get\|set <key> [value]` | Read/write config with dot notation |
+| `sfdt docs generate [--ai] [--roles [list]]` | Generate project docs (objects/Apex/flows/LWC) + ER diagram |
+| `sfdt data list\|export\|import\|delete <set>` | Named data sets over `sf data tree` for sandbox/scratch seeding |
+| `sfdt scratch create\|delete\|list\|pool` | Scratch org lifecycle and pre-created org pooling |
+| `sfdt notify <event> [--message <msg>]` | Notifications (Slack, Teams, Google Chat, webhook, Loki, email) |
+| `sfdt pr comment [--type audit\|monitor]` | Post snapshots/results as PR comments (via `gh`) |
+| `sfdt pr-description` | Generate a PR description from deployment changes |
+| `sfdt ci init --provider <p> --type <t>` | Generate CI pipeline templates (GitHub/GitLab/Azure/Bitbucket) |
 
-For full command details including options, arguments, and behavior, read `references/commands.md`.
+**Tooling & integrations**
+
+| Command | What it does |
+|---------|-------------|
+| `sfdt ui` | Local web dashboard (port 7654) |
+| `sfdt mcp` | Manage the MCP server (for AI agents/IDEs) |
+| `sfdt skills export --target <t>` | Export these agent skills to Claude/Cursor/Codex/Windsurf or an `npx skills` pack |
+| `sfdt plugin` | Manage sfdt CLI plugins |
+| `sfdt extension` / `sfdt feature-flags` | Chrome extension bridge + kill-switches |
+| `sfdt doctor [--extension]` | Diagnose the local sfdt install |
+| `sfdt ai` / `sfdt completion` / `sfdt update` | AI utilities, shell completion, self-update |
+
+Most commands support `--json`, emitting an sf-native `{ status, result, warnings }` envelope on stdout. For full command details including options, arguments, and behavior, read `references/commands.md`.
 
 ## Configuration system
 
@@ -90,19 +139,21 @@ sfdt test --analyze         # Run tests + analysis
 
 ### AI features require opt-in
 
-AI-powered commands (`review`, `quality --fix-plan`, `changelog generate`, `release` notes) only work when:
+AI-powered commands (`review`, `explain`, `quality --fix-plan`, `changelog generate`, `release` notes, `docs generate --ai`) only work when:
 1. `features.ai` is `true` in `.sfdt/config.json`
-2. The Claude CLI is installed and available on PATH
+2. The configured provider is available. `ai.provider` selects it: `claude` (Claude Code CLI), `gemini` (Gemini CLI), `openai` (Codex CLI), or `http` (any OpenAI-compatible endpoint — Ollama, OpenRouter, etc. — via `ai.baseURL`/`ai.model`/`ai.apiKeyEnv`)
 
-If either condition fails, the command exits with a message — it does not error.
+If either condition fails, the command exits with a friendly message — it does not error. The three CLI providers run agentic subprocesses (read-only sandbox); the `http` provider is plain text completion, so agentic commands pre-gather context for it instead.
 
 ### Targeting different orgs
 
-Most commands use the `defaultOrg` from config. Commands that accept `--org <alias>` (rollback, smoke, drift) override this for one-off operations against other orgs.
+Most commands use the `defaultOrg` from config. Commands that accept `--org <alias>` (deploy, rollback, smoke, drift, audit, monitor, coverage, flow, data, …) override this for one-off operations against other orgs.
 
-### The `--managed` deploy flag
+### Deploy modes
 
-`sfdt deploy` uses `deployment-assistant.sh` by default (interactive). Pass `--managed` to use `deploy-manager.sh` which provides validation gates and structured deployment flow.
+`sfdt deploy` uses `deployment-assistant.sh` by default (interactive). Two alternatives:
+- `--managed` uses `deploy-manager.sh` — validation gates and structured deployment flow
+- `--smart` runs a self-contained non-interactive delta deploy: computes changed metadata from the git diff, respects `package-no-overwrite.xml`, and picks the minimal safe test level (never downgrades tests in production). Combine with `--dry-run` for validate-only, `--pr-comment` to decorate the PR, or `--ai-fix` for AI-assisted error fixing. This is the mode CI pipelines use.
 
 ## Common tasks
 
@@ -154,13 +205,26 @@ sfdt drift                  # Check default org
 sfdt drift --org staging    # Check specific org
 ```
 
+### "Check org health"
+```bash
+sfdt audit all --org prod --json      # licenses, MFA, unused Apex, API versions, FLS, …
+sfdt monitor all --org prod --notify  # limits, Apex failures, security score → notification channels
+sfdt history --type audit --limit 10  # trend recent runs
+```
+
+### "Deploy only what changed in this branch (CI)"
+```bash
+sfdt deploy --smart --dry-run   # validate the delta
+sfdt deploy --smart --prod      # real deploy, tests never downgraded
+```
+
 ## Troubleshooting
 
 | Problem | Cause | Fix |
 |---------|-------|-----|
 | "Run `sfdt init` first" | No `.sfdt/` directory found | Run `sfdt init` in project root |
 | "AI features are not enabled" | `features.ai` is false | Edit `.sfdt/config.json`, set `features.ai: true` |
-| "Claude CLI not found" | Claude not installed | Install Claude CLI separately |
+| AI provider not found | Configured provider CLI not installed | Install the CLI for `ai.provider` (claude/gemini/codex), or switch to the `http` provider |
 | Command can't find `sf` | Salesforce CLI not on PATH | Install `@salesforce/cli` globally |
 | Deploy fails | Org auth expired | Run `sf org login web -a <alias>` |
 

--- a/skills/sfdt-cli/SKILL.md
+++ b/skills/sfdt-cli/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: sfdt-cli
+license: Apache-2.0
 description: "Guide for using AND contributing to the @sfdt/cli (Salesforce DevTools) CLI. Use when: (1) the user mentions sfdt commands, deployment, testing, Apex coverage, org drift, org health audits/monitoring, docs generation, or release manifests; (2) you see a .sfdt/ directory or sfdx-project.json and the user wants CLI-driven workflows; (3) the user says sfdt should/could support something, wants to add a command, extend config, or suggests sfdt can help with a task — this means implementing the feature in the CLI itself."
 triggers:
   - sfdt

--- a/skills/sfdt-cli/evals/evals.json
+++ b/skills/sfdt-cli/evals/evals.json
@@ -1,0 +1,23 @@
+{
+  "skill_name": "sfdt-cli",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "set up sfdt in this salesforce project and wire up a PR pipeline that only deploys what changed, validating against the uat org",
+      "expected_output": "sfdt init, then sfdt ci init --provider github --type deploy (smart delta deploy with --dry-run validation); explains the .sfdt/ config it created",
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "I want a scheduled weekly org health report for prod posted to our slack channel. we already have sfdt configured",
+      "expected_output": "Configures notifications channels (webhookUrlEnv env-var name, not inline secret), uses sfdt monitor all --notify / sfdt ci init --type monitor for the schedule",
+      "files": []
+    },
+    {
+      "id": 3,
+      "prompt": "sfdt should be able to show me which flows would collide on the same record before I deploy — does it do that? if not, add it",
+      "expected_output": "Points to the existing sfdt flow conflicts command rather than reimplementing; if extending, follows references/development.md (thin command, lib logic, config template + schema in lockstep)",
+      "files": []
+    }
+  ]
+}

--- a/skills/sfdt-cli/references/commands.md
+++ b/skills/sfdt-cli/references/commands.md
@@ -1,6 +1,6 @@
 # sfdt CLI — Command Reference
 
-Detailed reference for every sfdt command, including options, arguments, and internal behavior.
+Detailed reference for the core sfdt commands, including options, arguments, and internal behavior. Newer commands are summarized in [Additional commands](#additional-commands) — run `sfdt <command> --help` for their full, always-current option list.
 
 ## Table of Contents
 
@@ -20,6 +20,7 @@ Detailed reference for every sfdt command, including options, arguments, and int
 - [sfdt config](#sfdt-config)
 - [sfdt notify](#sfdt-notify)
 - [sfdt changelog](#sfdt-changelog)
+- [Additional commands](#additional-commands)
 
 ---
 
@@ -44,18 +45,26 @@ Initialize sfdt configuration for a Salesforce DX project. Creates the `.sfdt/` 
 
 ## sfdt deploy
 
-Deploy to a Salesforce org using the configured deployment script.
+Deploy to a Salesforce org — interactive manifest flow by default, or a self-contained smart delta deploy.
 
-**Usage**: `sfdt deploy [--managed]`
+**Usage**: `sfdt deploy [--managed] [--smart] [options]`
 
 **Options**:
 | Flag | Description |
 |------|-------------|
 | `--managed` | Use `deploy-manager.sh` (structured, validation gates) instead of `deployment-assistant.sh` (interactive) |
+| `--smart` | Smart delta deploy: git-diff-derived metadata only, `package-no-overwrite.xml` protection, minimal safe test level. Non-interactive; the CI mode |
+| `--dry-run` | Show what would run (smart mode: validate-only via `sf project deploy validate`) |
+| `--org <alias>` | Target org (default: config `defaultOrg`) |
+| `--source-dir <path>` | Deploy a source directory instead of a manifest |
+| `--delta-base <ref>` / `--delta-head <ref>` | Git range for the smart delta (defaults: config or `main` … `HEAD`) |
+| `--prod` | Treat target as production — never downgrade the test level |
+| `--skip-preflight` | Skip pre-deployment preflight checks |
+| `--ai-deps` / `--ai-fix` | AI dependency cleanup on the delta / AI deploy-error analysis on failure |
+| `--tag` / `--create-pr` / `--notify` | Post-deploy tagging, PR creation, notifications |
+| `--pr-comment` | (smart mode) decorate the current PR with the delta + outcome |
 
-**Scripts invoked**:
-- Default: `scripts/core/deployment-assistant.sh`
-- With `--managed`: `scripts/core/deploy-manager.sh`
+**Scripts invoked** (non-smart): `scripts/core/deployment-assistant.sh`, or `scripts/core/deploy-manager.sh` with `--managed`. Smart mode is pure Node (`src/lib/smart-deploy.js`), no archive/commit side effects.
 
 ---
 
@@ -63,13 +72,15 @@ Deploy to a Salesforce org using the configured deployment script.
 
 Run Apex tests with the enhanced test runner.
 
-**Usage**: `sfdt test [--legacy] [--analyze]`
+**Usage**: `sfdt test [--legacy] [--analyze] [--class-names <list>] [--logic]`
 
 **Options**:
 | Flag | Description |
 |------|-------------|
 | `--legacy` | Use `run-tests.sh` instead of `enhanced-test-runner.sh` |
 | `--analyze` | Run `test-analyzer.sh` after tests complete |
+| `--class-names <list>` | Run only these Apex test classes (comma-separated), overriding configured classes |
+| `--logic` | Run Apex + Flow tests together via `sf logic run test` (Spring '26 beta); pairs with `--org`, `--test-level`, `--tests`, `--category`, `--code-coverage`, `--wait` |
 
 **Behavior**:
 1. Runs selected test script (catches errors, doesn't immediately exit on failure)
@@ -88,7 +99,7 @@ Run Apex tests with the enhanced test runner.
 
 Run code quality analysis and optionally generate an AI fix plan.
 
-**Usage**: `sfdt quality [--tests] [--all] [--fix-plan]`
+**Usage**: `sfdt quality [--tests] [--all] [--fix-plan] [options]`
 
 **Options**:
 | Flag | Description |
@@ -96,6 +107,10 @@ Run code quality analysis and optionally generate an AI fix plan.
 | `--tests` | Run test-analyzer only (skip code-analyzer) |
 | `--all` | Run both code-analyzer and test-analyzer |
 | `--fix-plan` | Generate AI-powered fix plan grouped by severity |
+| `--include-fixes` | Ask Code Analyzer v5 for actionable fixes/suggestions (feeds the fix plan) |
+| `--generate-stubs` | Generate `@IsTest` stub classes for untested Apex (preview with `--dry-run`) |
+| `--api67` / `--test-hints` | Targeted readiness scans (user-mode API v67; `@IsTest(testFor=...)` hints); both support `--json` |
+| `--agent` | Non-interactive agent mode (don't block on the AI fix-plan session) |
 
 **Behavior**:
 - Default (no flags): runs `quality/code-analyzer.sh` only
@@ -109,16 +124,18 @@ Run code quality analysis and optionally generate an AI fix plan.
 
 Generate a release manifest and optionally AI-powered release notes.
 
-**Usage**: `sfdt release [version]`
+**Usage**: `sfdt release [version] [--package <name|all>] [--name <label>]`
 
-**Arguments**:
-| Argument | Required | Description |
+**Arguments / options**:
+| Flag/Arg | Required | Description |
 |----------|----------|-------------|
 | `version` | No | Version label for the release |
+| `--package <name\|all>` | No | Package directory to generate the manifest for (default: `all`) |
+| `--name <label>` | No | Release label (semver, free-form, or `today`) |
 
 **Behavior**:
-1. Runs `scripts/core/generate-release-manifest.sh` (passes version as arg if provided)
-2. If AI enabled and Claude available: prompts user to generate release notes
+1. Runs `scripts/core/generate-release-manifest.sh` (release label passed via `SFDT_RELEASE_NAME`)
+2. If AI enabled and the provider available: prompts user to generate release notes
 3. Release notes AI prompt analyzes `git log --oneline -30`
 4. Output sections: What's New, Bug Fixes, Breaking Changes, Deployment Notes
 
@@ -199,7 +216,7 @@ AI-powered Salesforce code review of current branch changes.
 |------|-------------|
 | `--base <branch>` | Base branch to diff against (default: `main`) |
 
-**Requirements**: AI must be enabled AND Claude CLI must be available.
+**Requirements**: AI must be enabled AND the configured provider available (see `ai.provider` in `references/config.md`).
 
 **Behavior**:
 1. Runs `git diff <base>...HEAD` to get branch diff
@@ -231,14 +248,14 @@ Detect metadata drift between local source and a target org.
 
 ## sfdt notify
 
-Send a notification to Slack for deployment events.
+Send a notification through the configured channels (Slack, MS Teams, Google Chat, generic webhook, Grafana Loki, email).
 
 **Usage**: `sfdt notify <event> [--version <ver>] [--org <alias>] [--message <msg>]`
 
 **Arguments**:
 | Argument | Required | Description |
 |----------|----------|-------------|
-| `event` | Yes | One of: `deploy-success`, `deploy-failure`, `test-failure`, `release-created` |
+| `event` | Yes | One of: `deploy-success`, `deploy-failure`, `test-failure`, `release-created`, `snapshot` |
 
 **Options**:
 | Flag | Description |
@@ -246,10 +263,11 @@ Send a notification to Slack for deployment events.
 | `--version <ver>` | Version label to include in notification |
 | `--org <alias>` | Org alias to include in notification |
 | `--message <msg>` | Custom message text |
+| `--type audit\|monitor` | With the `snapshot` event: which latest snapshot to dispatch |
 
-**Requirements**: `config.notifications.slack.webhookUrl` must be set in config.
+**Requirements**: `notifications.enabled` with at least one entry in `notifications.channels[]`. Channel secrets are referenced by env-var **name** (`webhookUrlEnv`, SMTP `*Env`) — never stored inline. The legacy `notifications.slack.webhookUrl` shape is still honoured for back-compat.
 
-**Behavior**: Builds a Slack Block Kit payload and POSTs to the webhook URL.
+**Behavior**: `dispatchSnapshot` filters channels by their `events` list and `severityThreshold`; when `notifications.summary.enabled`, an AI executive summary becomes the message body.
 
 ---
 
@@ -268,7 +286,7 @@ Use AI to generate [Unreleased] entries from git history.
 |------|-------------|
 | `--limit <number>` | Number of commits to analyze (default: 20) |
 
-**Requirements**: AI enabled + Claude CLI available. Creates CHANGELOG.md from template if it doesn't exist.
+**Requirements**: AI enabled + the configured provider available (`isAiAvailable`). Creates CHANGELOG.md from template if it doesn't exist.
 
 ### sfdt changelog release
 
@@ -374,3 +392,56 @@ Read and write `.sfdt/config.json` values without hand-editing the file.
 | `key` | Yes | Dot-notation path to the config field (e.g. `defaultOrg`) |
 
 **Behavior**: Loads config (including sfdx-project.json enrichment) and prints the resolved value to stdout. Exits with code 1 if the key is not found.
+
+---
+
+## Additional commands
+
+Compact reference for the rest of the CLI. Run `sfdt <command> --help` for the full option list; most support `--json` (sf-native `{ status, result, warnings }` envelope on stdout) and `--org <alias>`.
+
+### Org health
+
+| Command | Summary |
+|---------|---------|
+| `sfdt audit [all\|<check>] [--org] [--json] [--notify]` | Native org health audit (clean-room sfdx-hardis-style checks): audit trail, licenses, MFA, unused/unreferenced Apex, inactive users/flows/validations/workflows, API versions, permission sets, connected apps, field descriptions, object & field access. Writes `logs/audit-latest.json` + archives under `logs/audit-results/` |
+| `sfdt monitor [all\|<check>] [--org] [--json] [--notify]` | Org monitoring: limits, Apex job failures, security health-check score, org info, deployment history, legacy API usage, paused flows, metadata backup. Writes `logs/monitor-latest.json` |
+| `sfdt history [--type <t>] [--limit <n>] [--json]` | Queryable run history (SQLite index in `logs/history.db`) across audit/monitor/test/deploy/quality runs |
+| `sfdt coverage [--org] [--threshold <pct>] [--json]` | Org-wide + per-class Apex coverage; exits non-zero below the threshold (default 75) |
+| `sfdt flow scan\|conflicts [--org] [--output <file>] [--json]` | Flow health analysis via `@sfdt/flow-core`; `conflicts` lists record-triggered flows colliding on object + timing + event |
+| `sfdt dependencies <name> [--type <t>] [--gaps] [--org]` | Tooling-API dependency graph for a component (both directions); `--gaps` adds source-parsed inferred edges the API misses |
+
+### Docs, data, scratch
+
+| Command | Summary |
+|---------|---------|
+| `sfdt docs generate [--ai] [--no-ai] [--roles [list]] [--no-diagrams] [--json]` | MkDocs markdown for objects/Apex/Flows/LWC + ER diagram; `--roles` adds AI-authored per-component role guides |
+| `sfdt docs diagram [--output <file>]` | Standalone ER diagram |
+| `sfdt data list\|export\|import\|delete <set> [--org]` | Named data sets over `sf data export/import tree` for sandbox & scratch seeding |
+| `sfdt scratch create\|delete\|list` | Scratch org lifecycle using the configured definition file |
+| `sfdt scratch pool` | Maintain a pool of pre-created scratch orgs |
+
+### CI, PRs, releases
+
+| Command | Summary |
+|---------|---------|
+| `sfdt ci init --provider github\|gitlab\|azure\|bitbucket --type monitor\|deploy` | Generate a ready-to-use pipeline (scheduled monitoring or PR smart deploy) |
+| `sfdt pr comment [--type audit\|monitor] [--body\|--file]` | Post the latest snapshot (or arbitrary content) as a PR comment via `gh` |
+| `sfdt pr-description` (alias `pr-desc`) | Generate a PR description or Slack message from deployment changes |
+| `sfdt retrofit --source <a> --target <b> [--execute]` | Retrieve a configured metadata set from source org → commit → smart-deploy to target (validate-only unless `--execute`) |
+| `sfdt agent-test [--notify]` | Run an Agentforce agent test (`sf agent test run`) as a CI gate with pass/fail exit code |
+| `sfdt explain [file]` | AI analysis of a deployment error log |
+
+### Tooling & meta
+
+| Command | Summary |
+|---------|---------|
+| `sfdt ui` | Local Express dashboard on port 7654 (requires the pre-built `gui/dist/`) |
+| `sfdt mcp` | Manage the MCP server exposing sfdt tools to AI agents/IDEs |
+| `sfdt skills export --target claude\|cursor\|codex\|windsurf\|pack [--out <dir>]` | Export the bundled agent skills as IDE rules files or an `npx skills`-compatible pack |
+| `sfdt plugin` | Manage sfdt CLI plugins (`sfdt-plugin-*` packages, `.sfdt/plugins/*.js`) |
+| `sfdt extension` / `sfdt feature-flags` | Chrome extension native-messaging bridge; extension kill-switches |
+| `sfdt doctor [--extension]` | Diagnose the local install (Node, sf CLI, config, bridge stack) |
+| `sfdt ai` | AI utilities (provider status, prompt management) |
+| `sfdt completion [shell]` | Shell completion script (bash, zsh, fish) |
+| `sfdt update` | Self-update from npm |
+| `sfdt version` | Print the version |

--- a/skills/sfdt-cli/references/config.md
+++ b/skills/sfdt-cli/references/config.md
@@ -25,19 +25,37 @@ Created by `sfdt init` in the project root as `.sfdt/`:
     "notifications": false,
     "releaseManagement": true
   },
+  "ai": {
+    "provider": "claude",
+    "baseURL": "",
+    "model": "",
+    "apiKeyEnv": ""
+  },
   "deployment": {
-    "coverageThreshold": 75
+    "coverageThreshold": 75,
+    "smart": {}
   },
   "manifestDir": "manifest/release",
   "notifications": {
-    "slack": {
-      "webhookUrl": "https://hooks.slack.com/..."
-    }
+    "enabled": true,
+    "channels": [
+      {
+        "type": "slack",
+        "webhookUrlEnv": "SLACK_WEBHOOK_URL",
+        "events": ["deploy-failure", "snapshot"],
+        "severityThreshold": "warn"
+      }
+    ]
   }
 }
 ```
 
-**Required keys** (validated at load): `defaultOrg`, `features`
+Notes:
+- `ai.provider` is one of `claude` | `gemini` | `openai` | `http`. For `http`, set `ai.baseURL`, `ai.model`, and `ai.apiKeyEnv` — the **name** of the env var holding the API key; the key itself is never stored in config.
+- Notification channel secrets are likewise referenced by env-var name (`webhookUrlEnv`, SMTP `*Env`). The legacy `notifications.slack.webhookUrl` shape still works for back-compat.
+- The full shape (including `audit`, `monitoring`, `docs`, and `deployment.smart` blocks) lives in `src/templates/sfdt.config.json` — the canonical source of truth for keys and defaults.
+
+**Required keys** (validated at load): `defaultOrg`, `features`. Config is validated by AJV against `src/lib/config-schema.json` with `additionalProperties: false` — an unknown key fails `validateConfig()` at load time.
 
 ### environments.json
 
@@ -133,6 +151,8 @@ These are injected by `loadConfig()` and available to commands:
 | `SFDT_PACKAGE_DIRS` | `config.packageDirectories` | JSON array of all package paths |
 | `SFDT_MANIFEST_LAYOUT` | `config.manifestLayout` | `'flat'` (`'flat'` or `'subpath'`) |
 | `SFDT_CHANGELOG_DIR` | `config.changelogDir` | `'changelogs'` |
+| `SFDT_PARALLEL_DELAY` | `config.testConfig.parallelDelay` | script default `1` (seconds between parallel batches; exported env wins) |
+| `SFDT_DEFAULT_BRANCH` | `config.defaultBranch` | `'main'` (exported env wins) |
 
 ### Per-invocation env vars
 
@@ -146,12 +166,22 @@ Set by individual commands via `env:` option in `runScript()` calls — not part
 | `SFDT_RELEASE_NAME` | release, manifest | Full release label (semver, free-form, or date) |
 | `SFDT_CHANGELOG_FILE` | release, changelog | Resolved changelog file path |
 | `SFDT_DEPLOY_SOURCE_DIR` | deploy | Source directory path for folder-mode deploys; empty string for manifest-mode |
+| `SFDT_SMOKE_TESTS` | smoke | Comma-joined `config.smokeTests.testClasses` |
+| `SFDT_ANALYZER_INCLUDE_FIXES` | quality `--include-fixes` | `'true'` → Code Analyzer adds `--include-fixes --include-suggestions` |
+| `SFDT_TAG_RELEASE` / `SFDT_CREATE_PR` / `SFDT_NOTIFY_SLACK` | deploy `--tag`/`--create-pr`/`--notify` | Post-deploy tagging, PR creation, notifications |
+| `SFDT_DESTRUCTIVE_TIMING` | deploy | `'pre'` \| `'post'` (default) \| `'none'` \| `'only'` — when destructive changes apply |
+| `SFDT_VALIDATION_JOB_ID` | deploy | A validation Id (`0Af…`) for Quick Deploy — promotes a prior validation via `sf project deploy quick` |
 
 ## Adding new config fields
 
-When extending sfdt with new config:
+When extending sfdt with new config, three places move in lockstep:
 
-1. Add the field to the appropriate `.sfdt/*.json` file
-2. Add the env var mapping to `buildScriptEnv()` in `src/lib/script-runner.js`
-3. Update the SFDT_ env var table in the project CLAUDE.md
-4. If the field should be prompted during init, update `src/commands/init.js`
+1. Add the key (with default) to `src/templates/sfdt.config.json` — the canonical template `sfdt init` reads
+2. Add it to `src/lib/config-schema.json` — AJV validates with `additionalProperties: false`, so a key missing from the schema fails `validateConfig()` at runtime
+3. Read it in the consuming code
+
+Then, if applicable:
+
+4. Add the env var mapping to `buildScriptEnv()` in `src/lib/script-runner.js`
+5. Update the SFDT_ env var table in the project CLAUDE.md (and this file)
+6. If the field should be prompted during init, update `src/commands/init.js`

--- a/skills/sfdt-cli/references/development.md
+++ b/skills/sfdt-cli/references/development.md
@@ -67,10 +67,13 @@ register<Name>Command(program);
 
 ```
 scripts/
-  core/       # deploy, test, release, pull
-  new/        # preflight, rollback, smoke, drift
-  quality/    # code-analyzer, test-analyzer
-  utils/      # shared helper functions
+  core/         # deploy, test, release, pull
+  ops/          # preflight, rollback, smoke, drift
+  quality/      # code-analyzer, test-analyzer
+  ci/           # CI pipeline templates (interpolated by `sfdt ci init`)
+  integration/  # integration helpers
+  lib/          # shared shell libraries (e.g. metadata-parser.sh)
+  utils/        # shared helper functions
 ```
 
 ### Rules
@@ -100,6 +103,10 @@ fi
 ### Step 1 — Add to the template (required first)
 
 `src/templates/sfdt.config.json` is the source of truth. `sfdt init` reads it directly via `fs.readJson`. Add the key with its default value here.
+
+### Step 1b — Add to the schema (required, same commit)
+
+Config is validated by AJV against `src/lib/config-schema.json` with `additionalProperties: false` on every object. A key that ships in the template (or is read by code) but is missing from the schema fails `validateConfig()` at runtime with `Invalid configuration: "<path>" contains unknown key "<key>"`. Template, schema, and consuming code move in lockstep.
 
 ### Step 2 — Add a default in config.js (if needed)
 
@@ -189,6 +196,7 @@ Before marking any CLI change complete:
 - [ ] Command registered in `src/cli.js`
 - [ ] Shell script de-parameterized (no positional args)
 - [ ] Config key added to `src/templates/sfdt.config.json` if applicable
+- [ ] Config key added to `src/lib/config-schema.json` (AJV rejects unknown keys)
 - [ ] `buildScriptEnv()` updated if new `SFDT_` var added
 - [ ] CLAUDE.md env var table updated if new `SFDT_` var added
 - [ ] Tests written or updated
@@ -196,6 +204,7 @@ Before marking any CLI change complete:
 - [ ] `npm run lint` clean
 - [ ] `references/commands.md` updated if new/changed command
 - [ ] `references/config.md` updated if new config key
+- [ ] Docs site (`sfdt-site` repo → https://sfdt.dev/) updated for any user-facing change
 
 ---
 

--- a/src/commands/skills.js
+++ b/src/commands/skills.js
@@ -51,6 +51,12 @@ function parseFrontmatter(content) {
   return { frontmatter, body };
 }
 
+// Eval prompt seeds (skills/<name>/evals/) are authoring/benchmarking assets —
+// they must not ship in exported packs or installed .claude/skills folders.
+function isEvalFile(relOrAbsPath) {
+  return relOrAbsPath.split(/[\\/]/).includes('evals');
+}
+
 /**
  * Emit an `npx skills add`-compatible pack from the parsed skills.
  * Produces `<out>/manifest.json` (vercel-labs/skills schema, as used by
@@ -60,9 +66,9 @@ async function exportPack(parsedSkills, outOption) {
   const outDir = path.resolve(process.cwd(), outOption || 'sfdt-skills-pack');
 
   // Enumerate every file under the package skills/ dir once, then group by folder.
-  const allFiles = (await glob('**/*', { cwd: SKILLS_DIR, nodir: true })).map((f) =>
-    f.split(path.sep).join('/'),
-  );
+  const allFiles = (await glob('**/*', { cwd: SKILLS_DIR, nodir: true }))
+    .map((f) => f.split(path.sep).join('/'))
+    .filter((f) => !isEvalFile(f));
 
   // Start from a clean skills/ tree so a renamed or removed skill doesn't leave a
   // stale folder behind on re-export — keeps the pack reproducible from the source.
@@ -78,7 +84,9 @@ async function exportPack(parsedSkills, outOption) {
       // SKILL.md first, remaining files alphabetically — matches sf-skills ordering.
       .sort((a, b) => (a === 'SKILL.md' ? -1 : b === 'SKILL.md' ? 1 : a.localeCompare(b)));
 
-    await fs.copy(path.join(SKILLS_DIR, folderRel), path.join(outDir, 'skills', folderRel));
+    await fs.copy(path.join(SKILLS_DIR, folderRel), path.join(outDir, 'skills', folderRel), {
+      filter: (src) => !isEvalFile(path.relative(SKILLS_DIR, src)),
+    });
 
     manifestSkills.push({
       name: skill.name,
@@ -207,7 +215,19 @@ export function registerSkillsCommand(program) {
           await fs.writeFile(outFile, rulesMarkdown, 'utf-8');
           filesWritten.push(outFile);
         } else if (target === 'claude') {
-          // Write both .clauderules and .claudecode.json for double compatibility
+          // Primary: the real Claude Code convention — project skills live as
+          // folders under .claude/skills/<name>/ and are discovered natively
+          // (name + description frontmatter drive triggering).
+          for (const skill of parsedSkills) {
+            const folderRel = path.dirname(skill.file).split(path.sep).join('/');
+            const dest = path.join(cwd, '.claude', 'skills', folderRel);
+            await fs.copy(path.join(SKILLS_DIR, folderRel), dest, {
+              filter: (src) => !isEvalFile(path.relative(SKILLS_DIR, src)),
+            });
+            filesWritten.push(dest);
+          }
+
+          // Legacy compatibility files kept for older tooling that read them
           const clauderules = path.join(cwd, '.clauderules');
           await fs.writeFile(clauderules, rulesMarkdown, 'utf-8');
           filesWritten.push(clauderules);

--- a/test/commands/skills-content.test.js
+++ b/test/commands/skills-content.test.js
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { createCli } from '../../src/cli.js';
+
+// Content invariants for the bundled skills under skills/. These read the REAL
+// files (no mocks): the skills ship in the npm package and are exported into
+// user projects, so drift between them and the CLI is a user-facing bug.
+// See docs/skills-audit-2026-07-12.md for the audit that motivated this guard.
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const SKILLS_DIR = path.resolve(TEST_DIR, '..', '..', 'skills');
+
+function parseFrontmatter(content) {
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n/);
+  if (!match) return {};
+  const frontmatter = {};
+  for (const line of match[1].split(/\r?\n/)) {
+    const colonIndex = line.indexOf(':');
+    if (colonIndex !== -1 && !line.trim().startsWith('-')) {
+      const key = line.slice(0, colonIndex).trim();
+      const val = line
+        .slice(colonIndex + 1)
+        .trim()
+        .replace(/^['"]|['"]$/g, '');
+      if (val) frontmatter[key] = val;
+    }
+  }
+  return frontmatter;
+}
+
+const skillDirs = fs
+  .readdirSync(SKILLS_DIR, { withFileTypes: true })
+  .filter((d) => d.isDirectory())
+  .map((d) => d.name)
+  .sort();
+
+describe('bundled skills content invariants', () => {
+  it('finds the bundled skills', () => {
+    expect(skillDirs.length).toBeGreaterThanOrEqual(10);
+  });
+
+  it.each(skillDirs)('%s has valid SKILL.md frontmatter', (dir) => {
+    const skillPath = path.join(SKILLS_DIR, dir, 'SKILL.md');
+    expect(fs.existsSync(skillPath), `${dir}/SKILL.md missing`).toBe(true);
+
+    const fm = parseFrontmatter(fs.readFileSync(skillPath, 'utf-8'));
+    // name must match the folder — skill libraries key installs off it
+    expect(fm.name).toBe(dir);
+    // description drives triggering; the agent-skills spec caps it at 1024 chars
+    expect(fm.description, `${dir} description missing`).toBeTruthy();
+    expect(fm.description.length).toBeLessThanOrEqual(1024);
+    // license is required by skill registries/marketplaces
+    expect(fm.license, `${dir} missing license frontmatter`).toBe('Apache-2.0');
+  });
+
+  it.each(skillDirs)('%s has committed eval prompt seeds', (dir) => {
+    const evalsPath = path.join(SKILLS_DIR, dir, 'evals', 'evals.json');
+    expect(fs.existsSync(evalsPath), `${dir}/evals/evals.json missing`).toBe(true);
+
+    const evals = JSON.parse(fs.readFileSync(evalsPath, 'utf-8'));
+    expect(evals.skill_name).toBe(dir);
+    expect(Array.isArray(evals.evals)).toBe(true);
+    expect(evals.evals.length).toBeGreaterThanOrEqual(2);
+    for (const e of evals.evals) {
+      expect(typeof e.prompt).toBe('string');
+      expect(e.prompt.length).toBeGreaterThan(20);
+    }
+  });
+});
+
+describe('sfdt-cli skill stays in sync with the CLI', () => {
+  const skillText =
+    fs.readFileSync(path.join(SKILLS_DIR, 'sfdt-cli', 'SKILL.md'), 'utf-8') +
+    fs.readFileSync(path.join(SKILLS_DIR, 'sfdt-cli', 'references', 'commands.md'), 'utf-8');
+
+  it('documents every registered top-level command', () => {
+    const program = createCli();
+    const commandNames = program.commands
+      .map((cmd) => cmd.name())
+      .filter((name) => name !== 'help');
+
+    const missing = commandNames.filter(
+      (name) => !new RegExp(`sfdt ${name}\\b`).test(skillText),
+    );
+
+    // When this fails: a command was added/renamed in src/cli.js without
+    // updating skills/sfdt-cli/SKILL.md or references/commands.md.
+    expect(missing).toEqual([]);
+  });
+});

--- a/test/commands/skills.test.js
+++ b/test/commands/skills.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Command } from 'commander';
 import path from 'path';
 import { fileURLToPath } from 'url';
@@ -98,18 +98,34 @@ describe('skills export command', () => {
     expect(content).toContain('Some body text for Flow review.');
   });
 
-  it('generates and writes both .clauderules and .claudecode.json for target "claude"', async () => {
+  it('copies skill folders into .claude/skills/ plus legacy files for target "claude"', async () => {
+    // Use SKILLS_DIR-relative paths so folderRel resolves to clean skill names.
+    glob.mockResolvedValue([
+      path.join(SKILLS_DIR, 'sf-apex-review', 'SKILL.md'),
+      path.join(SKILLS_DIR, 'sf-flow-review', 'SKILL.md'),
+    ]);
+
     await createProgram().parseAsync(['node', 'sfdt', 'skills', 'export', '--target', 'claude']);
 
+    // Primary output: one folder copy per skill into .claude/skills/<name>
+    expect(fs.copy).toHaveBeenCalledTimes(2);
+    expect(fs.copy).toHaveBeenCalledWith(
+      path.join(SKILLS_DIR, 'sf-apex-review'),
+      expect.stringContaining(path.join('.claude', 'skills', 'sf-apex-review')),
+      expect.objectContaining({ filter: expect.any(Function) }),
+    );
+
+    // Eval seeds are filtered out of the copy
+    const filter = fs.copy.mock.calls[0][2].filter;
+    expect(filter(path.join(SKILLS_DIR, 'sf-apex-review', 'evals', 'evals.json'))).toBe(false);
+    expect(filter(path.join(SKILLS_DIR, 'sf-apex-review', 'SKILL.md'))).toBe(true);
+
+    // Legacy compatibility files still written
     expect(fs.writeFile).toHaveBeenCalledTimes(1);
+    expect(fs.writeFile.mock.calls[0][0]).toContain('.clauderules');
     expect(fs.writeJson).toHaveBeenCalledTimes(1);
-
-    const writeCall = fs.writeFile.mock.calls[0];
-    expect(writeCall[0]).toContain('.clauderules');
-
-    const jsonCall = fs.writeJson.mock.calls[0];
-    expect(jsonCall[0]).toContain('.claudecode.json');
-    expect(jsonCall[1].customInstructions).toContain('sf-apex-review');
+    expect(fs.writeJson.mock.calls[0][0]).toContain('.claudecode.json');
+    expect(fs.writeJson.mock.calls[0][1].customInstructions).toContain('sf-apex-review');
   });
 
   it('emits results as JSON when --json option is passed', async () => {
@@ -149,7 +165,13 @@ describe('skills export --target pack', () => {
           path.join(SKILLS_DIR, 'sfdt-cli', 'SKILL.md'),
         ];
       }
-      return ['sf-deploy/SKILL.md', 'sfdt-cli/SKILL.md', 'sfdt-cli/references/commands.md'];
+      // Includes an eval seed to prove it's filtered out of manifests/packs.
+      return [
+        'sf-deploy/SKILL.md',
+        'sf-deploy/evals/evals.json',
+        'sfdt-cli/SKILL.md',
+        'sfdt-cli/references/commands.md',
+      ];
     });
 
     fs.readFile.mockImplementation(async (file) => {
@@ -175,7 +197,13 @@ describe('skills export --target pack', () => {
     expect(fs.copy).toHaveBeenCalledWith(
       path.join(SKILLS_DIR, 'sf-deploy'),
       expect.stringContaining(path.join('out-pack', 'skills', 'sf-deploy')),
+      expect.objectContaining({ filter: expect.any(Function) }),
     );
+
+    // Eval seeds are excluded from the pack copy
+    const filter = fs.copy.mock.calls[0][2].filter;
+    expect(filter(path.join(SKILLS_DIR, 'sf-deploy', 'evals', 'evals.json'))).toBe(false);
+    expect(filter(path.join(SKILLS_DIR, 'sf-deploy', 'SKILL.md'))).toBe(true);
 
     expect(fs.writeJson).toHaveBeenCalledTimes(1);
     const [manifestPath, manifest] = fs.writeJson.mock.calls[0];


### PR DESCRIPTION
Full audit of the 10 skills under skills/ against skill-creator authoring
guidance, with every claim verified against the actual CLI. Fixes applied:

- sfdt-cli: quick reference now covers all 42 registered commands (was ~18);
  AI docs updated for the multi-provider system (claude/gemini/openai/http);
  deploy --smart documented; notify docs rewritten for the channel-based
  notifier; references/config.md gains the ai block, config-schema.json
  lockstep rule, and 9 missing SFDT_ env vars; references/development.md
  scripts layout corrected (ops/, not new/) and checklist extended
- sf-pmd-scan: remove project-specific "TWU-556 / SF-Rebuild" leftover; fix
  Code Analyzer v5 flags (--config-file custom rulesets, --target not
  --path-filter); cross-ref sfdt quality
- sf-flow-review: fix contradictory $Label hardcoded-ID guidance; correct
  Lightning Flow Scanner flags; add native sfdt flow scan/conflicts path
- sf-data: replace invalid `sf data import legacy` with `sf data import
  bulk`; fix --sobject flag naming; cross-ref sfdt data sets
- sf-test / sf-deploy: drop hardcoded 90% project target in favour of the
  configured deployment.coverageThreshold; fix destructive-changes mechanics;
  cross-ref sfdt test/coverage/preflight/deploy --smart
- sf-lwc: modernize @track guidance (fields reactive by default); apiVersion
  note; sf-org-audit: assertion grep now covers the modern Assert class;
  sf-scratch-org: edition-accurate scratch limits + sfdt scratch pool
- Descriptions made more assertive about trigger contexts across the pack
  (skills under-trigger otherwise)

Adds docs/skills-audit-2026-07-12.md with per-skill findings, severities,
and follow-up recommendations. Verified via `sfdt skills export` smoke test
and the vitest suite (extension/ workspace tsconfig collection failures are
pre-existing and unrelated).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BEAnpu9J25HPDSQf67GEcw