### PR TITLE
Re-enable live Salesforce integration CI (Workstream L)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,57 +61,82 @@ jobs:
       - name: Build GUI
         run: npm run build --workspace=gui
 
-  # integration:
-  #   needs: [test, gui-build]
-  #   runs-on: ubuntu-latest
-  #   if: github.event_name != 'pull_request'
-  #   permissions:
-  #     contents: read
-  #   env:
-  #     SF_JWT_KEY: ${{ secrets.SF_DEVHUB_JWT_KEY }}
-  #     SF_CLIENT_ID: ${{ secrets.SF_DEVHUB_CLIENT_ID }}
-  #     SF_USERNAME: ${{ secrets.SF_DEVHUB_USERNAME }}
-  #     SF_CONTAINER_MODE: true
-  #   strategy:
-  #     matrix:
-  #       node-version: [22]
-  #   steps:
-  #     - uses: actions/checkout@v7
-  #     - name: Use Node.js ${{ matrix.node-version }}
-  #       uses: actions/setup-node@v4
-  #       with:
-  #         node-version: ${{ matrix.node-version }}
-  #         cache: npm
-  #     - run: npm ci
-  #     - name: Build @sfdt/flow-core (CLI runtime dep)
-  #       run: npm run build:flow-core
-  #     - name: Pack @sfdt/flow-core and @sfdt/cli
-  #       # @sfdt/cli declares @sfdt/flow-core@^0.9.0 as a runtime dep. On a
-  #       # commit where flow-core is not yet on the public npm registry, the
-  #       # CLI tarball install would 404. Packing flow-core alongside and
-  #       # installing both at once keeps the integration job self-contained.
-  #       run: |
-  #         npm pack --workspace=@sfdt/flow-core
-  #         npm pack
-  #     - name: Install Salesforce CLI
-  #       run: npm install -g @salesforce/cli
-  #     - name: Checkout synthetic-spark fixture
-  #       uses: actions/checkout@v7
-  #       with:
-  #         repository: scoobydrew83/synthetic-spark
-  #         path: synthetic-spark
-  #     - name: Install sfdt globally from packed tarballs
-  #       # Install flow-core first so npm's local cache satisfies @sfdt/cli's
-  #       # runtime dep without hitting the registry. Explicit filenames so the
-  #       # glob doesn't double-list flow-core.
-  #       run: npm install -g sfdt-flow-core-*.tgz sfdt-cli-*.tgz
-  #     - name: Authenticate DevHub
-  #       run: |
-  #         echo "${{ secrets.SFDX_AUTH_URL }}" > auth_url.txt
-  #         sf org login sfdx-url --sfdx-url-file auth_url.txt --set-default-dev-hub
-  #         rm auth_url.txt
-  #     - name: Run integration tests
-  #       run: ./scripts/integration/run-integration-tests.sh ./synthetic-spark
+  # Gate: skip the live integration smoke gracefully when the DevHub auth
+  # secret isn't configured, so the job is a no-op (not a failure) until a
+  # maintainer adds SFDX_AUTH_URL + SF_DEVHUB_USERNAME. Never runs on
+  # pull_request (secrets are not exposed to fork PRs and must not run there).
+  integration-gate:
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/develop' && github.event_name != 'pull_request'
+    permissions:
+      contents: read
+    outputs:
+      configured: ${{ steps.check.outputs.configured }}
+    steps:
+      - id: check
+        env:
+          SFDX_AUTH_URL: ${{ secrets.SFDX_AUTH_URL }}
+        run: |
+          if [ -n "$SFDX_AUTH_URL" ]; then
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Live integration smoke skipped — set the SFDX_AUTH_URL and SF_DEVHUB_USERNAME secrets (and the 'integration' environment) to enable it."
+          fi
+
+  # Tier 2 live smoke against a real Dev Hub: create a scratch org, run the
+  # deploy/test/audit/versions/drift/rollback cycle against it, always delete.
+  # Behind the protected 'integration' environment and gated on secrets being
+  # present, on develop only.
+  integration:
+    needs: [test, gui-build, integration-gate]
+    if: needs.integration-gate.outputs.configured == 'true'
+    runs-on: ubuntu-latest
+    environment: integration
+    permissions:
+      contents: read
+    env:
+      SF_USERNAME: ${{ secrets.SF_DEVHUB_USERNAME }}
+      SF_CONTAINER_MODE: 'true'
+    steps:
+      - uses: actions/checkout@v7
+      - name: Use Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - name: Build @sfdt/flow-core (CLI runtime dep)
+        run: npm run build:flow-core
+      - name: Pack @sfdt/flow-core and @sfdt/cli
+        # @sfdt/cli declares @sfdt/flow-core@^0.9.0 as a runtime dep. On a commit
+        # where flow-core is not yet on the public npm registry, the CLI tarball
+        # install would 404. Packing flow-core alongside and installing both at
+        # once keeps the integration job self-contained.
+        run: |
+          npm pack --workspace=@sfdt/flow-core
+          npm pack
+      - name: Install Salesforce CLI
+        run: npm install -g @salesforce/cli
+      - name: Install sfdt globally from packed tarballs
+        # Install flow-core first so npm's local cache satisfies @sfdt/cli's
+        # runtime dep without hitting the registry. Explicit filenames so the
+        # glob doesn't double-list flow-core.
+        run: npm install -g sfdt-flow-core-*.tgz sfdt-cli-*.tgz
+      - name: Checkout synthetic-spark fixture
+        uses: actions/checkout@v7
+        with:
+          repository: scoobydrew83/synthetic-spark
+          path: synthetic-spark
+      - name: Authenticate Dev Hub
+        env:
+          SFDX_AUTH_URL: ${{ secrets.SFDX_AUTH_URL }}
+        run: |
+          printf '%s' "$SFDX_AUTH_URL" > auth_url.txt
+          sf org login sfdx-url --sfdx-url-file auth_url.txt --set-default-dev-hub
+          rm -f auth_url.txt
+      - name: Run integration smoke (scratch org create → cycle → always-delete)
+        run: ./scripts/integration/run-integration-tests.sh ./synthetic-spark
 
   publish-beta:
     needs: [test, gui-build]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Live Salesforce integration CI** — the `integration` job in `ci.yml` runs a Tier 2 smoke against a real Dev Hub on every push to `develop` (scratch org → deploy/test/audit/versions/drift/rollback cycle → always-delete). It's gated to a graceful no-op until `SFDX_AUTH_URL` + `SF_DEVHUB_USERNAME` secrets and an `integration` environment are configured, never runs on fork PRs, and always cleans up. See `docs/integration-ci.md`.
