### PR TITLE
fix(action): shorten Marketplace description to under 125 chars

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,8 +16,8 @@
 # to `command` — it is executed as a shell command line.
 name: SFDT for Salesforce
 description: >-
-  Salesforce DX DevOps toolkit — smart delta deploys, org monitoring and
-  auditing, quality analysis, and release management via the sfdt CLI.
+  Run any sfdt command in one step — smart delta deploys, org monitoring,
+  quality analysis, and Salesforce release management.
 author: sfdt
 branding:
   icon: cloud


### PR DESCRIPTION
GitHub's Marketplace publish validation rejects the current `action.yml`: **Description must be less than 125 characters** (it's 137). This trims it to 124:

> Run any sfdt command in one step — smart delta deploys, org monitoring, quality analysis, and Salesforce release management.

Name, icon, and color are untouched. Once this merges to `main`, refresh the v0.17.0 release's edit page — the Marketplace banner validates `action.yml` on the default branch, so the publish checkbox should clear without cutting a new release.

https://claude.ai/code/session_01XzVdKKVmUYicnARnppocsD