### PR TITLE
Truth corrections: license strings, stale counts, dead claims

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -114,20 +114,11 @@ The Web Store re-review process is slower than npm publish, so we bump the exten
 5. Upload to the Chrome Web Store dashboard. The listing references this README + `extension/PRIVACY.md` for reviewers.
 6. After the Store accepts the new version, tag: `git tag extension-vX.Y.Z && git push --tags`.
 
-### Releasing `@sfdt/flow-core` (when we publish it)
+### Releasing `@sfdt/flow-core`
 
-Flow-core is currently `"private": true` and consumed only as a workspace dependency. When we publish:
-
-1. Remove `"private": true` from `packages/flow-core/package.json`.
-2. Set `version` to `0.x.0` for the first publish; track its own changelog under `packages/flow-core/CHANGELOG.md`.
-3. Publish from `main`:
-   ```bash
-   cd packages/flow-core
-   npm publish --access public
-   ```
-4. Update root `package.json` (and `extension/package.json`) to depend on the published version instead of workspace `*` **only** when we have an external consumer — until then, workspace `*` is fine.
-
-The trigger for publishing flow-core is "a second consumer appears" — a Firefox build, a VS Code extension, an MCP server wrapper, or someone outside this repo wanting to build on the scoring engine.
+Flow-core is **public on npm** and publishes as a coupled sub-step of every CLI release — the
+`ci.yml` publish job publishes it **before** `@sfdt/cli` (the CLI's dependency must resolve
+first). It has no standalone release trigger; its version bumps with the CLI's release commit.
 
 ### Releasing `@sfdt/host`
 
@@ -142,7 +133,7 @@ Before any release PR is merged:
 - [ ] `npm test` clean (CLI + extension + flow-core + host + gui via the root workspace config).
 - [ ] `npm run lint` clean.
 - [ ] `npm run build:gui` and `npm run build:ext` both succeed.
