### PR TITLE
API-version audit: sfdt versions command + extended audit check + Chrome feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`sfdt versions` — cross-surface API-version audit.** Scans local source meta files (Apex classes/triggers, Flows, LWC, Aura + `sourceApiVersion`) and, when an org resolves, the org side (per-type Tooling distributions + the org's max API version/release), then reports per-type histograms and below-floor/behind-ceiling outliers. `--local-only` works fully offline; `--json` emits the standard envelope; MCP exposes read-only `sfdt_api_versions`; the VS Code command tree gains an "API Versions Report" entry.
+- **`sfdt audit api-versions` extended** — now covers active **Flows** (degrading gracefully on orgs that reject the Tooling query), reports the org's max API version in the summary ("3 below v45 (org max: v67, Summer '26)"), and a new `audit.apiVersionWarnBehind` config (default 0 = off) additionally warns on components more than N versions behind the org ceiling, with findings tagged `below-floor` vs `behind-ceiling`.
+- **Chrome extension: `api-version-audit` feature (40th feature)** — a Setup pill ("API v67 · 2 behind", amber when anything is below the shared flow-core floor) that expands to per-type version histograms with an org-max footer. Org-side only, no bridge required, opt-in like every feature.
+
+### Fixed
+
+- **`detectOrgRelease` always returned null when `sf` colorizes output** — `sf api request rest` emits ANSI color codes even without a TTY, breaking the JSON parse. Color is now forced off, which also restores the release-mismatch warnings in `compare`/`retrofit` and the org-release context in `monitor org-info` on affected environments.
+
 - **Surface catalog framework** (`generated/` + `schemas/` + `tools/`) — machine-generated, checked-in inventories of every public surface: CLI commands (Commander tree + a new `src/lib/command-policy.js` security/exposure policy), Chrome features (parity-tested `extension/lib/feature-manifests.json`), GUI pages (new single `gui/src/routes.js` registry), VS Code commands, MCP tools, bridge kinds, CI capabilities, package versions, and a cross-surface parity matrix. `npm run generate:catalogs` regenerates; `npm run check:all-contracts` (now in CI) fails on catalog drift, stale license strings, unsupported Node claims, and unsafe auth-docs guidance. Counts on the docs site stop being hand-maintained.
 
 - **`sfdt test --logic --allow-zero-tests`** — a "passing" unified logic run that executed **zero tests** now exits non-zero (it verified nothing — typo'd test names, missing `FlowTesting.` prefix, or a permissions gap); pass the flag when an empty run is expected. Logic run output now streams live *and* is captured for the guard/AI analysis.

--- a/extension/entrypoints/content.ts
+++ b/extension/entrypoints/content.ts
@@ -47,6 +47,7 @@ import { createDebugLogViewerFeature } from '../features/debug-log-viewer.js';
 import { createSavedSoqlFeature } from '../features/saved-soql.js';
 import { createOrgSwitcherFeature } from '../features/org-switcher.js';
 import { createOrgReleaseBadgeFeature } from '../features/org-release-badge.js';
+import { createApiVersionAuditFeature } from '../features/api-version-audit.js';
 
 const SALESFORCE_HOST_PATTERN =
   /^https:\/\/[^/]+\.(salesforce\.com|salesforce-setup\.com|my\.salesforce\.com|lightning\.force\.com)\//i;
@@ -79,6 +80,9 @@ export default defineContentScript({
     // Non-interactive pill in the Setup tab strip: org release + preview flag
     // (derived via flow-core, same as CLI `monitor org-info`).
     registry.register(createOrgReleaseBadgeFeature());
+    // Click-to-open pill next to the badge: org max API version + per-type
+    // ApiVersion histograms, banded via flow-core's minApiVersionFloor.
+    registry.register(createApiVersionAuditFeature());
     registry.register(createCanvasSearchFeature());
     registry.register(createFlowListSearchFeature());
     registry.register(createFlowHealthCheckFeature());

--- a/extension/features/api-version-audit.ts
+++ b/extension/features/api-version-audit.ts
@@ -1,0 +1,326 @@
+import { releaseFromVersionList, ORG_HEALTH_THRESHOLDS, type OrgReleaseInfo } from '@sfdt/flow-core';
+import { isFeatureEnabled, loadSettings, onSettingsChange } from '../lib/settings.js';
+import type { Feature } from '../lib/feature-registry.js';
+import { CONTEXTS } from '../lib/context-detector.js';
+import { waitForTabBar } from '../lib/setup-tab-bar.js';
+import { getSalesforceApi, type SalesforceApiClient } from '../lib/salesforce-api.js';
+
+// An interactive pill in the Setup tab strip auditing the org's API-version
+// spread: org max API version + release (via /services/data, same flow-core
+// reduction as the release badge) plus per-type ApiVersion histograms from the
+// Tooling API. "Behind" = components below flow-core's minApiVersionFloor, so
+// the banding matches the CLI's org-health checks. Clicking the pill toggles a
+// small histogram panel.
+
+const AUDIT_CLASS = 'sfdt-api-version-audit';
+const PANEL_CLASS = 'sfdt-api-version-audit-panel';
+const BEHIND_COLOUR = '#fe9339'; // amber — matches org-health's amber band
+const OK_COLOUR = '#706e6b'; // neutral grey
+
+interface ApiVersionRow {
+  ApiVersion?: number | null;
+}
+
+/** version → count, oldest first. */
+export type VersionHistogram = ReadonlyArray<readonly [number, number]>;
+
+export interface TypeDistribution {
+  label: string;
+  versions: VersionHistogram;
+}
+
+export interface AuditData {
+  release: OrgReleaseInfo | null;
+  types: TypeDistribution[];
+}
+
+const TYPE_QUERIES: ReadonlyArray<{ label: string; soql: string }> = [
+  { label: 'Apex Classes', soql: 'SELECT ApiVersion FROM ApexClass WHERE NamespacePrefix = null' },
+  { label: 'Apex Triggers', soql: 'SELECT ApiVersion FROM ApexTrigger WHERE NamespacePrefix = null' },
+  { label: 'Flows', soql: "SELECT ApiVersion FROM Flow WHERE Status = 'Active'" },
+];
+
+/** Aggregate raw ApiVersion rows into a version→count histogram, oldest first. */
+export function aggregateVersions(rows: ReadonlyArray<ApiVersionRow>): VersionHistogram {
+  const counts = new Map<number, number>();
+  for (const row of rows) {
+    const v = row?.ApiVersion;
+    if (typeof v !== 'number' || !Number.isFinite(v)) continue;
+    counts.set(v, (counts.get(v) ?? 0) + 1);
+  }
+  return [...counts.entries()].sort((a, b) => a[0] - b[0]);
+}
+
+/** Components with an ApiVersion below flow-core's minApiVersionFloor. */
+export function countBehind(types: ReadonlyArray<TypeDistribution>): number {
+  let behind = 0;
+  for (const t of types) {
+    for (const [version, count] of t.versions) {
+      if (version < ORG_HEALTH_THRESHOLDS.minApiVersionFloor) behind += count;
+    }
+  }
+  return behind;
+}
+
+/** Compose the short pill text + hover title from the fetched data. */
+export function describeAuditPill(data: AuditData): { text: string; title: string } {
+  const behind = countBehind(data.types);
+  const parts = [data.release ? `API v${data.release.apiVersion}` : 'API versions'];
+  if (behind > 0) parts.push(`${behind} behind`);
+
+  const titleBits: string[] = [];
+  if (data.release) {
+    titleBits.push(
+      `Org max API v${data.release.apiVersion} — ${data.release.release}${data.release.preview ? ' (preview)' : ''}`,
+    );
+  }
+  titleBits.push(
+    behind > 0
+      ? `${behind} component${behind === 1 ? '' : 's'} below v${ORG_HEALTH_THRESHOLDS.minApiVersionFloor}`
+      : `No components below v${ORG_HEALTH_THRESHOLDS.minApiVersionFloor}`,
+  );
+  return { text: parts.join(' · '), title: titleBits.join(' · ') };
+}
+
+/** Fetch release + per-type distributions; null only when nothing could be read. */
+async function fetchAuditData(api: SalesforceApiClient): Promise<AuditData | null> {
+  let release: OrgReleaseInfo | null = null;
+  try {
+    release = releaseFromVersionList(await api.apiGet('/services/data'));
+  } catch {
+    // Informational — a failed version list just drops the footer.
+  }
+
+  const types: TypeDistribution[] = [];
+  for (const t of TYPE_QUERIES) {
+    try {
+      const res = await api.toolingQuery<ApiVersionRow>(t.soql);
+      types.push({ label: t.label, versions: aggregateVersions(res.records) });
+    } catch {
+      // Each query stands alone — e.g. a failing Flow query still renders Apex.
+    }
+  }
+
+  if (!release && types.length === 0) return null;
+  return { release, types };
+}
+
+function buildPanel(doc: Document, data: AuditData): HTMLDivElement {
+  const panel = doc.createElement('div');
+  panel.className = PANEL_CLASS;
+  panel.style.cssText = [
+    'position: absolute',
+    'top: 100%',
+    'right: 0',
+    'z-index: 99999',
+    'background: #fff',
+    'border: 1px solid #d8dde6',
+    'border-radius: 4px',
+    'box-shadow: 0 2px 8px rgba(0,0,0,0.15)',
+    'padding: 10px 12px',
+    'min-width: 240px',
+    'max-height: 380px',
+    'overflow-y: auto',
+    'font-size: 12px',
+    'color: #16325c',
+    'text-align: left',
+    'white-space: nowrap',
+  ].join('; ');
+
+  const floor = ORG_HEALTH_THRESHOLDS.minApiVersionFloor;
+  for (const t of data.types) {
+    const heading = doc.createElement('div');
+    heading.style.cssText = 'font-weight: 700; margin: 6px 0 4px; font-size: 11px; text-transform: uppercase; letter-spacing: 0.02em; color: #54698d;';
+    heading.textContent = t.label;
+    panel.appendChild(heading);
+
+    if (t.versions.length === 0) {
+      const empty = doc.createElement('div');
+      empty.style.cssText = 'color: #54698d; font-style: italic;';
+      empty.textContent = 'none';
+      panel.appendChild(empty);
+      continue;
+    }
+
+    const max = Math.max(...t.versions.map(([, count]) => count));
+    for (const [version, count] of t.versions) {
+      const below = version < floor;
+      const row = doc.createElement('div');
+      row.className = `${PANEL_CLASS}-row`;
+      row.style.cssText = [
+        'display: flex',
+        'align-items: center',
+        'gap: 8px',
+        'padding: 1px 4px',
+        below ? `color: ${BEHIND_COLOUR}; font-weight: 700; background: #fef4ec` : '',
+      ].join('; ');
+      if (below) row.dataset['belowFloor'] = 'true';
+
+      const label = doc.createElement('span');
+      label.style.cssText = 'width: 36px; flex: 0 0 auto;';
+      label.textContent = `v${version}`;
+      const bar = doc.createElement('span');
+      bar.style.cssText = [
+        'display: inline-block',
+        'height: 8px',
+        'border-radius: 2px',
+        `width: ${Math.max(4, Math.round((count / max) * 80))}px`,
+        `background: ${below ? BEHIND_COLOUR : '#1589ee'}`,
+      ].join('; ');
+      const countEl = doc.createElement('span');
+      countEl.textContent = String(count);
+      row.append(label, bar, countEl);
+      panel.appendChild(row);
+    }
+  }
+
+  if (data.release) {
+    const footer = doc.createElement('div');
+    footer.className = `${PANEL_CLASS}-footer`;
+    footer.style.cssText = 'margin-top: 8px; padding-top: 6px; border-top: 1px solid #d8dde6; color: #54698d;';
+    footer.textContent = `Org max: v${data.release.apiVersion} — ${data.release.release}${data.release.preview ? ' (preview)' : ''}`;
+    panel.appendChild(footer);
+  }
+
+  return panel;
+}
+
+function removeAudit(doc: Document): void {
+  for (const el of doc.querySelectorAll(`.${AUDIT_CLASS}`)) el.remove();
+}
+
+export interface ApiVersionAuditOptions {
+  doc?: Document;
+  win?: Window;
+  api?: SalesforceApiClient;
+  waitTimeoutMs?: number;
+}
+
+export function createApiVersionAuditFeature(options: ApiVersionAuditOptions = {}): Feature {
+  const doc = options.doc ?? document;
+  const api = options.api ?? getSalesforceApi();
+  const timeoutMs = options.waitTimeoutMs ?? 10_000;
+  let injecting = false;
+  let unsubscribe: (() => void) | null = null;
+  // Version spread doesn't change within a session — fetch once, reuse across
+  // SPA navigations (each nav rebuilds the tab bar, so we re-inject the pill).
+  let cached: AuditData | null = null;
+  let escListener: ((e: KeyboardEvent) => void) | null = null;
+
+  function closePanel(): void {
+    for (const el of doc.querySelectorAll(`.${PANEL_CLASS}`)) el.remove();
+    if (escListener) {
+      doc.removeEventListener('keydown', escListener);
+      escListener = null;
+    }
+  }
+
+  function togglePanel(host: HTMLElement, data: AuditData): void {
+    if (host.querySelector(`.${PANEL_CLASS}`)) {
+      closePanel();
+      return;
+    }
+    closePanel();
+    host.appendChild(buildPanel(doc, data));
+    escListener = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') closePanel();
+    };
+    doc.addEventListener('keydown', escListener);
+  }
+
+  function buildPill(data: AuditData): HTMLLIElement {
+    const { text, title } = describeAuditPill(data);
+    const li = doc.createElement('li');
+    li.setAttribute('role', 'presentation');
+    li.className = `oneConsoleTabItem tabItem slds-context-bar__item ${AUDIT_CLASS}`;
+    li.style.cssText = 'display: flex; align-items: center; padding: 0 8px; position: relative;';
+
+    const pill = doc.createElement('span');
+    const behind = countBehind(data.types) > 0;
+    pill.style.cssText = [
+      'font-size: 10px',
+      'font-weight: 700',
+      'text-transform: uppercase',
+      'letter-spacing: 0.02em',
+      'color: #fff',
+      `background: ${behind ? BEHIND_COLOUR : OK_COLOUR}`,
+      'border-radius: 3px',
+      'padding: 2px 8px',
+      'white-space: nowrap',
+      'cursor: pointer',
+    ].join('; ');
+    pill.textContent = text;
+    pill.title = title;
+    pill.addEventListener('click', () => togglePanel(li, data));
+
+    li.appendChild(pill);
+    return li;
+  }
+
+  async function injectIfEnabled(): Promise<void> {
+    const settings = await loadSettings();
+    if (!isFeatureEnabled(settings, 'api-version-audit')) {
+      closePanel();
+      removeAudit(doc);
+      return;
+    }
+    if (injecting) return;
+    if (doc.querySelector(`.${AUDIT_CLASS}`)) return;
+
+    injecting = true;
+    try {
+      const tabBar = await waitForTabBar(doc, timeoutMs);
+      if (!tabBar) return;
+      if (doc.querySelector(`.${AUDIT_CLASS}`)) return; // another pass mounted it while we waited
+
+      cached ??= await fetchAuditData(api);
+      if (!cached) return;
+      tabBar.appendChild(buildPill(cached));
+    } catch (err) {
+      console.warn('[SFDT api-version-audit] failed to render', err);
+    } finally {
+      injecting = false;
+    }
+  }
+
+  return {
+    manifest: {
+      id: 'api-version-audit',
+      name: 'API Version Audit',
+      contexts: [CONTEXTS.SETUP_FLOWS, CONTEXTS.FLOW_TRIGGER_EXPLORER, CONTEXTS.SETUP_OTHER],
+    },
+
+    async init() {
+      await injectIfEnabled();
+      unsubscribe = onSettingsChange(async () => {
+        closePanel();
+        removeAudit(doc);
+        await injectIfEnabled();
+      });
+    },
+
+    // Side-button activation: make sure the pill exists, then toggle its panel.
+    async onActivate() {
+      await injectIfEnabled();
+      const host = doc.querySelector<HTMLElement>(`.${AUDIT_CLASS}`);
+      if (host && cached) togglePanel(host, cached);
+    },
+
+    async refresh() {
+      closePanel();
+      removeAudit(doc);
+      await injectIfEnabled();
+    },
+
+    async teardown() {
+      unsubscribe?.();
+      unsubscribe = null;
+      closePanel();
+      removeAudit(doc);
+    },
+  };
+}
+
+export function _apiVersionAuditTestApi() {
+  return { AUDIT_CLASS, PANEL_CLASS };
+}

--- a/extension/lib/feature-icons.ts
+++ b/extension/lib/feature-icons.ts
@@ -26,6 +26,7 @@ export const FEATURE_ICONS: Record<string, FeatureIcon> = {
   'soql-runner': { icon: '🗂', label: 'SOQL Query Runner' },
   'org-limits': { icon: '🚦', label: 'Org Limits' },
   'org-health': { icon: '🏥', label: 'Org Health' },
+  'api-version-audit': { icon: '📶', label: 'API Version Audit' },
   'rest-explore': { icon: '🛠', label: 'REST API Explorer' },
   'inspect-record': { icon: '🔍', label: 'Inspect Record (Show All Data)' },
   'show-api-names': { icon: '🏷️', label: 'Show API Names' },

--- a/extension/lib/feature-manifests.json
+++ b/extension/lib/feature-manifests.json
@@ -63,6 +63,19 @@
     "bridgeRequired": false
   },
   {
+    "id": "api-version-audit",
+    "name": "API Version Audit",
+    "contexts": [
+      "setup_flows",
+      "flow_trigger_explorer",
+      "setup_other"
+    ],
+    "enabledByDefault": true,
+    "workspace": false,
+    "sideButton": true,
+    "bridgeRequired": false
+  },
+  {
     "id": "canvas-search",
     "name": "Search & Highlight",
     "contexts": [

--- a/extension/test/api-version-audit.test.ts
+++ b/extension/test/api-version-audit.test.ts
@@ -1,0 +1,241 @@
+// API Version Audit tests — a click-to-open pill in the Setup tab strip
+// showing org max API version + per-type ApiVersion histograms. We exercise
+// the pure aggregation/description helpers and the feature against a
+// happy-dom tab bar with a mocked Salesforce API client.
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ORG_HEALTH_THRESHOLDS } from '@sfdt/flow-core';
+import {
+  createApiVersionAuditFeature,
+  aggregateVersions,
+  countBehind,
+  describeAuditPill,
+  _apiVersionAuditTestApi,
+} from '../features/api-version-audit.js';
+import { _clearSettingsCacheForTests, saveSettings, SettingsSchema } from '../lib/settings.js';
+import type { SalesforceApiClient } from '../lib/salesforce-api.js';
+
+const { AUDIT_CLASS, PANEL_CLASS } = _apiVersionAuditTestApi();
+const FLOOR = ORG_HEALTH_THRESHOLDS.minApiVersionFloor; // 45 at time of writing
+
+function resetDom(): void {
+  document.body.replaceChildren();
+  const tabBar = document.createElement('ul');
+  tabBar.className = 'tabBarItems';
+  document.body.appendChild(tabBar);
+}
+
+// Two GA versions; 67 is the org max.
+const GA_VERSIONS = [
+  { version: '66.0', label: "Spring '26" },
+  { version: '67.0', label: "Summer '26" },
+];
+
+// Per-query rows keyed on the FROM object. 2 below-floor rows total: one
+// ApexClass at v40 and one ApexTrigger at v44.
+const TOOLING_ROWS: Record<string, Array<{ ApiVersion: number }>> = {
+  ApexClass: [{ ApiVersion: 40 }, { ApiVersion: 62 }, { ApiVersion: 62 }],
+  ApexTrigger: [{ ApiVersion: 44 }],
+  Flow: [{ ApiVersion: 58 }],
+};
+
+function fakeApi(
+  over: Partial<Record<'apiGet' | 'toolingQuery', unknown>> = {},
+): SalesforceApiClient {
+  return {
+    apiGet: over.apiGet ?? (async () => GA_VERSIONS),
+    toolingQuery:
+      over.toolingQuery ??
+      (async (soql: string) => {
+        const type = /FROM (\w+)/.exec(soql)?.[1] ?? '';
+        const records = TOOLING_ROWS[type] ?? [];
+        return { records, size: records.length, done: true };
+      }),
+  } as unknown as SalesforceApiClient;
+}
+
+beforeEach(() => {
+  _clearSettingsCacheForTests();
+  resetDom();
+});
+
+describe('aggregateVersions', () => {
+  it('groups by version, oldest first, skipping unusable rows', () => {
+    expect(
+      aggregateVersions([
+        { ApiVersion: 62 },
+        { ApiVersion: 40 },
+        { ApiVersion: 62 },
+        { ApiVersion: null },
+        {},
+      ]),
+    ).toEqual([
+      [40, 1],
+      [62, 2],
+    ]);
+  });
+});
+
+describe('countBehind', () => {
+  it('counts components strictly below the flow-core floor', () => {
+    const types = [
+      { label: 'Apex Classes', versions: [[FLOOR - 5, 3], [FLOOR, 1], [62, 4]] as const },
+      { label: 'Flows', versions: [[FLOOR - 1, 2]] as const },
+    ];
+    expect(countBehind(types as never)).toBe(5);
+  });
+});
+
+describe('describeAuditPill', () => {
+  it('composes org max + behind count', () => {
+    const { text, title } = describeAuditPill({
+      release: { release: "Summer '26", apiVersion: 67, preview: false },
+      types: [{ label: 'Apex Classes', versions: [[40, 2], [62, 5]] }],
+    });
+    expect(text).toBe('API v67 · 2 behind');
+    expect(title).toContain('Org max API v67');
+    expect(title).toContain(`below v${FLOOR}`);
+  });
+
+  it('omits the behind part when nothing is below the floor', () => {
+    const { text } = describeAuditPill({
+      release: { release: "Summer '26", apiVersion: 67, preview: false },
+      types: [{ label: 'Apex Classes', versions: [[62, 5]] }],
+    });
+    expect(text).toBe('API v67');
+  });
+});
+
+describe('api-version-audit feature', () => {
+  it('injects an amber pill with org max and below-floor count', async () => {
+    await saveSettings(SettingsSchema.parse({}));
+    const feature = createApiVersionAuditFeature({ waitTimeoutMs: 0, api: fakeApi() });
+    await feature.init?.();
+    const pill = document.querySelector<HTMLElement>(`.${AUDIT_CLASS} span`);
+    expect(pill?.textContent).toBe('API v67 · 2 behind');
+    expect(pill?.style.background).toBe('#fe9339'); // amber — components below floor
+  });
+
+  it('renders a neutral pill when nothing is below the floor', async () => {
+    await saveSettings(SettingsSchema.parse({}));
+    const feature = createApiVersionAuditFeature({
+      waitTimeoutMs: 0,
+      api: fakeApi({
+        toolingQuery: async () => ({ records: [{ ApiVersion: 62 }], size: 1, done: true }),
+      }),
+    });
+    await feature.init?.();
+    const pill = document.querySelector<HTMLElement>(`.${AUDIT_CLASS} span`);
+    expect(pill?.textContent).toBe('API v67');
+    expect(pill?.style.background).toBe('#706e6b'); // neutral grey
+  });
+
+  it('still renders Apex/Trigger when the Flow query fails', async () => {
+    await saveSettings(SettingsSchema.parse({}));
+    const feature = createApiVersionAuditFeature({
+      waitTimeoutMs: 0,
+      api: fakeApi({
+        toolingQuery: async (soql: string) => {
+          if (soql.includes('FROM Flow')) throw new Error('INVALID_TYPE');
+          const type = /FROM (\w+)/.exec(soql)?.[1] ?? '';
+          const records = TOOLING_ROWS[type] ?? [];
+          return { records, size: records.length, done: true };
+        },
+      }),
+    });
+    await feature.init?.();
+    const pill = document.querySelector<HTMLElement>(`.${AUDIT_CLASS} span`);
+    expect(pill?.textContent).toBe('API v67 · 2 behind');
+    (pill as HTMLElement).click();
+    const panelText = document.querySelector(`.${PANEL_CLASS}`)?.textContent ?? '';
+    expect(panelText).toContain('Apex Classes');
+    expect(panelText).toContain('Apex Triggers');
+    expect(panelText).not.toContain('Flows');
+  });
+
+  it('click toggles a panel with histogram rows, below-floor rows highlighted', async () => {
+    await saveSettings(SettingsSchema.parse({}));
+    const feature = createApiVersionAuditFeature({ waitTimeoutMs: 0, api: fakeApi() });
+    await feature.init?.();
+    const pill = document.querySelector<HTMLElement>(`.${AUDIT_CLASS} span`)!;
+
+    pill.click();
+    const panel = document.querySelector<HTMLElement>(`.${PANEL_CLASS}`);
+    expect(panel).not.toBeNull();
+    // ApexClass v40+v62, ApexTrigger v44, Flow v58 = 4 histogram rows.
+    const rows = panel!.querySelectorAll(`.${PANEL_CLASS}-row`);
+    expect(rows).toHaveLength(4);
+    const below = panel!.querySelectorAll('[data-below-floor="true"]');
+    expect(below).toHaveLength(2); // v40 class + v44 trigger
+    expect(panel!.textContent).toContain("Org max: v67 — Summer '26");
+    expect(panel!.textContent).not.toContain('(preview)');
+
+    // Second click closes.
+    pill.click();
+    expect(document.querySelector(`.${PANEL_CLASS}`)).toBeNull();
+  });
+
+  it('marks preview releases in the footer and closes on Escape', async () => {
+    await saveSettings(SettingsSchema.parse({}));
+    const feature = createApiVersionAuditFeature({
+      waitTimeoutMs: 0,
+      api: fakeApi({
+        apiGet: async () => [
+          { version: '67.0', label: "Summer '26" },
+          { version: '68.0', label: "Winter '27" },
+        ],
+      }),
+    });
+    await feature.init?.();
+    const pill = document.querySelector<HTMLElement>(`.${AUDIT_CLASS} span`)!;
+    pill.click();
+    expect(document.querySelector(`.${PANEL_CLASS}`)?.textContent).toContain(
+      "Org max: v68 — Winter '27 (preview)",
+    );
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    expect(document.querySelector(`.${PANEL_CLASS}`)).toBeNull();
+  });
+
+  it('renders nothing when every fetch fails', async () => {
+    await saveSettings(SettingsSchema.parse({}));
+    const feature = createApiVersionAuditFeature({
+      waitTimeoutMs: 0,
+      api: fakeApi({
+        apiGet: async () => {
+          throw new Error('no versions');
+        },
+        toolingQuery: async () => {
+          throw new Error('no tooling');
+        },
+      }),
+    });
+    await feature.init?.();
+    expect(document.querySelector(`.${AUDIT_CLASS}`)).toBeNull();
+  });
+
+  it('does not double-inject when init runs twice', async () => {
+    await saveSettings(SettingsSchema.parse({}));
+    const feature = createApiVersionAuditFeature({ waitTimeoutMs: 0, api: fakeApi() });
+    await feature.init?.();
+    await feature.refresh?.();
+    expect(document.querySelectorAll(`.${AUDIT_CLASS}`)).toHaveLength(1);
+  });
+
+  it('is absent when the feature is disabled', async () => {
+    await saveSettings(SettingsSchema.parse({ features: { 'api-version-audit': false } }));
+    const feature = createApiVersionAuditFeature({ waitTimeoutMs: 0, api: fakeApi() });
+    await feature.init?.();
+    expect(document.querySelector(`.${AUDIT_CLASS}`)).toBeNull();
+  });
+
+  it('removes pill and panel on teardown', async () => {
+    await saveSettings(SettingsSchema.parse({}));
+    const feature = createApiVersionAuditFeature({ waitTimeoutMs: 0, api: fakeApi() });
+    await feature.init?.();
+    document.querySelector<HTMLElement>(`.${AUDIT_CLASS} span`)!.click();
+    expect(document.querySelector(`.${PANEL_CLASS}`)).not.toBeNull();
+    await feature.teardown?.();
+    expect(document.querySelector(`.${AUDIT_CLASS}`)).toBeNull();
+    expect(document.querySelector(`.${PANEL_CLASS}`)).toBeNull();
+  });
+});

--- a/extension/test/feature-manifests.test.ts
+++ b/extension/test/feature-manifests.test.ts
@@ -1,7 +1,7 @@
 // Parity test for lib/feature-manifests.json — the browser-runtime-free,
 // checked-in source of truth for feature metadata. It instantiates every
 // feature exactly as the two entrypoints do (entrypoints/content.ts registers
-// 35; entrypoints/app/main.ts additionally registers the 4 Workspace-only
+// 36; entrypoints/app/main.ts additionally registers the 4 Workspace-only
 // tools: apex-test-runner + the three bridge tools) and asserts the collected
 // manifests match the JSON 1:1.
 //
@@ -52,6 +52,7 @@ import { createDebugLogViewerFeature } from '../features/debug-log-viewer.js';
 import { createSavedSoqlFeature } from '../features/saved-soql.js';
 import { createOrgSwitcherFeature } from '../features/org-switcher.js';
 import { createOrgReleaseBadgeFeature } from '../features/org-release-badge.js';
+import { createApiVersionAuditFeature } from '../features/api-version-audit.js';
 // --- Workspace-only factories (entrypoints/app/main.ts) ---
 import { createApexTestRunnerFeature } from '../features/apex-test-runner.js';
 import {
@@ -98,6 +99,7 @@ function instantiateAllFeatures(): Feature[] {
     // entrypoints/content.ts, in registration order:
     createSetupTabsFeature(),
     createOrgReleaseBadgeFeature(),
+    createApiVersionAuditFeature(),
     createCanvasSearchFeature(),
     createFlowListSearchFeature(),
     createFlowHealthCheckFeature(),

--- a/generated/chrome-features.json
+++ b/generated/chrome-features.json
@@ -64,6 +64,19 @@
       "bridgeRequired": false
     },
     {
+      "id": "api-version-audit",
+      "name": "API Version Audit",
+      "contexts": [
+        "setup_flows",
+        "flow_trigger_explorer",
+        "setup_other"
+      ],
+      "enabledByDefault": true,
+      "workspace": false,
+      "sideButton": true,
+      "bridgeRequired": false
+    },
+    {
       "id": "canvas-search",
       "name": "Search & Highlight",
       "contexts": [

--- a/generated/commands.json
+++ b/generated/commands.json
@@ -4081,6 +4081,59 @@
       "source": "src/commands/history.js"
     },
     {
+      "id": "versions",
+      "path": [
+        "versions"
+      ],
+      "description": "Audit Salesforce API versions across local source and the org (Apex, Flow, LWC, Aura vs the org max)",
+      "aliases": [],
+      "hidden": false,
+      "arguments": [],
+      "options": [
+        {
+          "flags": "--org <alias>",
+          "name": "org",
+          "required": false,
+          "default": null,
+          "description": "Target org (default: config.defaultOrg)"
+        },
+        {
+          "flags": "--local-only",
+          "name": "localOnly",
+          "required": false,
+          "default": null,
+          "description": "Skip the org side even when an org is configured"
+        },
+        {
+          "flags": "--json",
+          "name": "json",
+          "required": false,
+          "default": null,
+          "description": "Emit the full report as JSON"
+        }
+      ],
+      "subcommands": [],
+      "mutating": false,
+      "requiresProject": true,
+      "requiresOrg": false,
+      "supportsJson": true,
+      "docsCategory": "org-health",
+      "surfaces": {
+        "cli": true,
+        "sfPlugin": true,
+        "gui": false,
+        "vscode": true,
+        "chrome": true
+      },
+      "mcpTools": [
+        {
+          "name": "sfdt_api_versions",
+          "mutating": false
+        }
+      ],
+      "source": "src/commands/versions.js"
+    },
+    {
       "id": "version",
       "path": [
         "version"

--- a/generated/mcp-tools.json
+++ b/generated/mcp-tools.json
@@ -304,6 +304,16 @@
       ]
     },
     {
+      "name": "sfdt_api_versions",
+      "description": "Audit Salesforce API versions across local source and the org — per-type version distributions (Apex classes/triggers, Flows, LWC, Aura), sourceApiVersion, the org's max API version, and below-floor/behind-ceiling outliers. Read-only.",
+      "confirmExecution": false,
+      "internal": false,
+      "inputProperties": [
+        "org",
+        "localOnly"
+      ]
+    },
+    {
       "name": "sfdt_get_parked_result",
       "description": "Retrieve the full payload of a previously parked tool result.",
       "confirmExecution": false,

--- a/generated/summary.json
+++ b/generated/summary.json
@@ -1,15 +1,15 @@
 {
   "cli": {
-    "topLevelCommands": 43,
-    "jsonCapableCommands": 20,
+    "topLevelCommands": 44,
+    "jsonCapableCommands": 21,
     "mutatingCommands": 16
   },
   "chrome": {
-    "registeredFeatures": 39,
-    "displayTools": 38,
+    "registeredFeatures": 40,
+    "displayTools": 39,
     "workspaceTools": 22,
     "bridgeRequired": 5,
-    "standalone": 34,
+    "standalone": 35,
     "syntheticMenuItems": 1
   },
   "gui": {
@@ -17,10 +17,10 @@
   },
   "vscode": {
     "contributedCommands": 30,
-    "cliCatalogEntries": 104
+    "cliCatalogEntries": 105
   },
   "mcp": {
-    "tools": 30,
+    "tools": 31,
     "confirmGated": 10
   },
   "bridge": {

--- a/generated/surface-parity.json
+++ b/generated/surface-parity.json
@@ -555,6 +555,20 @@
       "sideEffects": null
     },
     {
+      "id": "versions",
+      "surfaces": {
+        "cli": true,
+        "sfPlugin": true,
+        "gui": false,
+        "vscode": true,
+        "chrome": true
+      },
+      "mcpTools": [
+        "sfdt_api_versions"
+      ],
+      "sideEffects": null
+    },
+    {
       "id": "version",
       "surfaces": {
         "cli": true,

--- a/generated/vscode-commands.json
+++ b/generated/vscode-commands.json
@@ -278,6 +278,15 @@
       "group": null
     },
     {
+      "id": "versions",
+      "label": "API Versions Report",
+      "detail": "Local + org API-version audit (Apex, Flow, LWC, Aura vs the org max)",
+      "args": [
+        "versions"
+      ],
+      "group": null
+    },
+    {
       "id": "audit-all",
       "label": "All Checks",
       "detail": "Run every audit check",
@@ -340,7 +349,7 @@
     {
       "id": "audit-api-versions",
       "label": "API Versions",
-      "detail": "Deprecated metadata API versions",
+      "detail": "Deprecated API versions + org ceiling (Apex, triggers, Flows)",
       "args": [
         "audit",
         "api-versions"

--- a/skills/sfdt-cli/SKILL.md
+++ b/skills/sfdt-cli/SKILL.md
@@ -72,6 +72,7 @@ User runs command → Load .sfdt/ config → Set SFDT_* env vars → Execute she
 | `sfdt dependencies <name> [--gaps]` | What a component references / is referenced by (Tooling API + source parsing) |
 | `sfdt flow scan\|conflicts [--org] [--json]` | Flow health analysis; record-triggered flow collision detection |
 | `sfdt history [--type <t>] [--limit <n>] [--json]` | Recent run history from the local index |
+| `sfdt versions [--org <alias>] [--local-only] [--json]` | API-version audit: local meta files (Apex/Flow/LWC/Aura) + org distributions vs the org max |
 | `sfdt pull` | Pull metadata from default org |
 
 **Project & data**

--- a/src/cli.js
+++ b/src/cli.js
@@ -45,6 +45,7 @@ import { registerCiCommand } from './commands/ci.js';
 import { registerPrCommand } from './commands/pr.js';
 import { registerRetrofitCommand } from './commands/retrofit.js';
 import { registerHistoryCommand } from './commands/history.js';
+import { registerVersionsCommand } from './commands/versions.js';
 import { formatSplash } from './lib/output.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -115,6 +116,7 @@ export function createCli() {
   registerPrCommand(program);
   registerRetrofitCommand(program);
   registerHistoryCommand(program);
+  registerVersionsCommand(program);
 
   // Explicit `sfdt version` subcommand (mirrors the -v / --version flag)
   program

--- a/src/commands/audit.js
+++ b/src/commands/audit.js
@@ -25,7 +25,10 @@ function buildParams(config) {
     audittrail: { lookbackDays: a.auditTrailLookbackDays ?? AUDIT_DEFAULTS.auditTrailLookbackDays },
     licenses: { warnThreshold: a.licenseWarnThreshold ?? AUDIT_DEFAULTS.licenseWarnThreshold },
     'inactive-users': { lookbackDays: a.inactiveUserDays ?? AUDIT_DEFAULTS.inactiveUserDays },
-    'api-versions': { minApiVersion: a.minApiVersion ?? AUDIT_DEFAULTS.minApiVersion },
+    'api-versions': {
+      minApiVersion: a.minApiVersion ?? AUDIT_DEFAULTS.minApiVersion,
+      warnBehind: a.apiVersionWarnBehind ?? AUDIT_DEFAULTS.apiVersionWarnBehind,
+    },
     'connected-apps': { flagPermissive: a.connectedAppFlagPermissive ?? AUDIT_DEFAULTS.connectedAppFlagPermissive },
     'field-descriptions': { maxMissing: a.fieldDescriptionMaxMissing ?? AUDIT_DEFAULTS.fieldDescriptionMaxMissing },
     'soap-logins': { lookbackDays: a.soapLoginLookbackDays ?? AUDIT_DEFAULTS.soapLoginLookbackDays },

--- a/src/commands/versions.js
+++ b/src/commands/versions.js
@@ -1,0 +1,119 @@
+/**
+ * `sfdt versions` — audit Salesforce API versions across local source and the
+ * org. Local scanning (Apex/Trigger/Flow/LWC/Aura meta files +
+ * sourceApiVersion) always runs; the org side (per-type distributions + the
+ * org's max API version) is added when an org resolves, and degrades to
+ * local-only with a warning when it doesn't. Informational report — exit 0;
+ * the CI-gating surface is `sfdt audit api-versions`.
+ */
+
+import chalk from 'chalk';
+import { loadConfig } from '../lib/config.js';
+import { scanLocalApiVersions, fetchOrgApiVersions, buildReport } from '../lib/api-versions.js';
+import { AUDIT_DEFAULTS } from '../lib/audit-runner.js';
+import { resolveExitCode } from '../lib/exit-codes.js';
+import { emitJson, emitJsonError } from '../lib/output.js';
+
+/** Band a histogram row: red below the hard floor, yellow behind the ceiling. */
+function bandRow({ version, count }, { minApiVersion, effectiveFloor }) {
+  const label = version === 'unspecified' ? 'unspecified' : `v${version}`;
+  const text = `${label} ×${count}`;
+  if (version === 'unspecified') return chalk.dim(text);
+  const v = Number(version);
+  if (v < minApiVersion) return chalk.red(text);
+  if (v < effectiveFloor) return chalk.yellow(text);
+  return text;
+}
+
+function printSide(label, side, thresholds) {
+  console.log(chalk.bold(`\n${label}`));
+  for (const [type, { count, histogram }] of Object.entries(side.byType)) {
+    const rows = histogram.map((h) => bandRow(h, thresholds)).join(' · ');
+    console.log(`  ${type.padEnd(12)} ${String(count).padStart(4)}  ${rows}`);
+  }
+  if (!Object.keys(side.byType).length) console.log(chalk.dim('  (no components found)'));
+  const outliers = side.outliers ?? [];
+  if (outliers.length) {
+    console.log(chalk.yellow(`  ${outliers.length} component(s) below the effective floor v${thresholds.effectiveFloor}:`));
+    for (const o of outliers.slice(0, 15)) {
+      const why = o.reason === 'below-floor' ? chalk.red('below-floor') : chalk.yellow('behind-ceiling');
+      console.log(`    ${o.type.padEnd(12)} ${String(o.name).padEnd(40)} v${o.apiVersion} ${why}`);
+    }
+    if (outliers.length > 15) console.log(chalk.dim(`    … and ${outliers.length - 15} more (use --json for the full list)`));
+  }
+}
+
+export function registerVersionsCommand(program) {
+  program
+    .command('versions')
+    .description('Audit Salesforce API versions across local source and the org (Apex, Flow, LWC, Aura vs the org max)')
+    .option('--org <alias>', 'Target org (default: config.defaultOrg)')
+    .option('--local-only', 'Skip the org side even when an org is configured')
+    .option('--json', 'Emit the full report as JSON')
+    .action(async (options) => {
+      const jsonMode = !!options.json;
+      try {
+        const config = await loadConfig();
+        const thresholds = {
+          minApiVersion: config.audit?.minApiVersion ?? AUDIT_DEFAULTS.minApiVersion,
+          warnBehind: config.audit?.apiVersionWarnBehind ?? AUDIT_DEFAULTS.apiVersionWarnBehind,
+        };
+
+        const local = await scanLocalApiVersions(config);
+
+        let org = null;
+        const orgAlias = options.org || config.defaultOrg;
+        if (!options.localOnly && orgAlias) {
+          try {
+            org = await fetchOrgApiVersions(orgAlias);
+          } catch (err) {
+            if (!jsonMode) {
+              console.error(chalk.yellow(`Org "${orgAlias}" not reachable (${err.message}) — local-only report.`));
+            }
+          }
+        }
+
+        const report = buildReport(local, org, thresholds);
+
+        if (jsonMode) {
+          emitJson(report);
+          return;
+        }
+
+        console.log(chalk.bold('\nAPI Version Audit'));
+        console.log(
+          chalk.dim(
+            `floor v${report.thresholds.minApiVersion}` +
+              (report.thresholds.warnBehind > 0 ? ` · warn-behind ${report.thresholds.warnBehind}` : '') +
+              ` · effective floor v${report.thresholds.effectiveFloor}`,
+          ),
+        );
+        if (local.sourceApiVersion) {
+          console.log(chalk.dim(`sourceApiVersion (sfdx-project.json): ${local.sourceApiVersion} — inherited by "unspecified" components`));
+        }
+        if (report.org?.ceiling) {
+          console.log(
+            `Org max: ${chalk.bold(`v${report.org.ceiling}`)}` +
+              (report.org.release ? ` — ${report.org.release}` : '') +
+              (report.org.preview ? chalk.yellow(' (preview)') : ''),
+          );
+          if (report.org.degraded.length) {
+            console.log(chalk.dim(`  (${report.org.degraded.join(', ')} not queryable on this org)`));
+          }
+        }
+
+        printSide('Local source', report.local, report.thresholds);
+        if (report.org) printSide(`Org (${orgAlias})`, report.org, report.thresholds);
+        else console.log(chalk.dim('\nOrg side skipped — pass --org <alias> (or set defaultOrg) for the org comparison.'));
+        console.log('');
+        // ponytail: exit 0 always — informational report; add --strict if CI wants gating.
+      } catch (err) {
+        if (jsonMode) {
+          emitJsonError(err);
+        } else {
+          console.error(chalk.red(`versions failed: ${err.message}`));
+        }
+        process.exitCode = resolveExitCode(err);
+      }
+    });
+}

--- a/src/lib/api-versions.js
+++ b/src/lib/api-versions.js
@@ -1,0 +1,181 @@
+/**
+ * API-version audit runner for `sfdt versions` — inventories the Salesforce
+ * API versions of LOCAL source metadata (Apex classes/triggers, Flows, LWC,
+ * Aura, plus sfdx-project.json sourceApiVersion) and, when an org is
+ * reachable, the ORG side (per-type distributions + the org's max API
+ * version), then builds a comparable report.
+ *
+ * Scans only the `-meta.xml` sidecars (never source bodies) — apiVersion is a
+ * flat text node, parsed with doc-generator's focused `tag()` helper. The
+ * `api-versions` audit check (src/lib/audit-runner.js) stays org-scoped; this
+ * module owns the local dimension.
+ */
+
+import path from 'path';
+import fs from 'fs-extra';
+import { glob } from 'glob';
+import { tag } from './doc-generator.js';
+import { query } from './org-query.js';
+import { detectOrgRelease } from './org-release.js';
+
+// Meta-file glob → component type. `**/`-prefixed so both package-root dirs
+// (force-app, whose metadata sits under main/default/...) and direct source
+// paths work. Aura bundles carry apiVersion in several meta variants
+// (.cmp/.app/.evt/.intf/.tokens-meta.xml); entries without an <apiVersion>
+// node (e.g. .design-meta.xml) are dropped by the null filter.
+const LOCAL_PATTERNS = [
+  { type: 'ApexClass', pattern: '**/classes/*.cls-meta.xml', strip: /\.cls-meta\.xml$/ },
+  { type: 'ApexTrigger', pattern: '**/triggers/*.trigger-meta.xml', strip: /\.trigger-meta\.xml$/ },
+  { type: 'Flow', pattern: '**/flows/*.flow-meta.xml', strip: /\.flow-meta\.xml$/ },
+  { type: 'LWC', pattern: '**/lwc/*/*.js-meta.xml', strip: /\.js-meta\.xml$/ },
+  { type: 'Aura', pattern: '**/aura/*/*-meta.xml', strip: /\.[a-z]+-meta\.xml$/ },
+];
+
+/**
+ * Scan the project's package directories for component API versions.
+ * Components whose meta omits <apiVersion> land in the `unspecified` bucket —
+ * they inherit sourceApiVersion at deploy time and are never counted as
+ * below-floor.
+ *
+ * @returns {Promise<{ components: Array<{type,name,apiVersion,file}>, sourceApiVersion: string|null }>}
+ */
+export async function scanLocalApiVersions(config) {
+  const root = config._projectRoot;
+  // config.packageDirectories entries are sfdx-project.json objects
+  // ({ path, absolutePath, ... }), not strings — normalize both shapes.
+  const dirs = (config.packageDirectories?.length
+    ? config.packageDirectories.map((d) => d?.absolutePath ?? d?.path ?? d)
+    : [config.defaultSourcePath ?? 'force-app/main/default']
+  ).filter((d) => typeof d === 'string');
+
+  const components = [];
+  for (const dir of dirs) {
+    const base = path.isAbsolute(dir) ? dir : path.join(root, dir);
+    if (!(await fs.pathExists(base))) continue;
+    for (const { type, pattern, strip } of LOCAL_PATTERNS) {
+      const files = await glob(pattern, { cwd: base, absolute: true });
+      for (const file of files.sort()) {
+        const xml = await fs.readFile(file, 'utf8').catch(() => '');
+        const v = tag(xml, 'apiVersion');
+        if (type === 'Aura' && v == null) continue; // non-versioned aura meta variant
+        components.push({
+          type,
+          name: path.basename(file).replace(strip, ''),
+          apiVersion: v != null ? Number.parseFloat(v) : null,
+          file: path.relative(root, file),
+        });
+      }
+    }
+  }
+  return { components, sourceApiVersion: config.sourceApiVersion ?? null };
+}
+
+/**
+ * Fetch the org side: max API version (best-effort) and per-type ApiVersion
+ * rows via the Tooling API. Each type degrades independently — a Flow query
+ * failure still returns Apex results.
+ *
+ * @returns {Promise<{ ceiling: number|null, release: string|null, preview: boolean,
+ *   byType: Record<string, Array<{name, apiVersion}>>, degraded: string[] }>}
+ */
+export async function fetchOrgApiVersions(orgAlias) {
+  const rel = await detectOrgRelease(orgAlias).catch(() => null);
+  const ceiling = rel?.apiVersion ? Number.parseInt(rel.apiVersion, 10) : null;
+
+  const queries = {
+    ApexClass: `SELECT Name, ApiVersion FROM ApexClass WHERE NamespacePrefix = null ORDER BY ApiVersion`,
+    ApexTrigger: `SELECT Name, ApiVersion FROM ApexTrigger WHERE NamespacePrefix = null ORDER BY ApiVersion`,
+    Flow: `SELECT Definition.DeveloperName, ApiVersion FROM Flow WHERE Status = 'Active' ORDER BY ApiVersion`,
+  };
+  const byType = {};
+  const degraded = [];
+  await Promise.all(
+    Object.entries(queries).map(async ([type, soql]) => {
+      try {
+        const rows = await query(orgAlias, soql, { tooling: true });
+        byType[type] = rows.map((r) => ({
+          name: r.Name ?? r.Definition?.DeveloperName ?? '(unknown)',
+          apiVersion: r.ApiVersion,
+        }));
+      } catch {
+        degraded.push(type);
+      }
+    }),
+  );
+  return {
+    ceiling: Number.isFinite(ceiling) ? ceiling : null,
+    release: rel?.release ?? null,
+    preview: !!rel?.preview,
+    byType,
+    degraded,
+  };
+}
+
+/** version→count histogram from a component list, versions ascending; null → 'unspecified'. */
+function histogram(items) {
+  const counts = new Map();
+  for (const c of items) {
+    const key = c.apiVersion == null ? 'unspecified' : String(Math.trunc(c.apiVersion));
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .sort(([a], [b]) => {
+      if (a === 'unspecified') return 1;
+      if (b === 'unspecified') return -1;
+      return Number(a) - Number(b);
+    })
+    .map(([version, count]) => ({ version, count }));
+}
+
+/**
+ * Pure report builder. `local` from scanLocalApiVersions, `org` from
+ * fetchOrgApiVersions (or null for offline mode).
+ */
+export function buildReport(local, org, { minApiVersion = 45, warnBehind = 0 } = {}) {
+  const minApi = Number.parseInt(minApiVersion, 10);
+  const behind = Number.parseInt(warnBehind, 10) || 0;
+  const ceiling = org?.ceiling ?? null;
+  const effectiveFloor = Math.max(
+    minApi,
+    behind > 0 && Number.isFinite(ceiling) ? ceiling - behind : 0,
+  );
+
+  const classify = (items) =>
+    items
+      .filter((c) => c.apiVersion != null && c.apiVersion < effectiveFloor)
+      .map((c) => ({ ...c, reason: c.apiVersion < minApi ? 'below-floor' : 'behind-ceiling' }));
+
+  const localByType = {};
+  for (const c of local.components) (localByType[c.type] ??= []).push(c);
+
+  const report = {
+    thresholds: { minApiVersion: minApi, warnBehind: behind, effectiveFloor },
+    local: {
+      sourceApiVersion: local.sourceApiVersion,
+      totalComponents: local.components.length,
+      byType: Object.fromEntries(
+        Object.entries(localByType).map(([t, items]) => [t, { count: items.length, histogram: histogram(items) }]),
+      ),
+      outliers: classify(local.components),
+      unspecified: local.components.filter((c) => c.apiVersion == null).length,
+    },
+    org: null,
+  };
+
+  if (org) {
+    const orgComponents = Object.entries(org.byType).flatMap(([type, items]) =>
+      items.map((i) => ({ ...i, type })),
+    );
+    report.org = {
+      ceiling,
+      release: org.release,
+      preview: org.preview,
+      degraded: org.degraded,
+      byType: Object.fromEntries(
+        Object.entries(org.byType).map(([t, items]) => [t, { count: items.length, histogram: histogram(items) }]),
+      ),
+      outliers: classify(orgComponents),
+    };
+  }
+  return report;
+}

--- a/src/lib/audit-runner.js
+++ b/src/lib/audit-runner.js
@@ -34,6 +34,7 @@ export const AUDIT_DEFAULTS = {
   licenseWarnThreshold: ORG_HEALTH_THRESHOLDS.usageAmber, // 0.75 (was 0.9 before flow-core unification)
   inactiveUserDays: ORG_HEALTH_THRESHOLDS.inactiveUserDays, // 90
   minApiVersion: ORG_HEALTH_THRESHOLDS.minApiVersionFloor, // 45
+  apiVersionWarnBehind: 0, // 0 = disabled; N > 0 also warns on components > N versions behind the org max
   fieldDescriptionMaxMissing: 0,
   connectedAppFlagPermissive: true,
   soapLoginLookbackDays: 30,
@@ -392,20 +393,45 @@ export async function checkInactiveUsers(orgAlias, { lookbackDays = AUDIT_DEFAUL
 }
 
 /**
- * Deprecated API versions — Apex classes/triggers on an API version below the
- * configured floor. Salesforce hard-blocks very old versions, so this surfaces
- * remediation work before it becomes a breaking change.
+ * Deprecated API versions — Apex classes/triggers/Flows on an API version
+ * below the effective floor. Salesforce hard-blocks very old versions, so this
+ * surfaces remediation work before it becomes a breaking change. The floor is
+ * `minApiVersion`, optionally raised to `orgCeiling - warnBehind` when
+ * `audit.apiVersionWarnBehind` > 0 and the org's max API version is
+ * detectable — so components can also warn for lagging far behind the org,
+ * not only for nearing hard deprecation.
  */
-export async function checkApiVersions(orgAlias, { minApiVersion = AUDIT_DEFAULTS.minApiVersion } = {}) {
+export async function checkApiVersions(orgAlias, {
+  minApiVersion = AUDIT_DEFAULTS.minApiVersion,
+  warnBehind = AUDIT_DEFAULTS.apiVersionWarnBehind,
+} = {}) {
   const id = 'api-versions';
   const title = 'Deprecated API versions';
   try {
-    // minApiVersion is interpolated into SOQL and may originate from
-    // user-editable config — coerce to a safe number to prevent SOQL injection.
+    // minApiVersion/warnBehind are interpolated into SOQL and may originate
+    // from user-editable config — coerce to safe numbers to prevent SOQL
+    // injection.
     const minApi = Number.parseInt(minApiVersion, 10);
     if (!Number.isFinite(minApi)) {
       throw new Error(`audit.minApiVersion must be a number, got: ${minApiVersion}`);
     }
+    const behind = Number.parseInt(warnBehind, 10) || 0;
+
+    // Best-effort org ceiling (max API version) — adds context to the summary
+    // and drives the warnBehind threshold. Never fails the check.
+    let release = null;
+    try {
+      const { detectOrgRelease } = await import('./org-release.js');
+      release = await detectOrgRelease(orgAlias);
+    } catch {
+      release = null;
+    }
+    const ceiling = release?.apiVersion ? Number.parseInt(release.apiVersion, 10) : null;
+    const effectiveFloor = Math.max(
+      minApi,
+      behind > 0 && Number.isFinite(ceiling) ? ceiling - behind : 0,
+    );
+
     // ApexClass and ApexTrigger are independent Tooling queries — run them in
     // parallel. Iterate the types in order afterwards so findings stay stable
     // (all ApexClass rows before ApexTrigger rows).
@@ -413,18 +439,47 @@ export async function checkApiVersions(orgAlias, { minApiVersion = AUDIT_DEFAULT
     const rowsByType = await Promise.all(
       types.map((type) => query(
         orgAlias,
-        `SELECT Name, ApiVersion FROM ${type} WHERE NamespacePrefix = null AND ApiVersion < ${minApi} ORDER BY ApiVersion`,
+        `SELECT Name, ApiVersion FROM ${type} WHERE NamespacePrefix = null AND ApiVersion < ${effectiveFloor} ORDER BY ApiVersion`,
         { tooling: true },
       )),
     );
     const findings = [];
+    const reasonFor = (v) => (v < minApi ? 'below-floor' : 'behind-ceiling');
     types.forEach((type, i) => {
-      for (const r of rowsByType[i]) findings.push({ type, name: r.Name, apiVersion: r.ApiVersion });
+      for (const r of rowsByType[i]) {
+        findings.push({ type, name: r.Name, apiVersion: r.ApiVersion, reason: reasonFor(r.ApiVersion) });
+      }
     });
+
+    // Flow coverage — active flow versions below the floor. Degrades silently
+    // like the beta-gated checks: some orgs/API versions reject Flow Tooling
+    // queries, and that must not error the whole check.
+    let flowNote = '';
+    try {
+      const flowRows = await query(
+        orgAlias,
+        `SELECT Definition.DeveloperName, ApiVersion FROM Flow WHERE Status = 'Active' AND ApiVersion < ${effectiveFloor} ORDER BY ApiVersion`,
+        { tooling: true },
+      );
+      for (const r of flowRows) {
+        findings.push({
+          type: 'Flow',
+          name: r.Definition?.DeveloperName ?? r.DeveloperName ?? '(unknown)',
+          apiVersion: r.ApiVersion,
+          reason: reasonFor(r.ApiVersion),
+        });
+      }
+    } catch {
+      flowNote = '; Flow versions not queryable on this org (Apex-only result)';
+    }
+
+    const ceilingNote = Number.isFinite(ceiling)
+      ? ` (org max: v${ceiling}${release?.release ? `, ${release.release}` : ''})`
+      : '';
     return result(id, title, findings.length ? 'warn' : 'ok',
       findings.length
-        ? `${findings.length} component(s) below API v${minApi}`
-        : `All components on API v${minApi} or newer`,
+        ? `${findings.length} component(s) below API v${effectiveFloor}${ceilingNote}${flowNote}`
+        : `All components on API v${effectiveFloor} or newer${ceilingNote}${flowNote}`,
       findings);
   } catch (err) {
     return errored(id, title, err);

--- a/src/lib/command-policy.js
+++ b/src/lib/command-policy.js
@@ -444,4 +444,13 @@ export const COMMAND_POLICY = {
     surfaces: { gui: false, vscode: false, chrome: false },
     mcpTools: {},
   },
+  versions: {
+    mutating: false,
+    requiresProject: true,
+    requiresOrg: false, // org side is optional; local scan always works
+    supportsJson: true,
+    docsCategory: 'org-health',
+    surfaces: { gui: false, vscode: true, chrome: true }, // chrome = the org-side api-version-audit feature
+    mcpTools: { sfdt_api_versions: { mutating: false } },
+  },
 };

--- a/src/lib/config-schema.json
+++ b/src/lib/config-schema.json
@@ -196,6 +196,7 @@
         "licenseWarnThreshold": { "type": "number", "minimum": 0, "maximum": 1 },
         "inactiveUserDays": { "type": "integer", "minimum": 1 },
         "minApiVersion": { "type": "number", "minimum": 1 },
+        "apiVersionWarnBehind": { "type": "integer", "minimum": 0 },
         "fieldDescriptionMaxMissing": { "type": "integer", "minimum": 0 },
         "connectedAppFlagPermissive": { "type": "boolean" },
         "soapLoginLookbackDays": { "type": "integer", "minimum": 1 }

--- a/src/lib/doc-generator.js
+++ b/src/lib/doc-generator.js
@@ -18,9 +18,11 @@ import { getPrompt, interpolate } from './prompts.js';
  * unit-test without a live org or filesystem fixtures.
  */
 
-// XML helpers (focused, not a full parser)
+// XML helpers (focused, not a full parser). `tag` is exported for other
+// meta-XML readers (src/lib/api-versions.js) — apiVersion and friends are flat
+// text nodes, so a focused regex beats a parser dependency.
 
-function tag(xml, name) {
+export function tag(xml, name) {
   const m = xml.match(new RegExp(`<${name}>([\\s\\S]*?)</${name}>`));
   return m ? decode(m[1].trim()) : null;
 }
@@ -158,6 +160,7 @@ async function collectFlows(base) {
       status: tag(xml, 'status'),
       processType: tag(xml, 'processType'),
       description: tag(xml, 'description'),
+      apiVersion: tag(xml, 'apiVersion'),
     });
   }
   return out.sort((a, b) => a.name.localeCompare(b.name));

--- a/src/lib/mcp-server.js
+++ b/src/lib/mcp-server.js
@@ -462,6 +462,21 @@ export const TOOLS = [
     ]
   },
   {
+    name: 'sfdt_api_versions',
+    description: 'Audit Salesforce API versions across local source and the org — per-type version distributions (Apex classes/triggers, Flows, LWC, Aura), sourceApiVersion, the org\'s max API version, and below-floor/behind-ceiling outliers. Read-only.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        org: { type: 'string', description: 'Target org alias (default: config defaultOrg).' },
+        localOnly: { type: 'boolean', description: 'Skip the org side even when an org is configured.' }
+      }
+    },
+    examples: [
+      { description: 'Full local + org API-version report', input: { org: 'dev' } },
+      { description: 'Offline scan of local source only', input: { localOnly: true } }
+    ]
+  },
+  {
     name: 'sfdt_get_parked_result',
     description: 'Retrieve the full payload of a previously parked tool result.',
     inputSchema: {
@@ -715,6 +730,14 @@ export class SfdtMcpServer {
         const cmdArgs = ['history', '--json'];
         if (args.type) cmdArgs.push('--type', args.type);
         if (args.limit != null) cmdArgs.push('--limit', String(args.limit));
+        const { stdout } = await this.#runCliCommand(cmdArgs);
+        return this.#parseCliJson(stdout);
+      }
+
+      case 'sfdt_api_versions': {
+        const cmdArgs = ['versions', '--json'];
+        if (args.org) cmdArgs.push('--org', args.org);
+        if (args.localOnly) cmdArgs.push('--local-only');
         const { stdout } = await this.#runCliCommand(cmdArgs);
         return this.#parseCliJson(stdout);
       }

--- a/src/lib/org-release.js
+++ b/src/lib/org-release.js
@@ -24,7 +24,11 @@ export { expectedGaApiVersion };
 export async function detectOrgRelease(orgAlias, { timeoutMs } = {}) {
   try {
     const args = ['api', 'request', 'rest', '/services/data', '--target-org', orgAlias];
-    const resp = timeoutMs ? await execa('sf', args, { timeout: timeoutMs }) : await execa('sf', args);
+    // sf colorizes `api request rest` output even without a TTY (unlike
+    // --json commands), which breaks JSON.parse — force color off.
+    const opts = { env: { ...process.env, NO_COLOR: '1', FORCE_COLOR: '0' } };
+    if (timeoutMs) opts.timeout = timeoutMs;
+    const resp = await execa('sf', args, opts);
     return releaseFromVersionList(safeParse(resp.stdout));
   } catch {
     return null;

--- a/src/templates/sfdt.config.json
+++ b/src/templates/sfdt.config.json
@@ -91,6 +91,7 @@
     "licenseWarnThreshold": 0.75,
     "inactiveUserDays": 90,
     "minApiVersion": 45,
+    "apiVersionWarnBehind": 0,
     "fieldDescriptionMaxMissing": 0,
     "connectedAppFlagPermissive": true,
     "soapLoginLookbackDays": 30

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -64,6 +64,7 @@ describe('createCli', () => {
       'pr',
       'retrofit',
       'history',
+      'versions',
       'version',
     ];
 

--- a/test/commands/versions.test.js
+++ b/test/commands/versions.test.js
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Command } from 'commander';
+
+vi.mock('../../src/lib/config.js', () => ({ loadConfig: vi.fn() }));
+vi.mock('../../src/lib/api-versions.js', () => ({
+  scanLocalApiVersions: vi.fn(),
+  fetchOrgApiVersions: vi.fn(),
+  buildReport: vi.fn(),
+}));
+
+import { loadConfig } from '../../src/lib/config.js';
+import { scanLocalApiVersions, fetchOrgApiVersions, buildReport } from '../../src/lib/api-versions.js';
+import { registerVersionsCommand } from '../../src/commands/versions.js';
+
+function createProgram() {
+  const program = new Command();
+  program.exitOverride();
+  registerVersionsCommand(program);
+  return program;
+}
+
+const LOCAL = { components: [], sourceApiVersion: '66.0' };
+const REPORT = {
+  thresholds: { minApiVersion: 45, warnBehind: 0, effectiveFloor: 45 },
+  local: { sourceApiVersion: '66.0', totalComponents: 0, byType: {}, outliers: [], unspecified: 0 },
+  org: null,
+};
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  loadConfig.mockResolvedValue({ _projectRoot: '/p', defaultOrg: 'dev', audit: {} });
+  scanLocalApiVersions.mockResolvedValue(LOCAL);
+  buildReport.mockReturnValue(REPORT);
+});
+afterEach(() => {
+  process.exitCode = undefined;
+});
+
+describe('versions command', () => {
+  it('runs local + org and emits the sf-native JSON envelope', async () => {
+    fetchOrgApiVersions.mockResolvedValue({ ceiling: 67, release: "Summer '26", preview: false, byType: {}, degraded: [] });
+    const logSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    await createProgram().parseAsync(['node', 'sfdt', 'versions', '--json']);
+
+    expect(fetchOrgApiVersions).toHaveBeenCalledWith('dev');
+    const out = logSpy.mock.calls.map((c) => c[0]).join('');
+    const envelope = JSON.parse(out);
+    expect(envelope).toMatchObject({ status: 0, result: REPORT });
+    expect(process.exitCode).toBeUndefined();
+    logSpy.mockRestore();
+  });
+
+  it('--local-only never touches the org', async () => {
+    await createProgram().parseAsync(['node', 'sfdt', 'versions', '--local-only']);
+    expect(fetchOrgApiVersions).not.toHaveBeenCalled();
+    expect(buildReport).toHaveBeenCalledWith(LOCAL, null, expect.any(Object));
+  });
+
+  it('--org overrides the configured default', async () => {
+    fetchOrgApiVersions.mockResolvedValue({ ceiling: null, release: null, preview: false, byType: {}, degraded: [] });
+    await createProgram().parseAsync(['node', 'sfdt', 'versions', '--org', 'uat']);
+    expect(fetchOrgApiVersions).toHaveBeenCalledWith('uat');
+  });
+
+  it('degrades to a local-only report when the org is unreachable (exit 0)', async () => {
+    fetchOrgApiVersions.mockRejectedValue(new Error('no such org'));
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await createProgram().parseAsync(['node', 'sfdt', 'versions']);
+
+    expect(buildReport).toHaveBeenCalledWith(LOCAL, null, expect.any(Object));
+    expect(errSpy.mock.calls.join('\n')).toContain('local-only report');
+    expect(process.exitCode).toBeUndefined();
+    errSpy.mockRestore();
+  });
+
+  it('passes the configured audit thresholds through', async () => {
+    loadConfig.mockResolvedValue({
+      _projectRoot: '/p',
+      defaultOrg: null,
+      audit: { minApiVersion: 50, apiVersionWarnBehind: 3 },
+    });
+    await createProgram().parseAsync(['node', 'sfdt', 'versions']);
+    expect(buildReport).toHaveBeenCalledWith(LOCAL, null, { minApiVersion: 50, warnBehind: 3 });
+  });
+
+  it('emits the JSON error envelope with a nonzero exit on failure', async () => {
+    loadConfig.mockRejectedValue(new Error('Run `sfdt init` first'));
+    const logSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    await createProgram().parseAsync(['node', 'sfdt', 'versions', '--json']);
+
+    const envelope = JSON.parse(logSpy.mock.calls.map((c) => c[0]).join(''));
+    expect(envelope.message).toContain('sfdt init');
+    expect(envelope.exitCode).toBeGreaterThan(0);
+    expect(process.exitCode).toBeGreaterThan(0);
+    logSpy.mockRestore();
+  });
+});

--- a/test/lib/api-versions.test.js
+++ b/test/lib/api-versions.test.js
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import path from 'path';
+import os from 'os';
+import fs from 'fs-extra';
+
+vi.mock('../../src/lib/org-query.js', () => ({ query: vi.fn() }));
+vi.mock('../../src/lib/org-release.js', () => ({ detectOrgRelease: vi.fn() }));
+
+import { query } from '../../src/lib/org-query.js';
+import { detectOrgRelease } from '../../src/lib/org-release.js';
+import { scanLocalApiVersions, fetchOrgApiVersions, buildReport } from '../../src/lib/api-versions.js';
+
+const meta = (v) => `<?xml version="1.0"?><root><apiVersion>${v}</apiVersion></root>`;
+
+let tmp;
+beforeEach(async () => {
+  vi.resetAllMocks();
+  tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'sfdt-apiver-'));
+});
+afterEach(() => fs.remove(tmp));
+
+describe('scanLocalApiVersions', () => {
+  it('scans apex/trigger/flow/lwc/aura meta files across package-root and direct layouts', async () => {
+    // package-root layout (metadata under main/default) — like sfdx "force-app"
+    const base = path.join(tmp, 'force-app', 'main', 'default');
+    await fs.outputFile(path.join(base, 'classes', 'Foo.cls-meta.xml'), meta('58.0'));
+    await fs.outputFile(path.join(base, 'triggers', 'Bar.trigger-meta.xml'), meta('45.0'));
+    await fs.outputFile(path.join(base, 'flows', 'My_Flow.flow-meta.xml'), meta('60.0'));
+    await fs.outputFile(path.join(base, 'lwc', 'cmp', 'cmp.js-meta.xml'), meta('61.0'));
+    await fs.outputFile(path.join(base, 'aura', 'aur', 'aur.cmp-meta.xml'), meta('40.0'));
+    // aura meta variant WITHOUT apiVersion must be dropped, not counted
+    await fs.outputFile(path.join(base, 'aura', 'aur', 'aur.design-meta.xml'), '<?xml version="1.0"?><design/>');
+
+    const config = {
+      _projectRoot: tmp,
+      // sfdx-project.json shape: objects with path/absolutePath
+      packageDirectories: [{ path: 'force-app', absolutePath: path.join(tmp, 'force-app') }],
+      sourceApiVersion: '66.0',
+    };
+    const { components, sourceApiVersion } = await scanLocalApiVersions(config);
+    expect(sourceApiVersion).toBe('66.0');
+    expect(components.map((c) => [c.type, c.name, c.apiVersion])).toEqual([
+      ['ApexClass', 'Foo', 58],
+      ['ApexTrigger', 'Bar', 45],
+      ['Flow', 'My_Flow', 60],
+      ['LWC', 'cmp', 61],
+      ['Aura', 'aur', 40], // bundle name — the .cmp-meta.xml suffix strips entirely
+    ]);
+    expect(components.every((c) => typeof c.file === 'string' && !path.isAbsolute(c.file))).toBe(true);
+  });
+
+  it('buckets meta files without apiVersion as unspecified (null), never below-floor', async () => {
+    const base = path.join(tmp, 'src');
+    await fs.outputFile(path.join(base, 'classes', 'NoVer.cls-meta.xml'), '<?xml version="1.0"?><ApexClass/>');
+    const config = { _projectRoot: tmp, packageDirectories: [], defaultSourcePath: 'src' };
+    const { components } = await scanLocalApiVersions(config);
+    expect(components).toHaveLength(1);
+    expect(components[0].apiVersion).toBeNull();
+    const report = buildReport({ components, sourceApiVersion: '66.0' }, null, { minApiVersion: 45 });
+    expect(report.local.unspecified).toBe(1);
+    expect(report.local.outliers).toHaveLength(0);
+  });
+
+  it('scans multiple package directories and skips missing ones', async () => {
+    await fs.outputFile(path.join(tmp, 'pkg-a', 'classes', 'A.cls-meta.xml'), meta('50.0'));
+    await fs.outputFile(path.join(tmp, 'pkg-b', 'classes', 'B.cls-meta.xml'), meta('51.0'));
+    const config = {
+      _projectRoot: tmp,
+      packageDirectories: [{ path: 'pkg-a' }, { path: 'pkg-b' }, { path: 'gone' }],
+    };
+    const { components } = await scanLocalApiVersions(config);
+    expect(components.map((c) => c.name).sort()).toEqual(['A', 'B']);
+  });
+});
+
+describe('fetchOrgApiVersions', () => {
+  it('collects per-type rows and the ceiling', async () => {
+    detectOrgRelease.mockResolvedValue({ release: "Summer '26", apiVersion: 67, preview: false });
+    query.mockImplementation(async (org, soql) => {
+      if (soql.includes('ApexClass')) return [{ Name: 'Foo', ApiVersion: 58 }];
+      if (soql.includes('ApexTrigger')) return [];
+      return [{ Definition: { DeveloperName: 'My_Flow' }, ApiVersion: 60 }];
+    });
+    const org = await fetchOrgApiVersions('dev');
+    expect(org.ceiling).toBe(67);
+    expect(org.release).toBe("Summer '26");
+    expect(org.byType.ApexClass).toEqual([{ name: 'Foo', apiVersion: 58 }]);
+    expect(org.byType.Flow).toEqual([{ name: 'My_Flow', apiVersion: 60 }]);
+    expect(org.degraded).toEqual([]);
+  });
+
+  it('degrades per type — a Flow failure still returns Apex results', async () => {
+    detectOrgRelease.mockResolvedValue(null);
+    query.mockImplementation(async (org, soql) => {
+      if (soql.includes('FROM Flow')) throw new Error('not supported');
+      return [];
+    });
+    const org = await fetchOrgApiVersions('dev');
+    expect(org.ceiling).toBeNull();
+    expect(org.degraded).toEqual(['Flow']);
+    expect(org.byType.ApexClass).toEqual([]);
+  });
+});
+
+describe('buildReport', () => {
+  const local = {
+    sourceApiVersion: '66.0',
+    components: [
+      { type: 'ApexClass', name: 'Ancient', apiVersion: 30, file: 'x' },
+      { type: 'ApexClass', name: 'Lagging', apiVersion: 58, file: 'y' },
+      { type: 'ApexClass', name: 'Fresh', apiVersion: 66, file: 'z' },
+      { type: 'Flow', name: 'NoVer', apiVersion: null, file: 'w' },
+    ],
+  };
+
+  it('offline mode: floor-only classification, org is null', () => {
+    const r = buildReport(local, null, { minApiVersion: 45, warnBehind: 5 });
+    expect(r.org).toBeNull();
+    // no ceiling → warnBehind cannot raise the floor
+    expect(r.thresholds.effectiveFloor).toBe(45);
+    expect(r.local.outliers).toEqual([
+      expect.objectContaining({ name: 'Ancient', reason: 'below-floor' }),
+    ]);
+    expect(r.local.byType.ApexClass.histogram).toEqual([
+      { version: '30', count: 1 },
+      { version: '58', count: 1 },
+      { version: '66', count: 1 },
+    ]);
+    expect(r.local.byType.Flow.histogram).toEqual([{ version: 'unspecified', count: 1 }]);
+  });
+
+  it('org mode: warnBehind raises the floor and tags behind-ceiling', () => {
+    const org = { ceiling: 67, release: "Summer '26", preview: false, byType: { ApexClass: [{ name: 'OrgOld', apiVersion: 40 }] }, degraded: [] };
+    const r = buildReport(local, org, { minApiVersion: 45, warnBehind: 5 });
+    expect(r.thresholds.effectiveFloor).toBe(62);
+    expect(r.local.outliers.map((o) => [o.name, o.reason])).toEqual([
+      ['Ancient', 'below-floor'],
+      ['Lagging', 'behind-ceiling'],
+    ]);
+    expect(r.org.outliers).toEqual([
+      expect.objectContaining({ name: 'OrgOld', reason: 'below-floor' }),
+    ]);
+  });
+});

--- a/test/lib/audit-runner.test.js
+++ b/test/lib/audit-runner.test.js
@@ -13,7 +13,14 @@ vi.mock('../../src/lib/org-query.js', () => ({
   toSoqlDate: (d) => new Date(d).toISOString().replace(/\.\d{3}Z$/, 'Z'),
 }));
 
+// checkApiVersions dynamically imports org-release.js for the best-effort org
+// ceiling — mock it so tests never spawn a real `sf` subprocess.
+vi.mock('../../src/lib/org-release.js', () => ({
+  detectOrgRelease: vi.fn().mockResolvedValue(null),
+}));
+
 import { query } from '../../src/lib/org-query.js';
+import { detectOrgRelease } from '../../src/lib/org-release.js';
 import {
   runAudit,
   CHECK_IDS,
@@ -255,14 +262,68 @@ describe('checkInactiveUsers', () => {
 });
 
 describe('checkApiVersions', () => {
-  it('aggregates deprecated classes and triggers', async () => {
+  it('aggregates deprecated classes, triggers, and flows with below-floor reasons', async () => {
+    detectOrgRelease.mockResolvedValueOnce(null);
     query
       .mockResolvedValueOnce([{ Name: 'OldClass', ApiVersion: 30 }]) // ApexClass
-      .mockResolvedValueOnce([{ Name: 'OldTrigger', ApiVersion: 28 }]); // ApexTrigger
+      .mockResolvedValueOnce([{ Name: 'OldTrigger', ApiVersion: 28 }]) // ApexTrigger
+      .mockResolvedValueOnce([{ Definition: { DeveloperName: 'Old_Flow' }, ApiVersion: 33 }]); // Flow
     const r = await checkApiVersions('dev', { minApiVersion: 45 });
     expect(r.status).toBe('warn');
-    expect(r.findings).toHaveLength(2);
-    expect(r.findings.map((f) => f.type)).toEqual(['ApexClass', 'ApexTrigger']);
+    expect(r.findings).toHaveLength(3);
+    expect(r.findings.map((f) => f.type)).toEqual(['ApexClass', 'ApexTrigger', 'Flow']);
+    expect(r.findings.every((f) => f.reason === 'below-floor')).toBe(true);
+    expect(r.summary).toContain('below API v45');
+  });
+
+  it('adds the org ceiling to the summary when detectable', async () => {
+    detectOrgRelease.mockResolvedValueOnce({ release: "Summer '26", apiVersion: 67, preview: false });
+    query.mockResolvedValue([]);
+    const r = await checkApiVersions('dev', { minApiVersion: 45 });
+    expect(r.status).toBe('ok');
+    expect(r.summary).toContain("org max: v67, Summer '26");
+  });
+
+  it('raises the floor to ceiling - warnBehind and tags behind-ceiling findings', async () => {
+    detectOrgRelease.mockResolvedValueOnce({ release: "Summer '26", apiVersion: 67, preview: false });
+    query
+      .mockResolvedValueOnce([{ Name: 'Lagging', ApiVersion: 58 }]) // ApexClass: >= minApi, < 67-5=62
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
+    const r = await checkApiVersions('dev', { minApiVersion: 45, warnBehind: 5 });
+    expect(r.status).toBe('warn');
+    expect(r.findings[0]).toMatchObject({ name: 'Lagging', reason: 'behind-ceiling' });
+    expect(r.summary).toContain('below API v62');
+    // the effective floor reached the queries too
+    expect(query.mock.calls[0][1]).toContain('ApiVersion < 62');
+  });
+
+  it('warnBehind without a detectable ceiling falls back to the plain floor', async () => {
+    detectOrgRelease.mockResolvedValueOnce(null);
+    query.mockResolvedValue([]);
+    const r = await checkApiVersions('dev', { minApiVersion: 45, warnBehind: 5 });
+    expect(r.status).toBe('ok');
+    expect(query.mock.calls[0][1]).toContain('ApiVersion < 45');
+  });
+
+  it('degrades to an Apex-only result when the Flow query is rejected', async () => {
+    detectOrgRelease.mockResolvedValueOnce(null);
+    query
+      .mockResolvedValueOnce([{ Name: 'OldClass', ApiVersion: 30 }])
+      .mockResolvedValueOnce([])
+      .mockRejectedValueOnce(new Error('sObject type Flow is not supported'));
+    const r = await checkApiVersions('dev', { minApiVersion: 45 });
+    expect(r.status).toBe('warn'); // never errors the whole check
+    expect(r.findings).toHaveLength(1);
+    expect(r.summary).toContain('Flow versions not queryable');
+  });
+
+  it('a detectOrgRelease failure never affects the result', async () => {
+    detectOrgRelease.mockRejectedValueOnce(new Error('no sf api request on this CLI'));
+    query.mockResolvedValue([]);
+    const r = await checkApiVersions('dev', { minApiVersion: 45 });
+    expect(r.status).toBe('ok');
+    expect(r.summary).not.toContain('org max');
   });
 });
 

--- a/test/lib/monitor-runner.test.js
+++ b/test/lib/monitor-runner.test.js
@@ -211,7 +211,13 @@ describe('checkOrgInfo', () => {
     expect(r.findings[0]).toMatchObject({ release: 'Current Release', releaseApiVersion: ga, preview: false });
     expect(r.summary).toContain('Current Release');
     expect(r.summary).not.toContain('preview');
-    expect(execa).toHaveBeenCalledWith('sf', ['api', 'request', 'rest', '/services/data', '--target-org', 'dev']);
+    // env forces color off — sf colorizes `api request rest` output even
+    // without a TTY, which would break the JSON parse.
+    expect(execa).toHaveBeenCalledWith(
+      'sf',
+      ['api', 'request', 'rest', '/services/data', '--target-org', 'dev'],
+      expect.objectContaining({ env: expect.objectContaining({ NO_COLOR: '1' }) }),
+    );
   });
 
   it('marks a preview instance when the max API version is ahead of GA', async () => {

--- a/vscode/src/lib/commands.ts
+++ b/vscode/src/lib/commands.ts
@@ -90,6 +90,7 @@ export const COMMAND_GROUPS: CommandGroup[] = [
     icon: 'pulse',
     docsUrl: DOCS.orgHealth,
     entries: [
+      { id: 'versions', label: 'API Versions Report', detail: 'Local + org API-version audit (Apex, Flow, LWC, Aura vs the org max)', args: ['versions'], icon: 'versions' },
       {
         id: 'audit', label: 'Org Audit', detail: 'Diagnose org health (read-only)', args: ['audit', 'all'], refreshes: 'audit', icon: 'shield',
         children: [
@@ -99,7 +100,7 @@ export const COMMAND_GROUPS: CommandGroup[] = [
           { id: 'audit-mfa', label: 'MFA Coverage', detail: 'Users without MFA', args: ['audit', 'mfa'], refreshes: 'audit' },
           { id: 'audit-unused-apex', label: 'Unused Apex', detail: 'Apex classes with no coverage', args: ['audit', 'unused-apex'], refreshes: 'audit' },
           { id: 'audit-inactive-users', label: 'Inactive Users', detail: 'Users with no recent login', args: ['audit', 'inactive-users'], refreshes: 'audit' },
-          { id: 'audit-api-versions', label: 'API Versions', detail: 'Deprecated metadata API versions', args: ['audit', 'api-versions'], refreshes: 'audit' },
+          { id: 'audit-api-versions', label: 'API Versions', detail: 'Deprecated API versions + org ceiling (Apex, triggers, Flows)', args: ['audit', 'api-versions'], refreshes: 'audit' },
           { id: 'audit-inactive-flows', label: 'Inactive Flows', detail: 'Flows with no active version', args: ['audit', 'inactive-flows'], refreshes: 'audit' },
           { id: 'audit-unused-permsets', label: 'Unused Permission Sets', detail: 'Permission sets with no assignment', args: ['audit', 'unused-permsets'], refreshes: 'audit' },
           { id: 'audit-connected-apps', label: 'Connected Apps', detail: 'Connected apps permitting all users', args: ['audit', 'connected-apps'], refreshes: 'audit' },


### PR DESCRIPTION
## Summary

The approved cross-surface **API-version audit** feature (phase 1): tell the user what API versions their builds are on — local source AND the org — across CLI, Chrome, VS Code, and MCP.

## New: `sfdt versions`

- **Local scan** (works fully offline, `--local-only`): Apex classes/triggers, Flows, LWC, and Aura meta files across all package directories, plus `sourceApiVersion`. Components without `<apiVersion>` land in an "unspecified" bucket (they inherit `sourceApiVersion`) and are never counted as outliers.
- **Org side** (optional; degrades to local-only with a warning): per-type Tooling distributions + the org's max API version and release name.
- Per-type histograms with red (below the hard floor) / yellow (behind the ceiling) banding; `--json` envelope; exit 0 — the CI gate remains `sfdt audit api-versions`.
- MCP `sfdt_api_versions` (read-only); sf plugin via codegen; VS Code "API Versions Report" tree entry.

## Extended: `sfdt audit api-versions` (same check id — zero enum/GUI/VS Code churn)

Flow coverage (its own try/catch — degrades on orgs that reject the query), the org ceiling in the summary (`3 below v45 (org max: v67, Summer '26)`), and new config `audit.apiVersionWarnBehind` (default 0 = off) which raises the floor to `ceiling − N`, tagging findings `below-floor` vs `behind-ceiling`. `warnBehind: 0` is byte-identical to the previous behavior (existing tests pass unmodified).

## New Chrome feature: `api-version-audit` (the 40th)

Setup pill (`API v67 · 2 behind`, amber below the shared flow-core floor) expanding to per-type histograms with an org-max footer. Org-side only, no bridge, opt-in; `feature-manifests.json` regenerated with the parity test green.

## Bugs found by live verification, fixed at the root

- **`detectOrgRelease` always returned null** wherever `sf` colorizes output — `sf api request rest` emits ANSI codes even without a TTY, breaking the JSON parse. Color is now forced off, which also restores `compare`/`retrofit` release-mismatch warnings and `monitor org-info` release context.
- The local scanner handles sfdx `packageDirectories` **object** entries and package-root layouts (`**/` globs) — both caught by smoking the command against a real project before writing tests.

## Verification

- Live end-to-end against a real org: local 4 ApexClasses @ v62, org max v67 (Summer '26), audit summary carries the ceiling
- 3741 tests / 241 files pass — 31 new (extended audit-runner suite incl. warnBehind/degradation/never-fails-on-release-detect, scanner fixture tree, command suite, 13 Chrome tests); **three drift guards fired on the new command and were satisfied** (cli.test expected list, sfdt-cli skill, catalog regen)
- `check:all-contracts` green; catalogs now report 44 commands / 40 chrome features / 31 MCP tools
- Phase 2 (AI upgrade advisor grounded by a curated per-version registry) remains design-only, tracked as Planned in ROADMAP.md

https://claude.ai/code/session_01PRtcJodaDCxv9kY8GrAcxC