### PR TITLE
Hardening: Action shell-eval, host logDir, --wait validation, analyzer v4 policy

### DIFF
--- a/.github/workflows/action-selftest.yml
+++ b/.github/workflows/action-selftest.yml
@@ -1,7 +1,8 @@
 # Exercises the root composite action (action.yml) on every change to it, so a
 # broken action never reaches a release tag. Runs org-less commands only —
 # auth-method none — which covers setup-node, both CLI installs, the version
-# resolution, and command execution.
+# resolution, and both execution paths (args-json spawn and the hardened
+# legacy command string), plus the security rejections.
 name: Action Self-Test
 on:
   pull_request:
@@ -16,11 +17,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Run with cli-version auto (pinned to this checkout)
+      - name: Run with args-json (preferred path, cli-version auto)
         uses: ./
         with:
-          command: --version
-      - name: Run with cli-version latest
+          args-json: '["--version"]'
+      - name: Run with legacy command string (word-split, no shell)
         uses: ./
         with:
           command: --help
@@ -30,10 +31,46 @@ jobs:
         uses: ./
         continue-on-error: true
         with:
-          command: --version
+          args-json: '["--version"]'
           auth-method: oauth
-      - name: Assert the bad auth-method failed
-        if: steps.bad-auth.outcome != 'failure'
+      - name: Rejects shell metacharacters in command
+        id: bad-metachar
+        uses: ./
+        continue-on-error: true
+        with:
+          command: --version; echo pwned
+      - name: Rejects command substitution in command
+        id: bad-subst
+        uses: ./
+        continue-on-error: true
+        with:
+          command: --version $(touch /tmp/pwned)
+      - name: Rejects args-json that is not a string array
+        id: bad-json
+        uses: ./
+        continue-on-error: true
+        with:
+          args-json: '{"cmd":"--version"}'
+      - name: Rejects passing both args-json and command
+        id: bad-both
+        uses: ./
+        continue-on-error: true
+        with:
+          args-json: '["--version"]'
+          command: --version
+      - name: Allows shell mode only with explicit opt-in
+        uses: ./
+        with:
+          command: --version && sfdt --help
+          allow-shell-command: 'true'
+      - name: Assert every rejection actually failed
+        if: >
+          steps.bad-auth.outcome != 'failure' ||
+          steps.bad-metachar.outcome != 'failure' ||
+          steps.bad-subst.outcome != 'failure' ||
+          steps.bad-json.outcome != 'failure' ||
+          steps.bad-both.outcome != 'failure'
         run: |
-          echo "expected auth-method validation to fail the step" >&2
+          echo "expected all rejection cases to fail their steps" >&2
+          echo "bad-auth=${{ steps.bad-auth.outcome }} bad-metachar=${{ steps.bad-metachar.outcome }} bad-subst=${{ steps.bad-subst.outcome }} bad-json=${{ steps.bad-json.outcome }} bad-both=${{ steps.bad-both.outcome }}" >&2
           exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`sfdt test --logic --allow-zero-tests`** — a "passing" unified logic run that executed **zero tests** now exits non-zero (it verified nothing — typo'd test names, missing `FlowTesting.` prefix, or a permissions gap); pass the flag when an empty run is expected. Logic run output now streams live *and* is captured for the guard/AI analysis.
+- **`sfdt quality --allow-legacy-analyzer`** (and config `quality.analyzer.allowLegacyV4`) — Code Analyzer v4 no longer runs as a silent fallback. v5 is required for authoritative scans; a v4-only environment emits the `skipped` marker unless legacy mode is explicitly enabled, and legacy results are labeled non-authoritative. v4 support will be removed at 1.0.
+- **GitHub Action `args-json` input** — the preferred way to pass sfdt arguments (a JSON array, executed with no shell, immune to shell injection). New `allow-shell-command` input gates the legacy eval behavior.
+
+### Changed
+
+- **GitHub Action `command` input is deprecated and hardened.** Without `allow-shell-command: 'true'` it now accepts only shell-neutral characters and is word-split without a shell — strings with quotes, `$`, `;`, newlines, etc. are rejected with a migration hint instead of being eval'd. The generated GitHub CI templates (`sfdt ci init --runner action`) now emit `args-json`.
+- **`sfdt test --logic --wait` is validated** — must be a whole number of minutes ≥ 1 (previously any string was passed through to `sf logic run test`).
+- **`sfdt extension install-host` persists the full project context** — the host config now records `schemaVersion`, `projectRoot`, `configDir`, the **resolved absolute `logDir`** (custom `config.logDir` values survive browser-launched host sessions), `cliVersion`, and `installedAt`. Old host configs (projectRoot-only) keep working unchanged.
+
 ## [0.17.0] - 2026-07-12
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,7 @@ Dockerfile      Official Docker image definition
 | `SFDT_SMOKE_TESTS` | Per-invocation: comma-joined `config.smokeTests.testClasses`, set by `smoke.js` (a user-exported env value wins) |
 | `SFDT_ANALYZER_INCLUDE_FIXES` | Per-invocation: `"true"` from `quality --include-fixes`; `scripts/quality/code-analyzer.sh` adds `--include-fixes --include-suggestions` to the Code Analyzer v5 run |
 | `SFDT_ANALYZER_OUTPUT_FILE` | Per-invocation: from `quality --output-file <path>`; `scripts/quality/code-analyzer.sh` adds a second `--output-file` to the Code Analyzer v5 run (format inferred from the extension, e.g. `.sarif`); v4 logs a warning and skips |
+| `SFDT_ANALYZER_ALLOW_LEGACY` | Per-invocation: `"true"` from `quality --allow-legacy-analyzer` or config `quality.analyzer.allowLegacyV4`; permits the legacy Code Analyzer v4 (`sf scanner run`) when v5 is unavailable. Without it, a v4-only environment emits the `skipped` marker (v5 required — J-1 policy; skip is never rendered as a pass). v4 support is removed at 1.0 |
 | `SFDT_TAG_RELEASE` / `SFDT_CREATE_PR` / `SFDT_NOTIFY_SLACK` | Per-invocation: `"true"` from `deploy --tag/--create-pr/--notify` (or the GUI Release Hub toggles); drive post-deploy tagging, PR creation, and notifications in `deployment-assistant.sh` |
 | `SFDT_PACKAGE_DIRS` | JSON array of all package paths from `config.packageDirectories`, e.g. `["force-app/main/default","force-app/feature-a"]` |
 | `SFDT_MANIFEST_LAYOUT` | `config.manifestLayout` (`"flat"` or `"subpath"`); default `"flat"` |

--- a/README.md
+++ b/README.md
@@ -406,11 +406,16 @@ shipped at that ref — no unpinned `@latest`).
 - name: Smart delta validation
   uses: scoobydrew83/sfdt@v0
   with:
-    command: deploy --smart --org ci --delta-base "origin/${{ github.event.pull_request.base.ref }}" --dry-run
+    args-json: '["deploy","--smart","--org","ci","--delta-base","origin/${{ github.event.pull_request.base.ref }}","--dry-run"]'
     auth-method: sfdx-url
     sfdx-auth-url: ${{ secrets.SFDX_AUTH_URL }}
     org-alias: ci
 ```
+
+`args-json` (a JSON array of arguments) is executed with no shell, so values can
+never be interpreted as shell syntax. The legacy `command` string input still
+works for shell-neutral strings but is deprecated; strings needing quoting or
+expansion additionally require `allow-shell-command: 'true'` (trusted input only).
 
 JWT bearer flow instead of an auth URL:
 

--- a/action.yml
+++ b/action.yml
@@ -5,15 +5,21 @@
 #
 #   - uses: scoobydrew83/sfdt@v0
 #     with:
-#       command: deploy --smart --org ci --delta-base "origin/main" --dry-run
+#       args-json: '["deploy","--smart","--org","ci","--delta-base","origin/main","--dry-run"]'
 #       auth-method: sfdx-url
 #       sfdx-auth-url: ${{ secrets.SFDX_AUTH_URL }}
 #       org-alias: ci
 #
+# args-json is the preferred interface: a JSON array of arguments spawned
+# directly (no shell), so quoting, spaces, and untrusted values can't be
+# interpreted as shell syntax. The legacy `command` string input is deprecated:
+# without allow-shell-command it accepts only shell-neutral characters and is
+# word-split without a shell; with allow-shell-command: true it keeps the old
+# eval behavior — never pass untrusted input to it in that mode.
+#
 # Pinning the action tag pins the CLI: cli-version defaults to "auto", which
 # resolves the version shipped in this repository at the pinned ref. Secrets
-# must be passed as expressions (never literals); do not pass untrusted input
-# to `command` — it is executed as a shell command line.
+# must be passed as expressions (never literals).
 name: SFDT for Salesforce
 description: >-
   Salesforce DX DevOps toolkit — smart delta deploys, org monitoring and
@@ -24,11 +30,27 @@ branding:
   color: blue
 
 inputs:
+  args-json:
+    description: >-
+      The sfdt arguments as a JSON array of strings, e.g.
+      '["deploy","--smart","--org","ci","--dry-run"]'. Spawned directly with
+      no shell — the safe interface. Exactly one of args-json / command is
+      required.
+    required: false
   command:
     description: >-
-      The sfdt command line to run (everything after "sfdt"), e.g.
-      "deploy --smart --org ci --dry-run" or "monitor all --org ci --json".
-    required: true
+      DEPRECATED — prefer args-json. The sfdt command line to run (everything
+      after "sfdt"). Without allow-shell-command it accepts only shell-neutral
+      characters (letters, digits, space, and _@%+=:,./-) and runs without a
+      shell; anything else (quotes, $, ;, |, newlines, …) is rejected.
+    required: false
+  allow-shell-command:
+    description: >-
+      Set "true" to run the command input through a shell (legacy eval
+      behavior) when it needs quoting or expansion. Only for fully trusted,
+      static strings — never workflow-interpolated user input. Removed in v1.
+    required: false
+    default: 'false'
   cli-version:
     description: >-
       @sfdt/cli version to install. "auto" (default) uses the version shipped
@@ -73,11 +95,19 @@ runs:
       shell: bash
       env:
         AUTH_METHOD: ${{ inputs.auth-method }}
+        SFDT_ARGS_JSON: ${{ inputs.args-json }}
+        SFDT_COMMAND: ${{ inputs.command }}
       run: |
         case "$AUTH_METHOD" in
           none|sfdx-url|jwt) ;;
           *) echo "auth-method must be one of: none, sfdx-url, jwt (got: $AUTH_METHOD)" >&2; exit 1 ;;
         esac
+        if [ -z "$SFDT_ARGS_JSON" ] && [ -z "$SFDT_COMMAND" ]; then
+          echo "::error::one of args-json or command is required"; exit 1
+        fi
+        if [ -n "$SFDT_ARGS_JSON" ] && [ -n "$SFDT_COMMAND" ]; then
+          echo "::error::args-json and command are mutually exclusive — pass exactly one"; exit 1
+        fi
 
     - uses: actions/setup-node@v4
       with:
@@ -155,5 +185,37 @@ runs:
     - name: Run sfdt
       shell: bash
       env:
+        SFDT_ARGS_JSON: ${{ inputs.args-json }}
         SFDT_COMMAND: ${{ inputs.command }}
-      run: eval "sfdt ${SFDT_COMMAND}"
+        SFDT_ALLOW_SHELL: ${{ inputs.allow-shell-command }}
+      run: |
+        if [ -n "$SFDT_ARGS_JSON" ]; then
+          # Preferred path: JSON array of args passed as a bash argv — the
+          # values never touch shell parsing, so nothing in them can be
+          # interpreted as shell syntax. jq is preinstalled on hosted runners.
+          if ! jq -e 'type=="array" and length>0 and all(.[]; type=="string")' >/dev/null 2>&1 <<<"$SFDT_ARGS_JSON"; then
+            echo "::error::args-json must be a non-empty JSON array of strings"; exit 1
+          fi
+          if jq -e 'any(.[]; test("\n"))' >/dev/null <<<"$SFDT_ARGS_JSON"; then
+            echo "::error::args-json values must not contain newlines"; exit 1
+          fi
+          readarray -t SFDT_ARGS < <(jq -r '.[]' <<<"$SFDT_ARGS_JSON")
+          sfdt "${SFDT_ARGS[@]}"
+        elif [ "$SFDT_ALLOW_SHELL" = "true" ]; then
+          echo "::warning::command with allow-shell-command runs through a shell (legacy eval) — migrate to args-json; this mode is removed in v1"
+          eval "sfdt ${SFDT_COMMAND}"
+        else
+          # Deprecated string path, hardened: reject newlines and anything
+          # outside a shell-neutral charset, then word-split WITHOUT a shell.
+          case "$SFDT_COMMAND" in
+            *$'\n'*)
+              echo "::error::the command input must not contain newlines — use args-json"; exit 1 ;;
+          esac
+          if printf '%s' "$SFDT_COMMAND" | LC_ALL=C grep -q '[^A-Za-z0-9 _@%+=:,./-]'; then
+            echo "::error::the command input contains shell-special characters (quotes, \$, ;, |, …). Use args-json (a JSON array, executed with no shell) — or set allow-shell-command: true only for a fully trusted static string."
+            exit 1
+          fi
+          echo "::notice::the command input is deprecated — prefer args-json (executed without a shell)"
+          read -r -a SFDT_ARGS <<< "$SFDT_COMMAND"
+          sfdt "${SFDT_ARGS[@]}"
+        fi

--- a/host/installers/install-host.js
+++ b/host/installers/install-host.js
@@ -227,12 +227,27 @@ export async function installNativeHost(opts) {
     return { ok: false, error: 'No browser manifest could be installed', results };
   }
 
-  // Record the project root so the host's read-only kinds can find logs/ and
-  // .sfdt/config.json. Non-fatal: the manifest install already succeeded.
+  // Record the project context so the host's read-only kinds can find logs/
+  // and .sfdt/config.json. The resolved logDir is persisted (not re-derived at
+  // runtime) so a custom config.logDir survives the host being launched by the
+  // browser, outside any project. Non-fatal: the manifest install already
+  // succeeded.
   let hostConfigFile = null;
   if (opts.projectRoot) {
+    const root = opts.projectRoot;
+    const abs = (p, fallback) => {
+      const v = p ?? fallback;
+      return path.isAbsolute(v) ? v : path.join(root, v);
+    };
     try {
-      ({ file: hostConfigFile } = await writeHostConfig({ projectRoot: opts.projectRoot }));
+      ({ file: hostConfigFile } = await writeHostConfig({
+        schemaVersion: 1,
+        projectRoot: root,
+        configDir: abs(opts.configDir, '.sfdt'),
+        logDir: abs(opts.logDir, 'logs'),
+        cliVersion: opts.cliVersion ?? null,
+        installedAt: new Date().toISOString(),
+      }));
     } catch {
       // Best-effort — the host falls back to SFDT_PROJECT_ROOT / errors clearly.
     }

--- a/host/installers/install-host.test.js
+++ b/host/installers/install-host.test.js
@@ -158,7 +158,7 @@ describe('installNativeHost — darwin', () => {
     expect(parsed.allowed_origins).toEqual([`chrome-extension://${VALID_EXTENSION_ID}/`]);
   });
 
