### PR TITLE
chore: release extension v0.7.0

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to `@sfdt/extension` are documented here. Format follows [Ke
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-07-14
+
+### Added
+- **API Version Audit** (`api-version-audit`) — an org-side pill in the Setup tab strip showing the org's max API version and release (e.g. `API v67 · 3 behind`). Click it to expand a panel of per-type API-version histograms — Apex classes, Apex triggers, and active Flows — with a bar per version and an org-max footer. Components below the shared `@sfdt/flow-core` API-version floor are banded amber (the same threshold the CLI's org-health checks use), and the pill itself turns amber when any component is behind. Runs entirely org-side against the Tooling API using your existing session — no bridge required.
+
+### Fixed
+- **`api-version-audit` panel now closes on click-outside.** It previously only closed on Escape, so the absolute panel could float over subsequent content after an SPA navigation; it now also dismisses on any click outside the pill/panel (matching the `rest-explore`/`soql-runner` dropdown pattern).
+- **Relicensed MIT → Apache-2.0.** The README license line was corrected to Apache-2.0 to match the repository `LICENSE` and the extension's `package.json`.
+
 ## [0.6.0] - 2026-07-09
 
 ### Fixed

--- a/extension/README.md
+++ b/extension/README.md
@@ -28,7 +28,7 @@ window that reports the chosen org's URL, so the existing tools run unchanged.
 
 ---
 
-## Features (36)
+## Features (40)
 
 Every feature is opt-in (toggle off in the options page), and any feature can be remotely disabled without a Web Store re-review via `sfdt feature-flags disable <id>`.
 
@@ -65,6 +65,7 @@ Every feature is opt-in (toggle off in the options page), and any feature can be
 | `org-switcher` | Switch the Workspace between logged-in orgs | Workspace |
 | `org-health` | Side panel surfacing the CLI's audit/monitor snapshots (status dots, findings, Copy JSON) via the bridge's `org-health` request | Setup + Flow Builder |
 | `org-health-live` | Runs org-health checks live against the org (Apex coverage, inactive users, licenses, API versions, limits) — no CLI snapshot needed | Workspace |
+| `api-version-audit` | Setup tab-strip pill showing the org's max API version + release; expands to per-type API-version histograms (Apex classes/triggers, active Flows) with components below the flow-core floor banded amber — read live from the org, no bridge | Setup + Trigger Explorer |
 | `code-coverage` | Apex code coverage: org-wide % + per-class bands (worst-covered first, 75% deploy line flagged), read live from the org | Workspace |
 | `dependency-explorer` | "What references this / what does this reference" via `MetadataComponentDependency` (Apex/Flow/field/page/LWC) | Workspace |
 | `apex-test-runner` | Run Apex tests asynchronously and view pass/fail results | Workspace |

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sfdt/extension",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Chrome MV3 extension for Salesforce Flow Builder and other Salesforce tools. WXT + TypeScript.",
   "license": "Apache-2.0",
   "private": true,

--- a/generated/catalog-version.json
+++ b/generated/catalog-version.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "cliVersion": "0.18.0",
-  "extensionVersion": "0.6.0",
+  "extensionVersion": "0.7.0",
   "vscodeVersion": "0.4.1",
   "flowCoreVersion": "0.9.7",
   "bridgeProtocol": "1.2"

--- a/generated/packages.json
+++ b/generated/packages.json
@@ -13,7 +13,7 @@
     {
       "path": "extension/package.json",
       "name": "@sfdt/extension",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "Apache-2.0",
       "private": true,
       "engines": null


### PR DESCRIPTION
## Extension Release v0.7.0

Ships everything merged since `ext-v0.6.0` on the Chrome track.

### Added
- **`api-version-audit`** (the 40th feature) — an org-side Setup pill (`API v67 · N behind`) that expands to per-type API-version histograms (Apex classes/triggers, active Flows) with an org-max footer; amber when components are below the shared `@sfdt/flow-core` floor. Org-side only, no bridge.

### Fixed
- `api-version-audit` panel closes on click-outside (was Escape-only).
- Relicensed MIT → Apache-2.0 (README).

### Docs
- Feature count corrected 36 → **40** (verified against `feature-manifests.json` + `generated/summary.json`). PRIVACY unchanged — the feature adds no new permissions (existing Tooling API + session access).

## Pre-release gates
- [x] Extension test gate: `compile` clean, **809 tests / 54 files pass**, zip builds (`sfdtextension-0.7.0-chrome.zip`, ~260 kB)
- [ ] `/pre-release-security` — proceeded on the CLI cycle's continuous verification (same maintainer decision as v0.18.0)
- [ ] Manual Chrome smoke test — **not run headlessly this session**

## What happens on merge
`extension.yml` tags `ext-v0.7.0`, builds the Chrome zip, creates a GitHub Release, and (with CWS credentials wired per #5afeda8) auto-publishes to the Chrome Web Store.

## Known follow-up (not this release)
The README feature table has pre-existing drift vs `feature-manifests.json` (a few stale ids like `missing-description-flags`, some non-manifest rows, some real features omitted). Not a regression. Best fixed by **generating the table from the manifest** (like sfdt.dev's `<FeatureTable/>`) rather than hand-maintaining — recommend a dedicated follow-up.

https://claude.ai/code/session_01PRtcJodaDCxv9kY8GrAcxC