+
 ## [0.18.0] - 2026-07-14
 
 ### Added

--- a/docs/integration-ci.md
+++ b/docs/integration-ci.md
@@ -1,0 +1,43 @@
+# Live Salesforce integration CI
+
+The `integration` job in `.github/workflows/ci.yml` runs a **Tier 2 live smoke** against a real
+Dev Hub on every push to `develop`: it creates a scratch org, runs the sfdt
+pull → preflight → deploy → test → smoke → drift → compare → **versions** → **audit** → rollback
+cycle against it (`scripts/integration/run-integration-tests.sh`), and always deletes the scratch
+org on exit.
+
+## It's off until you configure it (by design)
+
+The job is **gated** so it is a graceful no-op — not a failure — until the secrets are set. An
+`integration-gate` job checks whether `SFDX_AUTH_URL` is present; if not, the smoke is skipped
+with a `::notice::` and CI stays green. This lets the workflow ship without breaking builds for
+anyone without Dev Hub credentials.
+
+## To enable it
+
+1. **Create the `integration` environment** (repo Settings → Environments → New environment →
+   `integration`). Add required reviewers if you want a manual approval gate before each live run.
+
+2. **Add two secrets** (scoped to the `integration` environment, or repo-wide):
+
+   | Secret | What it is |
+   |---|---|
+   | `SFDX_AUTH_URL` | The Dev Hub's sfdx auth URL — get it with `sf org auth show-sfdx-auth-url --target-org <devhub-alias>` (see [CI Authentication](https://sfdt.dev/cli/ci-authentication)). Used to `sf org login sfdx-url --set-default-dev-hub`. |
+   | `SF_DEVHUB_USERNAME` | The Dev Hub username/alias, passed as `--target-dev-hub` for `sf org create scratch`. |
+
+3. Push to `develop`. The gate detects the secret and runs the `integration` job.
+
+## Safety (blueprint Workstream L-2)
+
+- **Never on fork PRs** — the gate requires `github.ref == refs/heads/develop` and
+  `github.event_name != 'pull_request'`, so secrets are never exposed to untrusted PRs.
+- **Protected environment** — the `integration` environment can require reviewer approval.
+- **Least privilege** — use a dedicated Dev Hub / scratch definition, not a production org.
+- **Always cleanup** — the script's `trap cleanup EXIT` deletes the scratch org on success or
+  failure; the auth file is removed immediately after login.
+- **No secret archival** — no auth files or org details are uploaded as artifacts.
+
+## Scope
+
+This is Tier 2 (per-`develop` smoke). Tier 3 (nightly compatibility matrix across sf-CLI / Node
+versions) and Tier 4 (release-candidate end-to-end with an evidence bundle) remain future work.