-- [ ] If anything in `packages/flow-core/src/bridge-contract.ts` changed, the `/pre-release-cli-test` skill has been run (verifies all 21 CLI commands' `--help` smoke).
+- [ ] If anything in `packages/flow-core/src/bridge-contract.ts` changed, the `/pre-release-cli-test` skill has been run (verifies every registered CLI command's `--help` smoke — the list is derived from the Commander tree, never hardcoded).
 - [ ] If anything in `gui/` changed, the `/pre-release-ui-test` skill has been run.
 - [ ] If you're releasing the VS Code extension, `npm run test:vscode` + `npm run build:vscode` pass, the `.vsix` packages cleanly, and the `VSCE_PAT` secret is configured (or you'll upload the `.vsix` manually).
 - [ ] After a CLI release: verify the CI `docker` job pushed the GHCR image (public on first release), and the "Bump Homebrew tap" step updated the tap's `Formula/sfdt.rb` (requires the `HOMEBREW_TAP_TOKEN` secret — bump manually if it skipped).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -32,7 +32,7 @@
 
 ### Platform & Ecosystem
 - Plugin architecture — load from `config.plugins[]`, auto-discover `sfdt-plugin-*` packages, or drop `.sfdt/plugins/*.js` local files
-- Docker support — mounts a Salesforce DX project at `/project`; ships Node 20, Salesforce CLI, git, jq, and sfdt
+- Docker support — mounts a Salesforce DX project at `/project`; ships Node 22, Salesforce CLI, git, jq, and sfdt
 - DevOps Center MCP integration — pipeline status and work items injected into chat context when `config.mcp.enabled` is true; targeted Headless360 tool calling via `SalesforceMcpClient` for live pipeline and work-item data in the AI chat drawer
 - sfdt skills library — 10 Salesforce domain skills for use with AI agents (apex-review, data, deploy, flow-review, lwc, org-audit, pmd-scan, scratch-org, test, sfdt-cli)
 - Pre-built GUI included in the published npm package

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -74,7 +74,7 @@ SFDT uses a hybrid architecture: a Node.js CLI layer (Commander.js) handles argu
 - **Org inventory** (`org-inventory.js`) fetches a metadata member inventory from a Salesforce org via `sf org list metadata` or from local source files via glob. Results are returned as `Map<type, Set<member>>`.
 - **Org diff** (`org-diff.js`) compares two inventory maps and returns a flat array of `{ type, member, status }` objects where `status` is `source-only`, `target-only`, or `both`.
 - **Command runner (SSE)** — the GUI server exposes `GET /api/command/run?command=<name>` which streams shell script output as Server-Sent Events. This lets the dashboard run preflight, drift, and smoke scripts without a separate terminal session.
-- **No transpilation** required. The package is pure ESM (`"type": "module"` in package.json), targeting Node.js 18+.
+- **No transpilation** required. The package is pure ESM (`"type": "module"` in package.json), targeting Node.js >=22.15.0 (the `engines` floor in package.json).
 
 ## Package Structure
 
@@ -182,8 +182,10 @@ Specifies Apex test suites, test levels, and auto-detected test/Apex classes for
 
 ## Future Roadmap
 
-- **sf CLI plugin integration** — Package sfdt as a native `sf` plugin.
+(See `ROADMAP.md` at the repo root for current status. Items previously listed here have
+shipped: the sf CLI plugin (`packages/plugin`, `sf sfdt <command>`), the plugin system
+(`src/lib/plugin-loader.js` — `config.plugins[]`, `sfdt-plugin-*` auto-discovery,
+`.sfdt/plugins/*.js`), and the web dashboard (`sfdt ui`).)
+
 - **Windows support** — Port shell scripts to Node.js or cross-platform shell.
-- **Plugin system** — Allow 3rd-party packages to register sfdt commands.
-- **Dashboard generation** — HTML reports for test and deployment history.
 - **Interactive TUI mode** — A terminal UI for monitoring long-running operations.

--- a/extension/README.md
+++ b/extension/README.md
@@ -177,4 +177,4 @@ Architecture overview lives in the root [docs/ARCHITECTURE.md](../docs/ARCHITECT
 
 ## License
 
-MIT — see [../LICENSE](../LICENSE).
+Apache-2.0 — see [../LICENSE](../LICENSE).

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,6 +2,7 @@
   "name": "@sfdt/extension",
   "version": "0.6.0",
   "description": "Chrome MV3 extension for Salesforce Flow Builder and other Salesforce tools. WXT + TypeScript.",
+  "license": "Apache-2.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/gui/package.json
+++ b/gui/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@sfdt/gui",
+  "license": "Apache-2.0",
   "private": true,
   "version": "0.1.0",
   "type": "module",

--- a/host/package.json
+++ b/host/package.json
@@ -2,6 +2,7 @@
   "name": "@sfdt/host",
   "version": "0.11.0",
   "description": "Native messaging host that bridges the @sfdt/extension Chrome extension to the sfdt CLI when the sfdt ui localhost server is unavailable.",
+  "license": "Apache-2.0",
   "private": true,
   "type": "module",
   "bin": {

--- a/vscode/LICENSE
+++ b/vscode/LICENSE
@@ -1,21 +1,201 @@
-MIT License
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Copyright (c) 2025 SFDT Contributors
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+   1. Definitions.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2025 SFDT Contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.


### PR DESCRIPTION
## Summary

PR 2 of the blueprint-audit remediation program (`pr-analysis/blueprint-audit-2026-07-12.md`): mechanical corrections so every surface tells the truth about the product.

## License (project is Apache-2.0)

- `extension/README.md` — said "MIT — see ../LICENSE" while that LICENSE is Apache-2.0
- `vscode/LICENSE` — full stale MIT text contradicting `vscode/package.json`; replaced with the root Apache-2.0 license (the file ships in the .vsix — `.vscodeignore` doesn't exclude it)
- `extension/`, `host/`, `gui/` package.json — added missing `"license": "Apache-2.0"` fields

## Stale claims

- `RELEASING.md` — flow-core section said `"private": true` / "when we publish it"; it's public on npm and publishes as a coupled sub-step of every CLI release. "21 CLI commands" → Commander-tree-derived.
- `pre-release-cli-test` + `release` skills — hardcoded "21 commands" (actual: **43**) replaced with enumeration from `createCli()`; verified the one-liner returns 43
- `ROADMAP.md` — Docker "ships Node 20" → 22 (Dockerfile is `node:22-slim`)
- `docs/ARCHITECTURE.md` — "Node.js 18+" → `>=22.15.0`; sf CLI plugin, plugin system, and dashboard removed from "Future Roadmap" (all shipped)

Repo-wide sweeps for `MIT`, `Node 18`, `Node 20`, `21 commands`, and `flow-core is private` now return only historical/intentional references.

A full `docs/ARCHITECTURE.md` rewrite is a later program item (PR 6); this only fixes the falsehoods.

https://claude.ai/code/session_01PRtcJodaDCxv9kY8GrAcxC