### PR TITLE
chore: release vscode v0.5.0

### DIFF
--- a/generated/catalog-version.json
+++ b/generated/catalog-version.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "cliVersion": "0.18.0",
   "extensionVersion": "0.7.0",
-  "vscodeVersion": "0.4.1",
+  "vscodeVersion": "0.5.0",
   "flowCoreVersion": "0.9.7",
   "bridgeProtocol": "1.2"
 }

--- a/generated/packages.json
+++ b/generated/packages.json
@@ -37,7 +37,7 @@
     {
       "path": "vscode/package.json",
       "name": "sfdt-devtools",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "private": true,
       "engines": {

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -6,6 +6,19 @@ All notable changes to the **SFDT for Salesforce** VS Code extension (`sfdt.sfdt
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-07-14
+
+### Added
+
+- **API Versions Report** — a new Commands-tree entry (and palette command) that runs `sfdt versions`, auditing the API versions of local source (Apex, Flow, LWC, Aura) and the org side against the org's max API version. Requires `@sfdt/cli` 0.18.0.
+- **Run History** — a new Commands-tree entry that runs `sfdt history`, showing recent audit / monitor / quality / test / deploy runs from the local index.
+
+### Fixed
+
+- **Surface parity** — twelve CLI commands (`retrofit`, `notify`, `ai`, `data`, `scratch`, `config`, `feature-flags`, `mcp`, `extension`, `skills`, `plugin`, `update`) that were already invocable are now correctly reflected as VS Code-exposed in the command catalog, and the extended `audit api-versions` entry describes its Flow coverage and org-ceiling context.
+- **Run History no longer passes `--org`** — the new entry is marked `noOrg`, so it doesn't append `--org <defaultOrg>` (which `sfdt history` rejects); it would otherwise exit 1 for any user with a default org configured.
+- **Relicensed MIT → Apache-2.0** — `vscode/LICENSE` (which ships in the `.vsix`) now carries the Apache-2.0 text, matching the repository and the manifest's declared license.
+
 ## [0.4.1] - 2026-07-12
 
 ### Added

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "sfdt-devtools",
   "displayName": "SFDT for Salesforce",
   "description": "A full command center for the sfdt CLI in VS Code: a grouped Commands tree for every sfdt command, a live Status panel (org, branch, versions), the Org Health view, an org picker, the embedded dashboard, and per-org window theming.",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "publisher": "sfdt",


### PR DESCRIPTION
## VS Code Extension Release v0.5.0

Everything merged since `vscode-v0.4.1` on the VS Code track.

### Added
- **API Versions Report** — Commands-tree entry + palette command running `sfdt versions` (local + org API-version audit). Requires `@sfdt/cli` 0.18.0 (published).
- **Run History** — entry running `sfdt history` (recent audit/monitor/quality/test/deploy runs).

### Fixed
- **Surface parity** — 12 already-invocable CLI commands are now correctly reflected as VS Code-exposed in the catalog; `audit api-versions` detail updated.
- **Run History no longer passes `--org`** (`noOrg`) — `sfdt history` has no `--org`, so it would otherwise exit 1 for users with a default org.
- **Relicensed MIT → Apache-2.0** (`vscode/LICENSE`, shipped in the `.vsix`).

## Pre-release gates
- [x] `npm run lint -w vscode`, `npm run test:vscode` (**238 pass**), `npm run package:vscode` (`.vsix`, 29 files, 195 KB)
- [ ] `/pre-release-security` — proceeded on the CLI cycle's continuous verification
- [ ] Manual F5 Extension Development Host smoke — **not run this session**

## What happens on merge
`vscode-release.yml` runs `vsce publish` (Marketplace) and `ovsx publish` (Open VSX — `OVSX_PAT` is set), tags `vscode-v0.5.0`, and attaches the `.vsix` to a GitHub Release. `VSCE_PAT` + `OVSX_PAT` both present.

## Ordering
Merge after CLI v0.18.0 is published (done ✅) so the API Versions Report's `sfdt versions` resolves for users who update.

https://claude.ai/code/session_01PRtcJodaDCxv9kY8GrAcxC