--- a/scripts/integration/run-integration-tests.sh
+++ b/scripts/integration/run-integration-tests.sh
@@ -186,6 +186,14 @@ sfdt drift
 step "sfdt compare"
 sfdt compare
 
+# sfdt versions — local + org API-version audit (read-only)
+step "sfdt versions"
+sfdt versions --org "$SCRATCH_ORG_ALIAS"
+
+# sfdt audit — org-health checks incl. the extended api-versions check (read-only)
+step "sfdt audit api-versions"
+sfdt audit api-versions --org "$SCRATCH_ORG_ALIAS"
+
 # 4. Rollback sequence
 #    v1 state  → deploy (creates backup)
 #    patch XML → deploy (creates backup of v1, now at v2)


### PR DESCRIPTION
## Summary

PR 7 of the blueprint program — the last remaining item. Re-enables the live Dev Hub smoke that was commented out in `ci.yml`, hardened so it ships **without breaking builds** and only activates once you add secrets.

## How it's safe to merge now (off until configured)

- **`integration-gate` job** checks whether `SFDX_AUTH_URL` is set. Absent → the smoke is a graceful no-op (`::notice::`, CI green). Present → the `integration` job runs.
- **develop-only + never on `pull_request`** — secrets are never exposed to fork PRs.
- **`environment: integration`** — can require reviewer approval per run.
- **Always cleans up** — the script's `trap cleanup EXIT` deletes the scratch org on any exit; the auth file is removed right after login; nothing is archived.

## What it runs (Tier 2)

Scratch org create → `sfdt pull / preflight / deploy / test / smoke / drift / compare / versions / audit api-versions / rollback` against the org → delete. I added the `versions` + `audit api-versions` steps to exercise the new v0.18.0 feature live.

## To turn it on (you)

1. Create the `integration` environment.
2. Add `SFDX_AUTH_URL` (`sf org auth show-sfdx-auth-url --target-org <devhub>`) and `SF_DEVHUB_USERNAME`.
3. Push to `develop`.

Full setup + safety model in `docs/integration-ci.md`.

## Verification
- `ci.yml` YAML validates; job graph correct (`integration` needs test/gui-build/integration-gate, gated on the secret check).
- Integration script `bash -n` clean; `check:all-contracts` green.
- On this PR the gate evaluates false (no secret) → integration is a no-op, so CI stays green.

Tier 3 (nightly matrix) + Tier 4 (RC e2e + evidence bundle) remain future work.