### PR TITLE
Fix cleanup-pr-beta failing on every PR close (unexported env vars)

### DIFF
--- a/.github/workflows/pr-publish.yml
+++ b/.github/workflows/pr-publish.yml
@@ -145,6 +145,9 @@ jobs:
         run: |
           TAG="pr-${PR_NUMBER}"
           TAGS=$(npm view @sfdt/cli dist-tags --json 2>/dev/null || echo '{}')
+          # node reads these via process.env — they must be exported, or
+          # JSON.parse(undefined) throws and the job fails on every PR close.
+          export TAG TAGS
           EXISTS=$(node -e "
             const t = JSON.parse(process.env.TAGS);
             const tag = process.env.TAG;


### PR DESCRIPTION
## Summary

`cleanup-pr-beta`'s "Check if dist-tag exists" step assigns `TAG`/`TAGS` as shell locals, but its embedded `node -e` scripts read them via `process.env` — where they're `undefined`, so `JSON.parse(undefined)` throws and the job fails on **every PR close** (observed failing on #200's merge; only `PR_NUMBER` was in `env:`). One-line fix: `export TAG TAGS`.

https://claude.ai/code/session_01PRtcJodaDCxv9kY8GrAcxC