-  it('records the project root in the host config when projectRoot is passed', async () => {
+  it('records the full project context (defaults) when only projectRoot is passed', async () => {
     const r = await installNativeHost({
       extensionId: VALID_EXTENSION_ID,
       hostPath: HOST_PATH,
@@ -169,8 +169,47 @@ describe('installNativeHost — darwin', () => {
     expect(r.ok).toBe(true);
     expect(r.projectRoot).toBe('/work/my-sf-project');
     expect(r.hostConfigFile).toMatch(/sfdt-host\.json$/);
-    const written = fsState.get(r.hostConfigFile);
-    expect(JSON.parse(written)).toMatchObject({ projectRoot: '/work/my-sf-project' });
+    const written = JSON.parse(fsState.get(r.hostConfigFile));
+    expect(written).toMatchObject({
+      schemaVersion: 1,
+      projectRoot: '/work/my-sf-project',
+      configDir: '/work/my-sf-project/.sfdt',
+      logDir: '/work/my-sf-project/logs',
+    });
+    expect(written.installedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('persists a custom relative logDir resolved to an absolute path', async () => {
+    const r = await installNativeHost({
+      extensionId: VALID_EXTENSION_ID,
+      hostPath: HOST_PATH,
+      platform: 'darwin',
+      browser: 'chrome',
+      projectRoot: '/work/my-sf-project',
+      logDir: 'artifacts/sfdt-logs',
+      configDir: '/work/my-sf-project/.sfdt',
+      cliVersion: '0.17.0',
+    });
+    expect(r.ok).toBe(true);
+    expect(JSON.parse(fsState.get(r.hostConfigFile))).toMatchObject({
+      logDir: '/work/my-sf-project/artifacts/sfdt-logs',
+      cliVersion: '0.17.0',
+    });
+  });
+
+  it('persists a custom absolute logDir unchanged', async () => {
+    const r = await installNativeHost({
+      extensionId: VALID_EXTENSION_ID,
+      hostPath: HOST_PATH,
+      platform: 'darwin',
+      browser: 'chrome',
+      projectRoot: '/work/my-sf-project',
+      logDir: '/var/log/sfdt',
+    });
+    expect(r.ok).toBe(true);
+    expect(JSON.parse(fsState.get(r.hostConfigFile))).toMatchObject({
+      logDir: '/var/log/sfdt',
+    });
   });
 
   it('installs without a host config when no projectRoot is given', async () => {

--- a/scripts/ci/github-deploy.action.yml
+++ b/scripts/ci/github-deploy.action.yml
@@ -28,7 +28,7 @@ jobs:
         uses: {{actionRef}}
         continue-on-error: true
         with:
-          command: quality --output-file sfdt-quality.sarif
+          args-json: '["quality","--output-file","sfdt-quality.sarif"]'
           node-version: '{{nodeVersion}}'
       - name: Upload code scanning results
         if: always() && hashFiles('sfdt-quality.sarif') != ''
@@ -38,7 +38,7 @@ jobs:
       - name: Smart delta validation
         uses: {{actionRef}}
         with:
-          command: deploy --smart --org {{org}} --delta-base "origin/${{ github.event.pull_request.base.ref }}" --dry-run
+          args-json: '["deploy","--smart","--org","{{org}}","--delta-base","origin/${{ github.event.pull_request.base.ref }}","--dry-run"]'
           auth-method: {{authMethod}}
           org-alias: {{org}}
           node-version: '{{nodeVersion}}'

--- a/scripts/ci/github-monitor.action.yml
+++ b/scripts/ci/github-monitor.action.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Run org monitoring
         uses: {{actionRef}}
         with:
-          command: monitor all --org {{org}} --backup --notify --json
+          args-json: '["monitor","all","--org","{{org}}","--backup","--notify","--json"]'
           auth-method: {{authMethod}}
           org-alias: {{org}}
           node-version: '{{nodeVersion}}'

--- a/scripts/ci/github-release.action.yml
+++ b/scripts/ci/github-release.action.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Smart delta deploy
         uses: {{actionRef}}
         with:
-          command: deploy --smart --org {{org}} --delta-base "${{ steps.base.outputs.ref }}" --notify
+          args-json: '["deploy","--smart","--org","{{org}}","--delta-base","${{ steps.base.outputs.ref }}","--notify"]'
           auth-method: {{authMethod}}
           org-alias: {{org}}
           node-version: '{{nodeVersion}}'

--- a/scripts/quality/code-analyzer.sh
+++ b/scripts/quality/code-analyzer.sh
@@ -193,8 +193,12 @@ if command -v sf &>/dev/null && sf code-analyzer --help &>/dev/null; then
         printf '{"status":"skipped","reason":"sf code-analyzer run failed","result":[],"_sfdt_unavailable":"sf code-analyzer run failed — no violation data available for this run"}\n'
     fi
     rm -f "$_ANALYZER_TMP"
-elif [[ -n "$_SCANNER_V4" ]]; then
-    log_info "Running Salesforce Code Analyzer v4 (legacy sf scanner run)..."
+elif [[ -n "$_SCANNER_V4" && "${SFDT_ANALYZER_ALLOW_LEGACY:-}" == "true" ]]; then
+    # Legacy v4 runs only on explicit opt-in (quality --allow-legacy-analyzer or
+    # config quality.analyzer.allowLegacyV4). Its results are NON-AUTHORITATIVE:
+    # rule coverage and severities differ from v5, and SARIF/fixes/suggestions
+    # are unavailable. v4 support is removed at 1.0.
+    log_warning "Running LEGACY Salesforce Code Analyzer v4 (sf scanner run) — results are non-authoritative; upgrade to v5 (sf plugins install code-analyzer)."
     if [[ -n "${SFDT_ANALYZER_OUTPUT_FILE:-}" ]]; then
         log_warning "SFDT_ANALYZER_OUTPUT_FILE requires Code Analyzer v5 — no extra output file written."
     fi
@@ -204,6 +208,10 @@ elif [[ -n "$_SCANNER_V4" ]]; then
         --engine pmd,eslint \
         2>/dev/null || \
         printf '{"status":"skipped","reason":"sf scanner run failed","result":[],"_sfdt_unavailable":"sf scanner run failed — no violation data available for this run"}\n'
+elif [[ -n "$_SCANNER_V4" ]]; then
+    log_warning "Code Analyzer v5 not available; legacy v4 detected but NOT run (v5 is required for authoritative scans)."
+    log_warning "Install v5 with:  sf plugins install code-analyzer   — or rerun with --allow-legacy-analyzer to accept a non-authoritative v4 scan."
+    printf '{"status":"skipped","reason":"v5 required; legacy v4 present but not enabled","result":[],"_sfdt_unavailable":"Code Analyzer v5 not installed. Legacy v4 was detected but is opt-in only (--allow-legacy-analyzer, non-authoritative). Install v5: sf plugins install code-analyzer"}\n'
 else
     log_warning "Salesforce Code Analyzer not available — static violation analysis SKIPPED (not run)."
     log_warning "It auto-installs with a modern sf CLI, or run:  sf plugins install code-analyzer"

--- a/src/commands/extension.js
+++ b/src/commands/extension.js
@@ -18,6 +18,7 @@
 import chalk from 'chalk';
 import fs from 'fs-extra';
 import path from 'path';
+import { fileURLToPath } from 'url';
 // host/ is bundled inside the published @sfdt/cli tarball (see "files" in
 // package.json), and @sfdt/host itself is `"private": true` because it is
 // not a separately consumable npm package — it only makes sense as part of
@@ -40,6 +41,16 @@ import { resolveExitCode } from '../lib/exit-codes.js';
 import { emitJson, emitJsonError } from '../lib/output.js';
 
 const BROWSER_CHOICES = ['chrome', 'edge', 'brave', 'chromium', 'vivaldi', 'all'];
+
+/** The installed @sfdt/cli version, for the host-config record (best-effort). */
+async function cliVersion() {
+  try {
+    const pkgPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', 'package.json');
+    return (await fs.readJson(pkgPath)).version ?? null;
+  } catch {
+    return null;
+  }
+}
 
 // Chrome assigns extension IDs as exactly 32 chars from [a-p]
 // (a base-16 mapping of the public-key SHA-256 hash). Validate at parse time
@@ -83,13 +94,21 @@ export function registerExtensionCommand(program) {
             `--extension-id must be 32 lowercase letters a–p (Chrome extension IDs are base-16 → a-p). Got: ${options.extensionId}`,
           );
         }
-        // Record the project root so the host can find logs/ + .sfdt/config.json.
+        // Record the project context so the host can find logs/ + .sfdt/config.json.
         // Explicit flag wins; otherwise discover the current project (best-effort —
-        // install-host may be run outside a project, which is still valid).
+        // install-host may be run outside a project, which is still valid). When
+        // config loads, pass its resolved configDir/logDir so a custom
+        // config.logDir is persisted; with only --project-root the installer
+        // derives the defaults (<root>/.sfdt, <root>/logs).
         let projectRoot = options.projectRoot;
+        let configDir;
+        let logDir;
         if (!projectRoot) {
           try {
-            projectRoot = (await loadConfig())._projectRoot;
+            const config = await loadConfig();
+            projectRoot = config._projectRoot;
+            configDir = config._configDir;
+            logDir = config.logDir;
           } catch {
             projectRoot = undefined;
           }
@@ -98,6 +117,9 @@ export function registerExtensionCommand(program) {
           extensionId: options.extensionId,
           browser: options.browser,
           projectRoot,
+          configDir,
+          logDir,
+          cliVersion: await cliVersion(),
         });
         if (!result.ok) {
           if (jsonMode) {

--- a/src/commands/quality.js
+++ b/src/commands/quality.js
@@ -166,6 +166,7 @@ export function registerQualityCommand(program) {
     .option('--generate-stubs', 'Generate @IsTest stub classes for untested Apex classes')
     .option('--include-fixes', 'Ask Code Analyzer v5 for actionable fixes/suggestions in the scan output (feeds the AI fix plan)')
     .option('--output-file <path>', 'Also write the Code Analyzer v5 results to a file; the format follows the extension (e.g. .sarif for code-scanning upload)')
+    .option('--allow-legacy-analyzer', 'Permit the legacy Code Analyzer v4 (sf scanner run) when v5 is unavailable — results are non-authoritative (also: config quality.analyzer.allowLegacyV4)')
     .option('--dry-run', 'Preview --generate-stubs output without writing files')
     .option('--agent', 'Non-interactive agent mode (do not block waiting on the AI fix-plan session)')
     .option('--api67', "Run only the API v67 (Summer '26) user-mode readiness scan of local Apex sources")
@@ -188,11 +189,15 @@ export function registerQualityCommand(program) {
 
         let qualityOutput = '';
 
-        // --include-fixes/--output-file only affect the Code Analyzer v5 run
-        // (test-analyzer ignores them); the shell script reads the SFDT_ vars.
+        // --include-fixes/--output-file/--allow-legacy-analyzer only affect the
+        // Code Analyzer run (test-analyzer ignores them); the shell script reads
+        // the SFDT_ vars. Legacy v4 is opt-in via flag or config (J-1 policy).
+        const allowLegacy =
+          options.allowLegacyAnalyzer || config.quality?.analyzer?.allowLegacyV4 === true;
         const analyzerEnv = {
           ...(options.includeFixes ? { SFDT_ANALYZER_INCLUDE_FIXES: 'true' } : {}),
           ...(options.outputFile ? { SFDT_ANALYZER_OUTPUT_FILE: options.outputFile } : {}),
+          ...(allowLegacy ? { SFDT_ANALYZER_ALLOW_LEGACY: 'true' } : {}),
         };
 
         const runAnalyzer = async (scriptPath, label, extraEnv = {}) => {

--- a/src/commands/test.js
+++ b/src/commands/test.js
@@ -7,7 +7,7 @@ import { gatherLatestTestResults, frameProvidedContext } from '../lib/ai-context
 import { getPrompt } from '../lib/prompts.js';
 import { print } from '../lib/output.js';
 import { ExitCode, resolveExitCode } from '../lib/exit-codes.js';
-import { buildLogicTestArgs } from '../lib/logic-test.js';
+import { buildLogicTestArgs, detectZeroTests } from '../lib/logic-test.js';
 import { detectLwcTests, buildLwcTestArgs } from '../lib/lwc-test.js';
 
 /**
@@ -73,16 +73,25 @@ async function runLogicTests(config, options) {
     return;
   }
 
-  // Capture the run output when AI analysis is possible, so a failure can be
-  // fed to the AI (logic results aren't written to the standard result dir);
-  // otherwise stream straight to the terminal.
-  const canAnalyze = !!config.features?.ai;
+  // Stream live AND capture (execa 9 multi-destination stdio): the capture
+  // feeds the zero-test guard and, on failure, the AI analysis (logic results
+  // aren't written to the standard result dir).
+  const capture = { stdout: ['inherit', 'pipe'], stderr: ['inherit', 'pipe'], all: true };
   try {
-    const res = await execa('sf', args, canAnalyze ? { all: true } : { stdio: 'inherit' });
-    if (canAnalyze && res.all) console.log(res.all);
+    const res = await execa('sf', args, capture);
+    if (!options.allowZeroTests && detectZeroTests(res.all)) {
+      print.error(
+        `Zero tests were run on ${org}` +
+          (options.tests ? ` (tests: ${options.tests})` : '') +
+          (options.category ? ` (category: ${options.category})` : '') +
+          ' — a pass that verified nothing. Check test names (Flow tests need the FlowTesting.<name> prefix) and that the org grants "View All Data".',
+      );
+      print.info('Pass --allow-zero-tests if an empty run is expected.');
+      process.exitCode = 1;
+      return;
+    }
     print.success('All logic tests passed.');
   } catch (err) {
-    if (canAnalyze && err.all) console.log(err.all);
     print.error('Logic tests failed.');
     print.info('Note: `sf logic run test` is Beta and requires the "View All Data" org permission.');
     const output = String(err.all || err.stderr || err.stdout || err.message || '').slice(0, 12000);
@@ -134,7 +143,8 @@ export function registerTestCommand(program) {
     .option('--tests <list>', 'For --logic: comma-separated test names (Apex classes and FlowTesting.<name>)')
     .option('--category <cat>', 'For --logic: restrict to Apex or Flow')
     .option('--code-coverage', 'For --logic: retrieve code coverage results')
-    .option('--wait <minutes>', 'For --logic: streaming wait timeout in minutes (default: 30)')
+    .option('--wait <minutes>', 'For --logic: streaming wait timeout in whole minutes, >= 1 (default: 30)')
+    .option('--allow-zero-tests', 'For --logic: exit 0 even when Salesforce runs zero tests (default: zero tests fail the run)')
     .action(async (options) => {
       try {
         const config = await loadConfig();

--- a/src/lib/config-schema.json
+++ b/src/lib/config-schema.json
@@ -201,6 +201,19 @@
         "soapLoginLookbackDays": { "type": "integer", "minimum": 1 }
       }
     },
+    "quality": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "analyzer": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "allowLegacyV4": { "type": "boolean" }
+          }
+        }
+      }
+    },
     "monitoring": {
       "type": "object",
       "additionalProperties": false,

--- a/src/lib/logic-test.js
+++ b/src/lib/logic-test.js
@@ -38,6 +38,11 @@ export function buildLogicTestArgs(opts = {}, org) {
   // `sf logic run test` is async by default (returns a run id); wait for
   // results so `sfdt test --logic` is usable in CI without a separate poll.
   const wait = opts.wait != null && opts.wait !== '' ? String(opts.wait) : '30';
+  if (!/^\d+$/.test(wait) || Number.parseInt(wait, 10) < 1) {
+    throw new Error(
+      `Invalid --wait "${opts.wait}" — must be a whole number of minutes, 1 or greater`,
+    );
+  }
   const args = ['logic', 'run', 'test', '--target-org', org, '--wait', wait];
 
   if (opts.testLevel) args.push('--test-level', opts.testLevel);
@@ -47,4 +52,17 @@ export function buildLogicTestArgs(opts = {}, org) {
   if (opts.category) args.push('--test-category', opts.category);
   if (opts.codeCoverage) args.push('--code-coverage');
   return args;
+}
+
+/**
+ * Detect a run where Salesforce executed zero tests — a "pass" that verified
+ * nothing (typo'd test names, missing FlowTesting.<name> prefix, or a
+ * permissions gap). Matches the human table ("Tests Ran … 0") and the JSON
+ * summary shape; unknown output formats return false (never a false failure).
+ */
+export function detectZeroTests(output) {
+  if (!output) return false;
+  // ponytail: text heuristic against the beta runner's output; replace with a
+  // parsed result model if/when unified result normalization (blueprint I-4) lands.
+  return /Tests Ran\D{0,20}0\b/i.test(output) || /"testsRan"\s*:\s*0\b/.test(output);
 }

--- a/src/templates/sfdt.config.json
+++ b/src/templates/sfdt.config.json
@@ -95,6 +95,11 @@
     "connectedAppFlagPermissive": true,
     "soapLoginLookbackDays": 30
   },
+  "quality": {
+    "analyzer": {
+      "allowLegacyV4": false
+    }
+  },
   "monitoring": {
     "backupDir": "monitoring-backup",
     "limitWarnThreshold": 0.75,

--- a/test/action.test.js
+++ b/test/action.test.js
@@ -30,15 +30,40 @@ describe('root composite action (action.yml)', () => {
   it('declares the expected input surface', () => {
     const inputs = Object.keys(action.inputs);
     for (const name of [
-      'command', 'cli-version', 'auth-method',
+      'args-json', 'command', 'allow-shell-command', 'cli-version', 'auth-method',
       'sfdx-auth-url', 'consumer-key', 'jwt-secret-key', 'username', 'instance-url',
       'org-alias', 'node-version',
     ]) {
       expect(inputs, `missing input ${name}`).toContain(name);
     }
-    expect(action.inputs.command.required).toBe(true);
+    // Exactly one of args-json/command is required — enforced at runtime by
+    // the Validate step, so neither is required at the manifest level.
+    expect(action.inputs.command.required).toBe(false);
+    expect(action.inputs['args-json'].required).toBe(false);
+    expect(action.inputs['allow-shell-command'].default).toBe('false');
     expect(action.inputs['cli-version'].default).toBe('auto');
     expect(action.inputs['auth-method'].default).toBe('none');
+  });
+
+  it('never evals the command input without the explicit shell opt-in', () => {
+    const run = action.runs.steps.find((s) => s.name === 'Run sfdt');
+    // eval appears only inside the allow-shell-command branch…
+    const evalIdx = run.run.indexOf('eval "sfdt');
+    const guardIdx = run.run.indexOf('SFDT_ALLOW_SHELL" = "true"');
+    expect(guardIdx).toBeGreaterThan(-1);
+    expect(evalIdx).toBeGreaterThan(guardIdx);
+    // …the default string path rejects metacharacters and newlines…
+    expect(run.run).toContain("[^A-Za-z0-9 _@%+=:,./-]");
+    expect(run.run).toContain("*$'\\n'*");
+    // …and the args-json path validates a string array before use.
+    expect(run.run).toContain('type=="array"');
+    expect(run.run).toContain('all(.[]; type=="string")');
+  });
+
+  it('validates that exactly one of args-json/command is passed', () => {
+    const validate = action.runs.steps.find((s) => s.name === 'Validate inputs');
+    expect(validate.run).toContain('one of args-json or command is required');
+    expect(validate.run).toContain('mutually exclusive');
   });
 
   it('never interpolates secret inputs into run bodies (env-only)', () => {

--- a/test/commands/test.test.js
+++ b/test/commands/test.test.js
@@ -213,10 +213,30 @@ describe('test command', () => {
           'logic', 'run', 'test', '--target-org', 'qa', '--wait', '30',
           '--test-level', 'RunSpecifiedTests', '--tests', 'FooTest,FlowTesting.MyFlow', '--code-coverage',
         ],
-        // AI is enabled in the default test config → capture mode (all: true)
-        // so a failure can be fed to the AI; the argv is what matters here.
-        { all: true },
+        // Always stream + capture (execa multi-destination stdio): the capture
+        // feeds the zero-test guard and, on failure, the AI analysis.
+        { stdout: ['inherit', 'pipe'], stderr: ['inherit', 'pipe'], all: true },
       );
+      expect(print.success).toHaveBeenCalled();
+      expect(process.exitCode).toBeUndefined();
+    });
+
+    it('fails a "passing" run that executed zero tests', async () => {
+      execa.mockResolvedValue({ exitCode: 0, all: 'Test Summary\nTests Ran        0' });
+
+      await createProgram().parseAsync(['node', 'sfdt', 'test', '--logic', '--tests', 'NopeTest']);
+
+      expect(print.error).toHaveBeenCalledWith(expect.stringContaining('Zero tests were run'));
+      expect(print.error).toHaveBeenCalledWith(expect.stringContaining('NopeTest'));
+      expect(print.success).not.toHaveBeenCalled();
+      expect(process.exitCode).toBe(1);
+    });
+
+    it('allows a zero-test run with --allow-zero-tests', async () => {
+      execa.mockResolvedValue({ exitCode: 0, all: 'Tests Ran        0' });
+
+      await createProgram().parseAsync(['node', 'sfdt', 'test', '--logic', '--allow-zero-tests']);
+
       expect(print.success).toHaveBeenCalled();
       expect(process.exitCode).toBeUndefined();
     });
@@ -262,8 +282,12 @@ describe('test command', () => {
 
       await createProgram().parseAsync(['node', 'sfdt', 'test', '--logic']);
 
-      // capture mode → execa called with { all: true }, not stdio inherit
-      expect(execa).toHaveBeenCalledWith('sf', expect.any(Array), { all: true });
+      // stream + capture mode — the capture feeds the AI analysis
+      expect(execa).toHaveBeenCalledWith(
+        'sf',
+        expect.any(Array),
+        expect.objectContaining({ all: true }),
+      );
       // the captured run output is injected as context for every provider
       expect(gatherLatestTestResults).not.toHaveBeenCalled();
       expect(runAiPrompt).toHaveBeenCalledWith(
@@ -273,13 +297,19 @@ describe('test command', () => {
       expect(process.exitCode).toBe(1);
     });
 
-    it('streams (no capture) and skips AI when features.ai is off', async () => {
+    it('still captures output but skips AI when features.ai is off', async () => {
       loadConfig.mockResolvedValue({ _projectRoot: '/project', defaultOrg: 'dev', features: { ai: false } });
       execa.mockRejectedValue(Object.assign(new Error('failed'), { exitCode: 1 }));
 
       await createProgram().parseAsync(['node', 'sfdt', 'test', '--logic']);
 
-      expect(execa).toHaveBeenCalledWith('sf', expect.any(Array), { stdio: 'inherit' });
+      // capture is unconditional now (zero-test guard needs the output);
+      // 'inherit' in the stdio arrays keeps the live streaming behavior.
+      expect(execa).toHaveBeenCalledWith(
+        'sf',
+        expect.any(Array),
+        expect.objectContaining({ stdout: ['inherit', 'pipe'], all: true }),
+      );
       expect(inquirer.prompt).not.toHaveBeenCalled();
       expect(runAiPrompt).not.toHaveBeenCalled();
       expect(process.exitCode).toBe(1);

--- a/test/lib/logic-test.test.js
+++ b/test/lib/logic-test.test.js
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { buildLogicTestArgs, LOGIC_TEST_LEVELS, LOGIC_TEST_CATEGORIES } from '../../src/lib/logic-test.js';
+import {
+  buildLogicTestArgs,
+  detectZeroTests,
+  LOGIC_TEST_LEVELS,
+  LOGIC_TEST_CATEGORIES,
+} from '../../src/lib/logic-test.js';
 
 describe('buildLogicTestArgs', () => {
   it('builds a minimal run with the required org and a default 30-minute wait', () => {
@@ -13,11 +18,17 @@ describe('buildLogicTestArgs', () => {
     expect(() => buildLogicTestArgs({}, '')).toThrow(/No org specified/);
   });
 
-  it('honours an explicit --wait (including 0)', () => {
+  it('honours an explicit valid --wait', () => {
     expect(buildLogicTestArgs({ wait: '5' }, 'dev')).toContain('5');
-    // 0 is a legitimate caller-provided value, not "unset".
-    const args = buildLogicTestArgs({ wait: 0 }, 'dev');
-    expect(args[args.indexOf('--wait') + 1]).toBe('0');
+    const args = buildLogicTestArgs({ wait: 120 }, 'dev');
+    expect(args[args.indexOf('--wait') + 1]).toBe('120');
+  });
+
+  it('rejects non-integer, zero, and negative --wait values', () => {
+    for (const wait of ['0', 0, '-5', '2.5', 'abc', '10m', ' 5']) {
+      expect(() => buildLogicTestArgs({ wait }, 'dev'), `wait=${JSON.stringify(wait)}`)
+        .toThrow(/Invalid --wait/);
+    }
   });
 
   it('appends test level, tests, category, and code-coverage when provided', () => {
@@ -52,5 +63,26 @@ describe('buildLogicTestArgs', () => {
     for (const cat of LOGIC_TEST_CATEGORIES) {
       expect(() => buildLogicTestArgs({ category: cat }, 'dev')).not.toThrow();
     }
+  });
+});
+
+describe('detectZeroTests', () => {
+  it('flags the human summary table and JSON summary when zero tests ran', () => {
+    expect(detectZeroTests('=== Test Summary\nTests Ran        0\nPassing          0')).toBe(true);
+    expect(detectZeroTests('Tests Ran: 0')).toBe(true);
+    expect(detectZeroTests('Tests Ran | 0 |')).toBe(true);
+    expect(detectZeroTests('{"summary":{"testsRan": 0,"passing":0}}')).toBe(true);
+  });
+
+  it('does not flag runs that executed tests', () => {
+    expect(detectZeroTests('Tests Ran        10\nPassing          10')).toBe(false);
+    expect(detectZeroTests('Tests Ran: 20')).toBe(false);
+    expect(detectZeroTests('{"summary":{"testsRan": 105}}')).toBe(false);
+  });
+
+  it('returns false for empty or unrecognized output (never a false failure)', () => {
+    expect(detectZeroTests('')).toBe(false);
+    expect(detectZeroTests(undefined)).toBe(false);
+    expect(detectZeroTests('Run completed.')).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

PR 3 of the blueprint-audit remediation program — the four confirmed implementation-hardening findings.

## K — composite Action injection surface (`action.yml:159` was `eval "sfdt ${SFDT_COMMAND}"`)

- **New `args-json` input** (preferred): a JSON array of arguments, validated with jq and passed as a bash argv — values never touch shell parsing. Verified locally: `["deploy","--delta-base","origin/main; rm -rf /"]` reaches sfdt as one inert argument.
- **`command` deprecated + hardened**: without `allow-shell-command: 'true'` it accepts only shell-neutral characters (letters, digits, space, `_@%+=:,./-`) and is word-split with no shell; quotes/`$`/`;`/newlines are rejected with a migration hint. The opt-in keeps legacy eval for fully trusted static strings (removed in v1).
- Exactly-one-of validation; GitHub action-runner CI templates migrated to `args-json`; **selftest workflow** now covers both execution paths + five rejection cases (metachars, `$(…)` substitution, non-array JSON, both inputs, bad auth-method).

## H — native host loses custom `logDir`

`sfdt extension install-host` now persists `{ schemaVersion, projectRoot, configDir, logDir (resolved absolute), cliVersion, installedAt }` — a custom `config.logDir` survives browser-launched host sessions. Old projectRoot-only host configs keep working (the reader already falls back). Tests cover default/relative/absolute logDir.

## I — logic-test input validation + zero-test safeguard

- `--wait` must be a whole number of minutes ≥ 1 (was passed through unvalidated to `sf logic run test`).
- A "passing" run that executed **zero tests** now exits 1 — it verified nothing (typo'd names, missing `FlowTesting.` prefix, permission gap) — with the requested filters in the message; `--allow-zero-tests` opts out. Output now streams live *and* is captured (execa 9 multi-destination stdio), so the guard and AI failure analysis both work without losing streaming.

## J — Code Analyzer v4 policy (J-1 adopted)

v4 never runs as a silent fallback. v5 is required for authoritative scans; a v4-only environment emits the `skipped` marker (skip ≠ pass) unless legacy mode is explicitly enabled via `quality --allow-legacy-analyzer` or config `quality.analyzer.allowLegacyV4` — and then it's labeled non-authoritative. CI templates never enable it. Removed at 1.0.

## Verification

- 3696 tests pass (13 new/updated across action/logic-test/test-command/host-installer suites); lint clean
- Local smoke of the extracted Run-step script: 6/6 cases correct, no injection artifacts
- The action-selftest workflow runs on this PR (it touches `action.yml`)

CHANGELOG Unreleased populated. CLAUDE.md env table documents `SFDT_ANALYZER_ALLOW_LEGACY`.

https://claude.ai/code/session_01PRtcJodaDCxv9kY8GrAcxC