### PR TITLE
refactor(extension): design-token refactor — consolidate colours into --sfdt-* (P0-1)

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to `@sfdt/extension` are documented here. Format follows [Ke
 
 ## [Unreleased]
 
+### Changed
+- **Design-token refactor (internal, no visual change).** Every hard-coded colour across the content-script features, the Workspace app page, the options page, and the shared `ui/` components (~770 hex literals in 38 files) is now a `var(--sfdt-color-*)` CSS custom property. The raw values live in one place — `lib/tokens.ts` — which each surface injects at boot (`ensureTokens()` on Salesforce pages; the `:root` token block prepended to the app/options stylesheets). This is a pure refactor with no user-facing change; it's the enabling step for a future single-switch dark theme, which can now supply dark values in one file instead of hunting colours across the codebase. One documented exception remains: the user-configurable `canvasSearch.highlightColour` default (`#FFD700`) stays a literal because it's runtime data string-concatenated with an alpha suffix and cannot be a CSS variable.
+
 ## [0.7.0] - 2026-07-14
 
 ### Added

--- a/extension/entrypoints/app/main.ts
+++ b/extension/entrypoints/app/main.ts
@@ -16,6 +16,7 @@ import { releaseFromVersionList } from '@sfdt/flow-core';
 import { FEATURE_ICONS, WORKSPACE_TOOLS } from '../../lib/feature-icons.js';
 import { showToast } from '../../ui/toast.js';
 import { createWorkspaceTabs } from '../../ui/workspace-tabs.js';
+import { SFDT_TOKENS_CSS } from '../../lib/tokens.js';
 
 import { createSoqlRunnerFeature } from '../../features/soql-runner.js';
 import { createSavedSoqlFeature } from '../../features/saved-soql.js';
@@ -63,31 +64,31 @@ function isAllowedSfHost(host: string): boolean {
 
 const STYLES = `
   *, *::before, *::after { box-sizing: border-box; }
-  body { margin: 0; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif; color: #16325c; background: #f3f3f3; }
-  #sfdt-topbar { display: flex; align-items: center; gap: 12px; padding: 10px 16px; background: #16325c; color: #fff; }
+  body { margin: 0; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif; color: var(--sfdt-color-brand-deep); background: var(--sfdt-color-bg); }
+  #sfdt-topbar { display: flex; align-items: center; gap: 12px; padding: 10px 16px; background: var(--sfdt-color-brand-deep); color: var(--sfdt-color-surface); }
   #sfdt-topbar .title { font-weight: 600; font-size: 15px; }
   #sfdt-topbar .org { margin-left: auto; font-size: 12px; opacity: 0.85; font-family: ui-monospace, monospace; }
-  #sfdt-topbar .release-badge { display: none; align-items: center; font-size: 11px; padding: 2px 8px; border-radius: 10px; background: rgba(255,255,255,0.14); color: #fff; white-space: nowrap; }
-  #sfdt-topbar .release-badge.preview { background: #fe9339; color: #16325c; font-weight: 600; }
-  #sfdt-topbar button { padding: 5px 12px; border: 1px solid rgba(255,255,255,0.4); background: transparent; color: #fff; border-radius: 4px; cursor: pointer; font-size: 12px; }
+  #sfdt-topbar .release-badge { display: none; align-items: center; font-size: 11px; padding: 2px 8px; border-radius: 10px; background: rgba(255,255,255,0.14); color: var(--sfdt-color-surface); white-space: nowrap; }
+  #sfdt-topbar .release-badge.preview { background: var(--sfdt-color-warning); color: var(--sfdt-color-brand-deep); font-weight: 600; }
+  #sfdt-topbar button { padding: 5px 12px; border: 1px solid rgba(255,255,255,0.4); background: transparent; color: var(--sfdt-color-surface); border-radius: 4px; cursor: pointer; font-size: 12px; }
   #sfdt-topbar button:hover { background: rgba(255,255,255,0.12); }
   #sfdt-layout { display: flex; height: calc(100vh - 45px); }
-  #sfdt-sidebar { width: 260px; background: #fff; border-right: 1px solid #d8dde6; overflow-y: auto; padding: 8px; }
+  #sfdt-sidebar { width: 260px; background: var(--sfdt-color-surface); border-right: 1px solid var(--sfdt-color-border); overflow-y: auto; padding: 8px; }
   #sfdt-sidebar .tool { display: flex; gap: 10px; align-items: center; padding: 10px 12px; border-radius: 4px; cursor: pointer; font-size: 13px; }
-  #sfdt-sidebar .tool:hover { background: #f3f6f9; }
+  #sfdt-sidebar .tool:hover { background: var(--sfdt-color-surface-shade-2); }
   #sfdt-sidebar .tool .icon { font-size: 16px; }
   #sfdt-main { flex: 1; min-width: 0; display: flex; flex-direction: column; overflow: hidden; }
-  #sfdt-tabbar { display: flex; gap: 4px; padding: 6px 8px 0; background: #f3f3f3; border-bottom: 1px solid #d8dde6; overflow-x: auto; }
+  #sfdt-tabbar { display: flex; gap: 4px; padding: 6px 8px 0; background: var(--sfdt-color-bg); border-bottom: 1px solid var(--sfdt-color-border); overflow-x: auto; }
   #sfdt-tabbar:empty { display: none; }
-  #sfdt-tabbar .tab { display: flex; align-items: center; gap: 6px; padding: 6px 10px; background: #e9eef3; border: 1px solid #d8dde6; border-bottom: none; border-radius: 4px 4px 0 0; cursor: pointer; font-size: 12px; white-space: nowrap; color: #54698d; }
-  #sfdt-tabbar .tab.active { background: #fff; color: #16325c; font-weight: 600; }
-  #sfdt-tabbar .tab .x { border: 0; background: none; cursor: pointer; font-size: 14px; line-height: 1; color: #80868d; padding: 0 2px; }
-  #sfdt-tabbar .tab .x:hover { color: #c23934; }
+  #sfdt-tabbar .tab { display: flex; align-items: center; gap: 6px; padding: 6px 10px; background: var(--sfdt-color-surface-shade-4); border: 1px solid var(--sfdt-color-border); border-bottom: none; border-radius: 4px 4px 0 0; cursor: pointer; font-size: 12px; white-space: nowrap; color: var(--sfdt-color-text-weak); }
+  #sfdt-tabbar .tab.active { background: var(--sfdt-color-surface); color: var(--sfdt-color-brand-deep); font-weight: 600; }
+  #sfdt-tabbar .tab .x { border: 0; background: none; cursor: pointer; font-size: 14px; line-height: 1; color: var(--sfdt-color-text-icon); padding: 0 2px; }
+  #sfdt-tabbar .tab .x:hover { color: var(--sfdt-color-error); }
   #sfdt-panes { flex: 1; overflow: auto; }
   #sfdt-panes .pane { height: 100%; flex-direction: column; }
-  #sfdt-panes .welcome { max-width: 560px; margin: 40px auto; text-align: center; color: #54698d; padding: 0 24px; }
-  #sfdt-panes .welcome h2 { color: #16325c; }
-  #sfdt-panes code { background: #e9eef3; padding: 1px 5px; border-radius: 3px; font-size: 12px; }
+  #sfdt-panes .welcome { max-width: 560px; margin: 40px auto; text-align: center; color: var(--sfdt-color-text-weak); padding: 0 24px; }
+  #sfdt-panes .welcome h2 { color: var(--sfdt-color-brand-deep); }
+  #sfdt-panes code { background: var(--sfdt-color-surface-shade-4); padding: 1px 5px; border-radius: 3px; font-size: 12px; }
 `;
 
 function el<K extends keyof HTMLElementTagNameMap>(
@@ -138,18 +139,18 @@ function reloadWithOrg(host: string): void {
 function renderOrgPicker(root: HTMLElement): void {
   while (root.firstChild) root.removeChild(root.firstChild);
   const wrap = el('div');
-  wrap.style.cssText = 'max-width: 480px; margin: 80px auto; background: #fff; border: 1px solid #d8dde6; border-radius: 6px; padding: 24px;';
+  wrap.style.cssText = 'max-width: 480px; margin: 80px auto; background: var(--sfdt-color-surface); border: 1px solid var(--sfdt-color-border); border-radius: 6px; padding: 24px;';
   const h = el('h2');
   h.textContent = '⚡ SFDT Workspace';
   h.style.cssText = 'margin: 0 0 4px;';
   const p = el('p');
   p.textContent = 'Choose a Salesforce org to work in:';
-  p.style.cssText = 'color: #54698d; font-size: 13px; margin: 0 0 16px;';
+  p.style.cssText = 'color: var(--sfdt-color-text-weak); font-size: 13px; margin: 0 0 16px;';
   const list = el('div');
   list.style.cssText = 'display: flex; flex-direction: column; gap: 6px;';
   const loading = el('div');
   loading.textContent = 'Finding logged-in orgs…';
-  loading.style.cssText = 'color: #80868d; font-size: 12px;';
+  loading.style.cssText = 'color: var(--sfdt-color-text-icon); font-size: 12px;';
   list.appendChild(loading);
   wrap.appendChild(h);
   wrap.appendChild(p);
@@ -161,7 +162,7 @@ function renderOrgPicker(root: HTMLElement): void {
     while (list.firstChild) list.removeChild(list.firstChild);
     if (orgs.length === 0) {
       const empty = el('div');
-      empty.style.cssText = 'color: #c23934; font-size: 13px;';
+      empty.style.cssText = 'color: var(--sfdt-color-error); font-size: 13px;';
       empty.textContent =
         'No logged-in Salesforce orgs found. Log in to an org in another browser tab, then reload this page.';
       list.appendChild(empty);
@@ -170,13 +171,13 @@ function renderOrgPicker(root: HTMLElement): void {
     for (const org of orgs) {
       const btn = el('button');
       btn.style.cssText =
-        'text-align: left; padding: 12px; border: 1px solid #eef1f4; background: #fff; border-radius: 4px; cursor: pointer;';
+        'text-align: left; padding: 12px; border: 1px solid var(--sfdt-color-surface-shade-3); background: var(--sfdt-color-surface); border-radius: 4px; cursor: pointer;';
       const name = el('div');
       name.textContent = org.displayName;
       name.style.cssText = 'font-weight: 600; font-size: 13px;';
       const host = el('div');
       host.textContent = org.host;
-      host.style.cssText = 'font-size: 11px; color: #80868d; font-family: ui-monospace, monospace;';
+      host.style.cssText = 'font-size: 11px; color: var(--sfdt-color-text-icon); font-family: ui-monospace, monospace;';
       btn.appendChild(name);
       btn.appendChild(host);
       btn.addEventListener('click', () => {
@@ -348,7 +349,7 @@ function bootWorkspace(root: HTMLElement, orgHost: string): void {
 
 async function main(): Promise<void> {
   const styleTag = document.createElement('style');
-  styleTag.textContent = STYLES;
+  styleTag.textContent = `${SFDT_TOKENS_CSS}\n${STYLES}`;
   document.head.appendChild(styleTag);
 
   const root = document.getElementById('sfdt-app-root');

--- a/extension/entrypoints/content.ts
+++ b/extension/entrypoints/content.ts
@@ -11,6 +11,7 @@ import { createBridgeClient } from '../lib/sfdt-bridge.js';
 import { createTelemetry, type BridgeFailureCategory } from '../lib/telemetry.js';
 import { readKillSwitchCache, writeKillSwitchCache } from '../lib/killswitch-cache.js';
 import { mountSideButton, type MenuItem } from '../ui/side-button.js';
+import { ensureTokens } from '../lib/tokens.js';
 import { FEATURE_ICONS } from '../lib/feature-icons.js';
 import { createAiAssistantFeature } from '../features/ai-assistant.js';
 import { createApiNameGeneratorFeature } from '../features/api-name-generator.js';
@@ -67,6 +68,11 @@ export default defineContentScript({
     if (window.top !== window.self) return;
 
     if (!SALESFORCE_HOST_PATTERN.test(window.location.href)) return;
+
+    // Inject the --sfdt-* design tokens into the host page so every feature's
+    // inline `var(--sfdt-*)` colours resolve. Idempotent + namespaced, so it
+    // can't collide with Salesforce's own styles.
+    ensureTokens(document);
 
     const settings = await loadSettings();
     let currentSettings = settings;

--- a/extension/entrypoints/options/main.ts
+++ b/extension/entrypoints/options/main.ts
@@ -9,6 +9,7 @@ import { createBridgeClient, getBridgeData } from '../../lib/sfdt-bridge.js';
 import { createFeatureRegistry } from '../../lib/feature-registry.js';
 import { buildField } from '../../lib/zod-to-dom.js';
 import { createTelemetry } from '../../lib/telemetry.js';
+import { SFDT_TOKENS_CSS } from '../../lib/tokens.js';
 
 // Pull every feature factory in so each module's top-level
 // registerSettingsShape() call lands before loadSettings() runs.
@@ -39,8 +40,8 @@ const STYLES = `
   *, *::before, *::after { box-sizing: border-box; }
   body {
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
-    background: #fafaf9;
-    color: #16325c;
+    background: var(--sfdt-color-surface-alt);
+    color: var(--sfdt-color-brand-deep);
     margin: 0;
     padding: 32px 24px;
   }
@@ -52,30 +53,30 @@ const STYLES = `
     align-items: center;
     gap: 8px;
   }
-  .subtitle { color: #54698d; font-size: 13px; margin: 0 0 24px; }
+  .subtitle { color: var(--sfdt-color-text-weak); font-size: 13px; margin: 0 0 24px; }
   section {
-    background: #fff;
-    border: 1px solid #d8dde6;
+    background: var(--sfdt-color-surface);
+    border: 1px solid var(--sfdt-color-border);
     border-radius: 4px;
     padding: 16px 20px;
     margin-bottom: 16px;
   }
   section h2 { font-size: 15px; margin: 0 0 4px; font-weight: 600; }
-  section p.section-help { color: #54698d; font-size: 12px; margin: 0 0 12px; }
+  section p.section-help { color: var(--sfdt-color-text-weak); font-size: 12px; margin: 0 0 12px; }
   label.row {
     display: flex;
     align-items: center;
     justify-content: space-between;
     gap: 12px;
     padding: 8px 0;
-    border-top: 1px solid #f3f3f3;
+    border-top: 1px solid var(--sfdt-color-bg);
   }
   label.row:first-of-type { border-top: 0; }
   label.row .label-text { flex: 1; }
   label.row .label-text strong { display: block; font-weight: 500; font-size: 13px; }
-  label.row .label-text span { color: #80868d; font-size: 12px; }
+  label.row .label-text span { color: var(--sfdt-color-text-icon); font-size: 12px; }
   input[type="text"], input[type="number"], select, input[type="password"] {
-    border: 1px solid #d8dde6;
+    border: 1px solid var(--sfdt-color-border);
     border-radius: 3px;
     padding: 6px 8px;
     font-size: 13px;
@@ -84,7 +85,7 @@ const STYLES = `
   }
   input[type="color"] {
     width: 36px; height: 28px;
-    border: 1px solid #d8dde6;
+    border: 1px solid var(--sfdt-color-border);
     border-radius: 3px;
     padding: 0;
     cursor: pointer;
@@ -93,16 +94,16 @@ const STYLES = `
   button {
     padding: 6px 14px;
     border-radius: 3px;
-    border: 1px solid #d8dde6;
-    background: #fff;
-    color: #16325c;
+    border: 1px solid var(--sfdt-color-border);
+    background: var(--sfdt-color-surface);
+    color: var(--sfdt-color-brand-deep);
     cursor: pointer;
     font-size: 13px;
     font-family: inherit;
   }
-  button.primary { background: #0070d2; color: #fff; border-color: #0070d2; }
-  button:hover { background: #f3f3f3; }
-  button.primary:hover { background: #005fb2; }
+  button.primary { background: var(--sfdt-color-brand); color: var(--sfdt-color-surface); border-color: var(--sfdt-color-brand); }
+  button:hover { background: var(--sfdt-color-bg); }
+  button.primary:hover { background: var(--sfdt-color-brand-active); }
   .actions { margin-top: 12px; display: flex; gap: 8px; align-items: center; }
   .status {
     font-size: 12px;
@@ -111,21 +112,21 @@ const STYLES = `
     display: none;
   }
   .status.show { display: inline-block; }
-  .status.ok { background: #ddf3e4; color: #04844b; }
-  .status.warn { background: #fef1e1; color: #b46600; }
-  .status.error { background: #fde2e0; color: #c23934; }
+  .status.ok { background: var(--sfdt-color-success-bg); color: var(--sfdt-color-success); }
+  .status.warn { background: var(--sfdt-color-warning-bg-6); color: var(--sfdt-color-warning-text); }
+  .status.error { background: var(--sfdt-color-error-bg-4); color: var(--sfdt-color-error); }
   .hint {
-    background: #f4f6f9;
-    border-left: 3px solid #0070d2;
+    background: var(--sfdt-color-surface-shade);
+    border-left: 3px solid var(--sfdt-color-brand);
     padding: 8px 12px;
     font-size: 12px;
-    color: #54698d;
+    color: var(--sfdt-color-text-weak);
     margin: 12px 0;
     border-radius: 0 3px 3px 0;
   }
   .hint code {
-    background: #fff;
-    border: 1px solid #d8dde6;
+    background: var(--sfdt-color-surface);
+    border: 1px solid var(--sfdt-color-border);
     border-radius: 2px;
     padding: 1px 4px;
     font-family: ui-monospace, monospace;
@@ -188,7 +189,7 @@ async function render(): Promise<void> {
   if (!root) return;
 
   const styleTag = document.createElement('style');
-  styleTag.textContent = STYLES;
+  styleTag.textContent = `${SFDT_TOKENS_CSS}\n${STYLES}`;
   document.head.appendChild(styleTag);
 
   const registry = createFeatureRegistry();

--- a/extension/features/ai-assistant.ts
+++ b/extension/features/ai-assistant.ts
@@ -133,7 +133,7 @@ export function createAiAssistantFeature(options: AiAssistantOptions = {}): Feat
       heading.textContent = summary?.label ?? 'Flow';
       body.appendChild(heading);
       const subline = doc.createElement('div');
-      subline.style.cssText = 'color: #80868d; font-size: 12px; margin-bottom: 12px;';
+      subline.style.cssText = 'color: var(--sfdt-color-text-icon); font-size: 12px; margin-bottom: 12px;';
       subline.textContent = `${summary?.totalElements ?? 0} elements, ${summary?.totalResources ?? 0} resources · raw ~${rawTokens} tokens · cleaned ~${cleanTokens} tokens`;
       body.appendChild(subline);
 
@@ -158,7 +158,7 @@ export function createAiAssistantFeature(options: AiAssistantOptions = {}): Feat
       body.appendChild(promptRow);
 
       const description = doc.createElement('div');
-      description.style.cssText = 'color: #54698d; font-size: 12px; margin-bottom: 12px;';
+      description.style.cssText = 'color: var(--sfdt-color-text-weak); font-size: 12px; margin-bottom: 12px;';
       const updateDescription = () => {
         const sel = library.getById(select.value);
         description.textContent = sel?.description ?? '';
@@ -173,7 +173,7 @@ export function createAiAssistantFeature(options: AiAssistantOptions = {}): Feat
         const btn = doc.createElement('button');
         btn.textContent = label;
         btn.style.cssText =
-          'padding: 6px 10px; border: 1px solid #d8dde6; background: #fff; border-radius: 4px; cursor: pointer;';
+          'padding: 6px 10px; border: 1px solid var(--sfdt-color-border); background: var(--sfdt-color-surface); border-radius: 4px; cursor: pointer;';
         btn.addEventListener('click', () => void handler());
         return btn;
       };
@@ -208,7 +208,7 @@ export function createAiAssistantFeature(options: AiAssistantOptions = {}): Feat
         while (resultArea.firstChild) resultArea.removeChild(resultArea.firstChild);
         const panel = doc.createElement('div');
         panel.style.cssText =
-          'border: 1px solid #c23934; background: #fef2f1; color: #c23934; padding: 8px 12px; border-radius: 4px; font-size: 13px; white-space: pre-wrap;';
+          'border: 1px solid var(--sfdt-color-error); background: var(--sfdt-color-error-bg); color: var(--sfdt-color-error); padding: 8px 12px; border-radius: 4px; font-size: 13px; white-space: pre-wrap;';
         panel.textContent = message;
         resultArea.appendChild(panel);
       };
@@ -219,7 +219,7 @@ export function createAiAssistantFeature(options: AiAssistantOptions = {}): Feat
         header.style.cssText =
           'display: flex; align-items: center; justify-content: space-between; gap: 8px; margin-bottom: 6px;';
         const label = doc.createElement('span');
-        label.style.cssText = 'font-size: 12px; color: #54698d; font-weight: 600;';
+        label.style.cssText = 'font-size: 12px; color: var(--sfdt-color-text-weak); font-weight: 600;';
         label.textContent = provider ? `AI response (${provider})` : 'AI response';
         const copyBtn = makeBtn('📋 Copy response', async () => {
           await navigator.clipboard.writeText(responseText);
@@ -228,7 +228,7 @@ export function createAiAssistantFeature(options: AiAssistantOptions = {}): Feat
         header.append(label, copyBtn);
         const pre = doc.createElement('pre');
         pre.style.cssText =
-          'margin: 0; padding: 12px; background: #f3f3f3; border: 1px solid #d8dde6; border-radius: 4px; font-size: 12px; white-space: pre-wrap; word-break: break-word; max-height: 45vh; overflow: auto;';
+          'margin: 0; padding: 12px; background: var(--sfdt-color-bg); border: 1px solid var(--sfdt-color-border); border-radius: 4px; font-size: 12px; white-space: pre-wrap; word-break: break-word; max-height: 45vh; overflow: auto;';
         pre.textContent = responseText;
         resultArea.append(header, pre);
       };

--- a/extension/features/apex-anonymous.ts
+++ b/extension/features/apex-anonymous.ts
@@ -337,7 +337,7 @@ export function createApexAnonymousFeature(options: ApexAnonymousOptions = {}): 
     editor.placeholder = 'System.debug(\'Hello\');';
     editor.value = "System.debug('Hello from SFDT');";
     editor.style.cssText =
-      'width: 100%; min-height: 180px; font-family: ui-monospace, monospace; font-size: 12px; padding: 8px; border: 1px solid #d8dde6; border-radius: 4px; resize: vertical;';
+      'width: 100%; min-height: 180px; font-family: ui-monospace, monospace; font-size: 12px; padding: 8px; border: 1px solid var(--sfdt-color-border); border-radius: 4px; resize: vertical;';
     body.appendChild(editor);
 
     const toolbar = doc.createElement('div');
@@ -345,18 +345,18 @@ export function createApexAnonymousFeature(options: ApexAnonymousOptions = {}): 
     const runBtn = doc.createElement('button');
     runBtn.textContent = 'Execute';
     runBtn.style.cssText =
-      'padding: 6px 14px; background: #0070d2; color: #fff; border: 0; border-radius: 4px; cursor: pointer; font-size: 13px;';
+      'padding: 6px 14px; background: var(--sfdt-color-brand); color: var(--sfdt-color-surface); border: 0; border-radius: 4px; cursor: pointer; font-size: 13px;';
     const saveBtn = doc.createElement('button');
     saveBtn.textContent = 'Save snippet';
     saveBtn.style.cssText =
-      'padding: 6px 12px; border: 1px solid #d8dde6; background: #fff; border-radius: 4px; cursor: pointer; font-size: 12px;';
+      'padding: 6px 12px; border: 1px solid var(--sfdt-color-border); background: var(--sfdt-color-surface); border-radius: 4px; cursor: pointer; font-size: 12px;';
     const openLogBtn = doc.createElement('button');
     openLogBtn.textContent = '🪵 Open log';
     openLogBtn.style.cssText =
-      'padding: 6px 12px; border: 1px solid #d8dde6; background: #fff; border-radius: 4px; cursor: pointer; font-size: 12px; display: none;';
+      'padding: 6px 12px; border: 1px solid var(--sfdt-color-border); background: var(--sfdt-color-surface); border-radius: 4px; cursor: pointer; font-size: 12px; display: none;';
     const hint = doc.createElement('span');
     hint.textContent = 'Ctrl/Cmd+Enter to run';
-    hint.style.cssText = 'color: #80868d; font-size: 11px; margin-left: auto;';
+    hint.style.cssText = 'color: var(--sfdt-color-text-icon); font-size: 11px; margin-left: auto;';
     toolbar.appendChild(runBtn);
     toolbar.appendChild(saveBtn);
     toolbar.appendChild(openLogBtn);
@@ -364,17 +364,17 @@ export function createApexAnonymousFeature(options: ApexAnonymousOptions = {}): 
     body.appendChild(toolbar);
 
     const status = doc.createElement('div');
-    status.style.cssText = 'font-size: 12px; color: #54698d;';
+    status.style.cssText = 'font-size: 12px; color: var(--sfdt-color-text-weak);';
     body.appendChild(status);
 
     const resultPane = doc.createElement('pre');
     resultPane.style.cssText =
-      'margin: 0; padding: 10px; background: #fafaf9; border: 1px solid #d8dde6; border-radius: 4px; overflow: auto; max-height: 280px; font-family: ui-monospace, monospace; font-size: 12px; display: none; white-space: pre-wrap;';
+      'margin: 0; padding: 10px; background: var(--sfdt-color-surface-alt); border: 1px solid var(--sfdt-color-border); border-radius: 4px; overflow: auto; max-height: 280px; font-family: ui-monospace, monospace; font-size: 12px; display: none; white-space: pre-wrap;';
     body.appendChild(resultPane);
 
     const logPane = doc.createElement('pre');
     logPane.style.cssText =
-      'margin: 0; padding: 10px; background: #1e1e1e; color: #d4d4d4; border-radius: 4px; overflow: auto; max-height: 320px; font-family: ui-monospace, monospace; font-size: 11px; display: none; white-space: pre-wrap;';
+      'margin: 0; padding: 10px; background: var(--sfdt-color-code-bg); color: var(--sfdt-color-border-3); border-radius: 4px; overflow: auto; max-height: 320px; font-family: ui-monospace, monospace; font-size: 11px; display: none; white-space: pre-wrap;';
     body.appendChild(logPane);
 
     // The log captured by the most recent run, if any. Drives the Open log button.
@@ -402,7 +402,7 @@ export function createApexAnonymousFeature(options: ApexAnonymousOptions = {}): 
       capturedLogId = null;
       resultPane.style.display = 'none';
       resultPane.style.color = '';
-      status.style.color = '#54698d';
+      status.style.color = 'var(--sfdt-color-text-weak)';
       status.textContent = 'Executing…';
 
       // Trace-flag setup is best-effort: failing to arm log capture must never
@@ -435,7 +435,7 @@ export function createApexAnonymousFeature(options: ApexAnonymousOptions = {}): 
         const summary = summariseResult(result);
         const head = summary.ok ? '✓ Success' : '✗ Failed';
         status.textContent = head;
-        status.style.color = summary.ok ? '#04844b' : '#c23934';
+        status.style.color = summary.ok ? 'var(--sfdt-color-success)' : 'var(--sfdt-color-error)';
         const lines = [summary.message];
         if (result.exceptionStackTrace) lines.push('', result.exceptionStackTrace);
         resultPane.textContent = lines.join('\n');
@@ -458,7 +458,7 @@ export function createApexAnonymousFeature(options: ApexAnonymousOptions = {}): 
         status.textContent = '';
         resultPane.textContent = err instanceof Error ? err.message : String(err);
         resultPane.style.display = 'block';
-        resultPane.style.color = '#c23934';
+        resultPane.style.color = 'var(--sfdt-color-error)';
       } finally {
         runBtn.disabled = false;
       }

--- a/extension/features/apex-test-runner.ts
+++ b/extension/features/apex-test-runner.ts
@@ -62,7 +62,7 @@ export function shapeTestResults(rows: RawApexTestResultRow[]): ApexTestSummary 
   return { total: rows.length, passed, failed, skipped, failures };
 }
 
-const BAND_COLOUR = { green: '#04844b', red: '#c23934' } as const;
+const BAND_COLOUR = { green: 'var(--sfdt-color-success)', red: 'var(--sfdt-color-error)' } as const;
 
 // Test levels that need no class selection — RunSpecifiedTests is omitted
 // because it requires a class list the Workspace can't supply cleanly.
@@ -105,7 +105,7 @@ export function createApexTestRunnerFeature(options: ApexTestRunnerOptions = {})
   function renderError(results: HTMLElement, status: HTMLSpanElement, message: string): void {
     const panel = doc.createElement('div');
     panel.style.cssText =
-      'border: 1px solid #c23934; background: #fef2f1; color: #c23934; padding: 8px 12px; border-radius: 4px; font-size: 13px;';
+      'border: 1px solid var(--sfdt-color-error); background: var(--sfdt-color-error-bg); color: var(--sfdt-color-error); padding: 8px 12px; border-radius: 4px; font-size: 13px;';
     panel.textContent = message;
     results.appendChild(panel);
     status.textContent = 'Failed';
@@ -114,12 +114,12 @@ export function createApexTestRunnerFeature(options: ApexTestRunnerOptions = {})
   function renderSummary(results: HTMLElement, summary: ApexTestSummary, complete: boolean): void {
     const banner = doc.createElement('div');
     const band = summary.failed > 0 ? 'red' : 'green';
-    banner.style.cssText = `margin-bottom: 14px; padding: 12px 14px; border-radius: 6px; border: 1px solid #d8dde6; border-left: 4px solid ${BAND_COLOUR[band]}; display: flex; align-items: baseline; gap: 10px;`;
+    banner.style.cssText = `margin-bottom: 14px; padding: 12px 14px; border-radius: 6px; border: 1px solid var(--sfdt-color-border); border-left: 4px solid ${BAND_COLOUR[band]}; display: flex; align-items: baseline; gap: 10px;`;
     const big = doc.createElement('span');
     big.style.cssText = 'font-size: 20px; font-weight: 700;';
     big.textContent = `${summary.passed} passed · ${summary.failed} failed`;
     const cap = doc.createElement('span');
-    cap.style.cssText = 'font-size: 12px; color: #54698d;';
+    cap.style.cssText = 'font-size: 12px; color: var(--sfdt-color-text-weak);';
     cap.textContent =
       `${summary.total} method${summary.total === 1 ? '' : 's'}` +
       (summary.skipped > 0 ? `, ${summary.skipped} skipped` : '') +
@@ -132,14 +132,14 @@ export function createApexTestRunnerFeature(options: ApexTestRunnerOptions = {})
       for (const f of summary.failures) {
         const card = doc.createElement('div');
         card.style.cssText =
-          'border: 1px solid #f4c7c3; border-radius: 4px; padding: 8px 10px; margin-bottom: 6px; background: #fef6f5;';
+          'border: 1px solid var(--sfdt-color-error-border); border-radius: 4px; padding: 8px 10px; margin-bottom: 6px; background: var(--sfdt-color-error-bg-3);';
         const title = doc.createElement('div');
-        title.style.cssText = 'font-weight: 600; font-size: 12px; color: #c23934; word-break: break-all;';
+        title.style.cssText = 'font-weight: 600; font-size: 12px; color: var(--sfdt-color-error); word-break: break-all;';
         title.textContent = f.name;
         card.appendChild(title);
         if (f.message) {
           const msg = doc.createElement('div');
-          msg.style.cssText = 'font-size: 11px; color: #3e3e3c; margin-top: 4px; white-space: pre-wrap;';
+          msg.style.cssText = 'font-size: 11px; color: var(--sfdt-color-text); margin-top: 4px; white-space: pre-wrap;';
           msg.textContent = f.message;
           card.appendChild(msg);
         }
@@ -147,12 +147,12 @@ export function createApexTestRunnerFeature(options: ApexTestRunnerOptions = {})
       }
     } else if (summary.total > 0) {
       const ok = doc.createElement('div');
-      ok.style.cssText = 'padding: 8px 0; color: #04844b; font-size: 13px;';
+      ok.style.cssText = 'padding: 8px 0; color: var(--sfdt-color-success); font-size: 13px;';
       ok.textContent = 'All tests passed. 🎉';
       results.appendChild(ok);
     } else {
       const empty = doc.createElement('div');
-      empty.style.cssText = 'padding: 8px 0; color: #80868d; font-size: 13px;';
+      empty.style.cssText = 'padding: 8px 0; color: var(--sfdt-color-text-icon); font-size: 13px;';
       empty.textContent = 'No test results returned for this run.';
       results.appendChild(empty);
     }
@@ -224,7 +224,7 @@ export function createApexTestRunnerFeature(options: ApexTestRunnerOptions = {})
 
     const levelSelect = doc.createElement('select');
     levelSelect.style.cssText =
-      'padding: 5px 8px; border: 1px solid #d8dde6; border-radius: 4px; font-size: 13px;';
+      'padding: 5px 8px; border: 1px solid var(--sfdt-color-border); border-radius: 4px; font-size: 13px;';
     for (const level of TEST_LEVELS) {
       const opt = doc.createElement('option');
       opt.value = level;
@@ -235,10 +235,10 @@ export function createApexTestRunnerFeature(options: ApexTestRunnerOptions = {})
     const runBtn = doc.createElement('button');
     runBtn.textContent = 'Run';
     runBtn.style.cssText =
-      'padding: 5px 16px; border: 1px solid #0070d2; background: #0070d2; color: #fff; border-radius: 4px; cursor: pointer; font-size: 13px;';
+      'padding: 5px 16px; border: 1px solid var(--sfdt-color-brand); background: var(--sfdt-color-brand); color: var(--sfdt-color-surface); border-radius: 4px; cursor: pointer; font-size: 13px;';
 
     const status = doc.createElement('span');
-    status.style.cssText = 'color: #54698d; font-size: 12px; margin-left: auto;';
+    status.style.cssText = 'color: var(--sfdt-color-text-weak); font-size: 12px; margin-left: auto;';
 
     toolbar.append(levelSelect, runBtn, status);
     body.appendChild(toolbar);

--- a/extension/features/api-name-generator.ts
+++ b/extension/features/api-name-generator.ts
@@ -100,7 +100,7 @@ export function createApiNameGeneratorFeature(
 
     const preview = doc.createElement('div');
     preview.style.cssText =
-      'font-family: monospace; padding: 8px; background: #fafaf9; border: 1px solid #d8dde6; border-radius: 4px; margin-bottom: 12px; min-height: 20px;';
+      'font-family: monospace; padding: 8px; background: var(--sfdt-color-surface-alt); border: 1px solid var(--sfdt-color-border); border-radius: 4px; margin-bottom: 12px; min-height: 20px;';
     body.appendChild(preview);
 
     const update = () => {
@@ -129,7 +129,7 @@ export function createApiNameGeneratorFeature(
     const copy = doc.createElement('button');
     copy.textContent = 'Copy';
     copy.style.cssText =
-      'padding: 6px 12px; background: #0070d2; color: #fff; border: 0; border-radius: 4px; cursor: pointer;';
+      'padding: 6px 12px; background: var(--sfdt-color-brand); color: var(--sfdt-color-surface); border: 0; border-radius: 4px; cursor: pointer;';
     copy.addEventListener('click', async () => {
       if (!preview.textContent) return;
       await navigator.clipboard.writeText(preview.textContent);

--- a/extension/features/api-version-audit.ts
+++ b/extension/features/api-version-audit.ts
@@ -14,8 +14,8 @@ import { getSalesforceApi, type SalesforceApiClient } from '../lib/salesforce-ap
 
 const AUDIT_CLASS = 'sfdt-api-version-audit';
 const PANEL_CLASS = 'sfdt-api-version-audit-panel';
-const BEHIND_COLOUR = '#fe9339'; // amber — matches org-health's amber band
-const OK_COLOUR = '#706e6b'; // neutral grey
+const BEHIND_COLOUR = 'var(--sfdt-color-warning)'; // amber — matches org-health's amber band
+const OK_COLOUR = 'var(--sfdt-color-text-muted)'; // neutral grey
 
 interface ApiVersionRow {
   ApiVersion?: number | null;
@@ -113,8 +113,8 @@ function buildPanel(doc: Document, data: AuditData): HTMLDivElement {
     'top: 100%',
     'right: 0',
     'z-index: 99999',
-    'background: #fff',
-    'border: 1px solid #d8dde6',
+    'background: var(--sfdt-color-surface)',
+    'border: 1px solid var(--sfdt-color-border)',
     'border-radius: 4px',
     'box-shadow: 0 2px 8px rgba(0,0,0,0.15)',
     'padding: 10px 12px',
@@ -122,7 +122,7 @@ function buildPanel(doc: Document, data: AuditData): HTMLDivElement {
     'max-height: 380px',
     'overflow-y: auto',
     'font-size: 12px',
-    'color: #16325c',
+    'color: var(--sfdt-color-brand-deep)',
     'text-align: left',
     'white-space: nowrap',
   ].join('; ');
@@ -130,13 +130,13 @@ function buildPanel(doc: Document, data: AuditData): HTMLDivElement {
   const floor = ORG_HEALTH_THRESHOLDS.minApiVersionFloor;
   for (const t of data.types) {
     const heading = doc.createElement('div');
-    heading.style.cssText = 'font-weight: 700; margin: 6px 0 4px; font-size: 11px; text-transform: uppercase; letter-spacing: 0.02em; color: #54698d;';
+    heading.style.cssText = 'font-weight: 700; margin: 6px 0 4px; font-size: 11px; text-transform: uppercase; letter-spacing: 0.02em; color: var(--sfdt-color-text-weak);';
     heading.textContent = t.label;
     panel.appendChild(heading);
 
     if (t.versions.length === 0) {
       const empty = doc.createElement('div');
-      empty.style.cssText = 'color: #54698d; font-style: italic;';
+      empty.style.cssText = 'color: var(--sfdt-color-text-weak); font-style: italic;';
       empty.textContent = 'none';
       panel.appendChild(empty);
       continue;
@@ -152,7 +152,7 @@ function buildPanel(doc: Document, data: AuditData): HTMLDivElement {
         'align-items: center',
         'gap: 8px',
         'padding: 1px 4px',
-        below ? `color: ${BEHIND_COLOUR}; font-weight: 700; background: #fef4ec` : '',
+        below ? `color: ${BEHIND_COLOUR}; font-weight: 700; background: var(--sfdt-color-warning-bg-5)` : '',
       ].join('; ');
       if (below) row.dataset['belowFloor'] = 'true';
 
@@ -165,7 +165,7 @@ function buildPanel(doc: Document, data: AuditData): HTMLDivElement {
         'height: 8px',
         'border-radius: 2px',
         `width: ${Math.max(4, Math.round((count / max) * 80))}px`,
-        `background: ${below ? BEHIND_COLOUR : '#1589ee'}`,
+        `background: ${below ? BEHIND_COLOUR : 'var(--sfdt-color-info)'}`,
       ].join('; ');
       const countEl = doc.createElement('span');
       countEl.textContent = String(count);
@@ -177,7 +177,7 @@ function buildPanel(doc: Document, data: AuditData): HTMLDivElement {
   if (data.release) {
     const footer = doc.createElement('div');
     footer.className = `${PANEL_CLASS}-footer`;
-    footer.style.cssText = 'margin-top: 8px; padding-top: 6px; border-top: 1px solid #d8dde6; color: #54698d;';
+    footer.style.cssText = 'margin-top: 8px; padding-top: 6px; border-top: 1px solid var(--sfdt-color-border); color: var(--sfdt-color-text-weak);';
     footer.textContent = `Org max: v${data.release.apiVersion} — ${data.release.release}${data.release.preview ? ' (preview)' : ''}`;
     panel.appendChild(footer);
   }
@@ -254,7 +254,7 @@ export function createApiVersionAuditFeature(options: ApiVersionAuditOptions = {
       'font-weight: 700',
       'text-transform: uppercase',
       'letter-spacing: 0.02em',
-      'color: #fff',
+      'color: var(--sfdt-color-surface)',
       `background: ${behind ? BEHIND_COLOUR : OK_COLOUR}`,
       'border-radius: 3px',
       'padding: 2px 8px',

--- a/extension/features/bridge-tools.ts
+++ b/extension/features/bridge-tools.ts
@@ -83,7 +83,7 @@ interface ToolSpec {
 function renderJson(doc: Document, results: HTMLElement, data: unknown): void {
   const pre = doc.createElement('pre');
   pre.style.cssText =
-    'margin: 0; padding: 12px; background: #f3f3f3; border: 1px solid #d8dde6; border-radius: 4px; font-size: 12px; white-space: pre-wrap; word-break: break-word;';
+    'margin: 0; padding: 12px; background: var(--sfdt-color-bg); border: 1px solid var(--sfdt-color-border); border-radius: 4px; font-size: 12px; white-space: pre-wrap; word-break: break-word;';
   pre.textContent = JSON.stringify(data ?? null, null, 2);
   results.appendChild(pre);
 }
@@ -104,7 +104,7 @@ function createBridgeToolFeature(spec: ToolSpec, options: BridgeToolOptions): Fe
   function renderError(results: HTMLElement, status: HTMLSpanElement, message: string): void {
     const panel = doc.createElement('div');
     panel.style.cssText =
-      'border: 1px solid #c23934; background: #fef2f1; color: #c23934; padding: 8px 12px; border-radius: 4px; font-size: 13px;';
+      'border: 1px solid var(--sfdt-color-error); background: var(--sfdt-color-error-bg); color: var(--sfdt-color-error); padding: 8px 12px; border-radius: 4px; font-size: 13px;';
     panel.textContent = message;
     results.appendChild(panel);
     status.textContent = 'Failed';
@@ -151,9 +151,9 @@ function createBridgeToolFeature(spec: ToolSpec, options: BridgeToolOptions): Fe
     const runBtn = doc.createElement('button');
     runBtn.textContent = spec.runLabel;
     runBtn.style.cssText =
-      'padding: 5px 14px; border: 1px solid #0070d2; background: #0070d2; color: #fff; border-radius: 4px; cursor: pointer; font-size: 13px;';
+      'padding: 5px 14px; border: 1px solid var(--sfdt-color-brand); background: var(--sfdt-color-brand); color: var(--sfdt-color-surface); border-radius: 4px; cursor: pointer; font-size: 13px;';
     const status = doc.createElement('span');
-    status.style.cssText = 'color: #54698d; font-size: 12px;';
+    status.style.cssText = 'color: var(--sfdt-color-text-weak); font-size: 12px;';
     toolbar.append(controls, runBtn, status);
     body.appendChild(toolbar);
 
@@ -209,7 +209,7 @@ function textInput(doc: Document, placeholder: string): HTMLInputElement {
   input.type = 'text';
   input.placeholder = placeholder;
   input.style.cssText =
-    'flex: 1; min-width: 160px; padding: 5px 8px; border: 1px solid #d8dde6; border-radius: 4px; font-size: 13px;';
+    'flex: 1; min-width: 160px; padding: 5px 8px; border: 1px solid var(--sfdt-color-border); border-radius: 4px; font-size: 13px;';
   return input;
 }
 
@@ -229,7 +229,7 @@ export function createDriftFeature(options: BridgeToolOptions = {}): Feature {
         const input = textInput(doc, 'Component, e.g. Account.MyField__c');
         controls.appendChild(input);
         const live = doc.createElement('label');
-        live.style.cssText = 'display: inline-flex; align-items: center; gap: 4px; font-size: 12px; color: #54698d;';
+        live.style.cssText = 'display: inline-flex; align-items: center; gap: 4px; font-size: 12px; color: var(--sfdt-color-text-weak);';
         const cb = doc.createElement('input');
         cb.type = 'checkbox';
         live.append(cb, doc.createTextNode('Run live (slower)'));
@@ -258,7 +258,7 @@ export function createScanFeature(options: BridgeToolOptions = {}): Feature {
       setupInputs(doc, controls) {
         const select = doc.createElement('select');
         select.style.cssText =
-          'padding: 5px 8px; border: 1px solid #d8dde6; border-radius: 4px; font-size: 13px;';
+          'padding: 5px 8px; border: 1px solid var(--sfdt-color-border); border-radius: 4px; font-size: 13px;';
         for (const [value, label] of [
           ['scheduled', 'Scheduled flows only'],
           ['all', 'All flows'],

--- a/extension/features/code-coverage.ts
+++ b/extension/features/code-coverage.ts
@@ -22,10 +22,10 @@ export type RawCoverageRow = RawClassCoverageRow;
 export type CoverageRow = ClassCoverageRow;
 
 const BAND_COLOUR: Record<'green' | 'amber' | 'red' | 'none', string> = {
-  green: '#04844b',
-  amber: '#fe9339',
-  red: '#c23934',
-  none: '#b0adab',
+  green: 'var(--sfdt-color-success)',
+  amber: 'var(--sfdt-color-warning)',
+  red: 'var(--sfdt-color-error)',
+  none: 'var(--sfdt-color-text-disabled)',
 };
 
 export interface CodeCoverageOptions {
@@ -70,12 +70,12 @@ export function createCodeCoverageFeature(options: CodeCoverageOptions = {}): Fe
       // Org-wide summary banner.
       const summary = doc.createElement('div');
       const orgFrac = typeof orgPct === 'number' ? orgPct / 100 : null;
-      summary.style.cssText = `margin-bottom: 14px; padding: 12px 14px; border-radius: 6px; border: 1px solid #d8dde6; border-left: 4px solid ${BAND_COLOUR[coverageBand(orgFrac)]}; display: flex; align-items: baseline; gap: 10px;`;
+      summary.style.cssText = `margin-bottom: 14px; padding: 12px 14px; border-radius: 6px; border: 1px solid var(--sfdt-color-border); border-left: 4px solid ${BAND_COLOUR[coverageBand(orgFrac)]}; display: flex; align-items: baseline; gap: 10px;`;
       const big = doc.createElement('span');
       big.style.cssText = 'font-size: 22px; font-weight: 700;';
       big.textContent = typeof orgPct === 'number' ? `${orgPct}%` : '—';
       const cap = doc.createElement('span');
-      cap.style.cssText = 'font-size: 12px; color: #54698d;';
+      cap.style.cssText = 'font-size: 12px; color: var(--sfdt-color-text-weak);';
       cap.textContent = 'org-wide Apex coverage (75% required to deploy)';
       summary.appendChild(big);
       summary.appendChild(cap);
@@ -83,7 +83,7 @@ export function createCodeCoverageFeature(options: CodeCoverageOptions = {}): Fe
 
       if (rows.length === 0) {
         const empty = doc.createElement('div');
-        empty.style.cssText = 'padding: 12px; color: #80868d;';
+        empty.style.cssText = 'padding: 12px; color: var(--sfdt-color-text-icon);';
         empty.textContent = 'No coverage data. Run Apex tests in this org first.';
         results.appendChild(empty);
         return;
@@ -95,18 +95,18 @@ export function createCodeCoverageFeature(options: CodeCoverageOptions = {}): Fe
       for (const r of rows) {
         const card = doc.createElement('div');
         card.style.cssText =
-          'border: 1px solid #d8dde6; border-radius: 4px; padding: 10px; display: flex; flex-direction: column; gap: 6px;';
+          'border: 1px solid var(--sfdt-color-border); border-radius: 4px; padding: 10px; display: flex; flex-direction: column; gap: 6px;';
         const title = doc.createElement('div');
         title.style.cssText = 'font-weight: 600; font-size: 12px; word-break: break-all;';
         title.textContent = r.name;
         const bar = doc.createElement('div');
-        bar.style.cssText = 'height: 6px; background: #f3f3f3; border-radius: 3px; overflow: hidden;';
+        bar.style.cssText = 'height: 6px; background: var(--sfdt-color-bg); border-radius: 3px; overflow: hidden;';
         const fill = doc.createElement('div');
         const band = coverageBand(r.pct);
         fill.style.cssText = `height: 100%; width: ${((r.pct ?? 0) * 100).toFixed(1)}%; background: ${BAND_COLOUR[band]};`;
         bar.appendChild(fill);
         const usage = doc.createElement('div');
-        usage.style.cssText = 'font-size: 11px; color: #54698d;';
+        usage.style.cssText = 'font-size: 11px; color: var(--sfdt-color-text-weak);';
         usage.textContent = `${pctLabel(r.pct)} — ${r.covered}/${r.total} lines`;
         card.appendChild(title);
         card.appendChild(bar);
@@ -117,7 +117,7 @@ export function createCodeCoverageFeature(options: CodeCoverageOptions = {}): Fe
     } catch (err) {
       const errorPanel = doc.createElement('div');
       errorPanel.style.cssText =
-        'border: 1px solid #c23934; background: #fef2f1; color: #c23934; padding: 8px 12px; border-radius: 4px; font-size: 13px;';
+        'border: 1px solid var(--sfdt-color-error); background: var(--sfdt-color-error-bg); color: var(--sfdt-color-error); padding: 8px 12px; border-radius: 4px; font-size: 13px;';
       errorPanel.textContent = err instanceof Error ? err.message : String(err);
       results.appendChild(errorPanel);
       status.textContent = 'Failed';
@@ -135,11 +135,11 @@ export function createCodeCoverageFeature(options: CodeCoverageOptions = {}): Fe
     const toolbar = doc.createElement('div');
     toolbar.style.cssText = 'display: flex; align-items: center; gap: 10px; margin-bottom: 12px;';
     const status = doc.createElement('span');
-    status.style.cssText = 'color: #54698d; font-size: 12px;';
+    status.style.cssText = 'color: var(--sfdt-color-text-weak); font-size: 12px;';
     const refreshBtn = doc.createElement('button');
     refreshBtn.textContent = 'Refresh';
     refreshBtn.style.cssText =
-      'margin-left: auto; padding: 4px 10px; border: 1px solid #d8dde6; background: #fff; border-radius: 4px; cursor: pointer; font-size: 12px;';
+      'margin-left: auto; padding: 4px 10px; border: 1px solid var(--sfdt-color-border); background: var(--sfdt-color-surface); border-radius: 4px; cursor: pointer; font-size: 12px;';
     toolbar.appendChild(status);
     toolbar.appendChild(refreshBtn);
     body.appendChild(toolbar);

--- a/extension/features/data-import.ts
+++ b/extension/features/data-import.ts
@@ -174,7 +174,7 @@ export function createDataImportFeature(options: {
 
     // Configuration Row
     const configRow = doc.createElement('div');
-    configRow.style.cssText = 'display: flex; flex-wrap: wrap; gap: 16px; border-bottom: 1px solid #e0e0e0; padding-bottom: 16px;';
+    configRow.style.cssText = 'display: flex; flex-wrap: wrap; gap: 16px; border-bottom: 1px solid var(--sfdt-color-border-2); padding-bottom: 16px;';
     body.appendChild(configRow);
 
     // Target SObject Select
@@ -182,9 +182,9 @@ export function createDataImportFeature(options: {
     sobjDiv.style.cssText = 'display: flex; flex-direction: column; gap: 4px; min-width: 180px;';
     const sobjLabel = doc.createElement('label');
     sobjLabel.textContent = 'SObject Name';
-    sobjLabel.style.cssText = 'font-size: 11px; font-weight: 600; color: #54698d;';
+    sobjLabel.style.cssText = 'font-size: 11px; font-weight: 600; color: var(--sfdt-color-text-weak);';
     const sobjSelect = doc.createElement('select');
-    sobjSelect.style.cssText = 'padding: 6px; border: 1px solid #d8dde6; border-radius: 4px; font-size: 13px; outline: none;';
+    sobjSelect.style.cssText = 'padding: 6px; border: 1px solid var(--sfdt-color-border); border-radius: 4px; font-size: 13px; outline: none;';
     sobjDiv.appendChild(sobjLabel);
     sobjDiv.appendChild(sobjSelect);
     configRow.appendChild(sobjDiv);
@@ -194,9 +194,9 @@ export function createDataImportFeature(options: {
     opDiv.style.cssText = 'display: flex; flex-direction: column; gap: 4px; min-width: 120px;';
     const opLabel = doc.createElement('label');
     opLabel.textContent = 'Operation';
-    opLabel.style.cssText = 'font-size: 11px; font-weight: 600; color: #54698d;';
+    opLabel.style.cssText = 'font-size: 11px; font-weight: 600; color: var(--sfdt-color-text-weak);';
     const opSelect = doc.createElement('select');
-    opSelect.style.cssText = 'padding: 6px; border: 1px solid #d8dde6; border-radius: 4px; font-size: 13px; outline: none;';
+    opSelect.style.cssText = 'padding: 6px; border: 1px solid var(--sfdt-color-border); border-radius: 4px; font-size: 13px; outline: none;';
     const ops = [
       { v: 'create', l: 'Insert' },
       { v: 'update', l: 'Update' },
@@ -219,9 +219,9 @@ export function createDataImportFeature(options: {
     extIdDiv.style.cssText = 'display: none; flex-direction: column; gap: 4px; min-width: 150px;';
     const extIdLabel = doc.createElement('label');
     extIdLabel.textContent = 'External ID Field';
-    extIdLabel.style.cssText = 'font-size: 11px; font-weight: 600; color: #54698d;';
+    extIdLabel.style.cssText = 'font-size: 11px; font-weight: 600; color: var(--sfdt-color-text-weak);';
     const extIdSelect = doc.createElement('select');
-    extIdSelect.style.cssText = 'padding: 6px; border: 1px solid #d8dde6; border-radius: 4px; font-size: 13px; outline: none;';
+    extIdSelect.style.cssText = 'padding: 6px; border: 1px solid var(--sfdt-color-border); border-radius: 4px; font-size: 13px; outline: none;';
     extIdDiv.appendChild(extIdLabel);
     extIdDiv.appendChild(extIdSelect);
     configRow.appendChild(extIdDiv);
@@ -231,13 +231,13 @@ export function createDataImportFeature(options: {
     batchDiv.style.cssText = 'display: flex; flex-direction: column; gap: 4px; width: 80px;';
     const batchLabel = doc.createElement('label');
     batchLabel.textContent = 'Batch Size';
-    batchLabel.style.cssText = 'font-size: 11px; font-weight: 600; color: #54698d;';
+    batchLabel.style.cssText = 'font-size: 11px; font-weight: 600; color: var(--sfdt-color-text-weak);';
     const batchInput = doc.createElement('input');
     batchInput.type = 'number';
     batchInput.min = '1';
     batchInput.max = '200';
     batchInput.value = '200';
-    batchInput.style.cssText = 'padding: 6px; border: 1px solid #d8dde6; border-radius: 4px; font-size: 13px; outline: none;';
+    batchInput.style.cssText = 'padding: 6px; border: 1px solid var(--sfdt-color-border); border-radius: 4px; font-size: 13px; outline: none;';
     batchDiv.appendChild(batchLabel);
     batchDiv.appendChild(batchInput);
     configRow.appendChild(batchDiv);
@@ -247,13 +247,13 @@ export function createDataImportFeature(options: {
     concDiv.style.cssText = 'display: flex; flex-direction: column; gap: 4px; width: 80px;';
     const concLabel = doc.createElement('label');
     concLabel.textContent = 'Threads';
-    concLabel.style.cssText = 'font-size: 11px; font-weight: 600; color: #54698d;';
+    concLabel.style.cssText = 'font-size: 11px; font-weight: 600; color: var(--sfdt-color-text-weak);';
     const concInput = doc.createElement('input');
     concInput.type = 'number';
     concInput.min = '1';
     concInput.max = '10';
     concInput.value = '2';
-    concInput.style.cssText = 'padding: 6px; border: 1px solid #d8dde6; border-radius: 4px; font-size: 13px; outline: none;';
+    concInput.style.cssText = 'padding: 6px; border: 1px solid var(--sfdt-color-border); border-radius: 4px; font-size: 13px; outline: none;';
     concDiv.appendChild(concLabel);
     concDiv.appendChild(concInput);
     configRow.appendChild(concDiv);
@@ -263,20 +263,20 @@ export function createDataImportFeature(options: {
     pasteDiv.style.cssText = 'display: flex; flex-direction: column; gap: 6px;';
     const pasteLabel = doc.createElement('span');
     pasteLabel.textContent = 'Paste CSV / Excel Data (Tab or Comma delimited)';
-    pasteLabel.style.cssText = 'font-size: 12px; font-weight: 600; color: #3e3e3c;';
+    pasteLabel.style.cssText = 'font-size: 12px; font-weight: 600; color: var(--sfdt-color-text);';
     const pasteArea = doc.createElement('textarea');
     pasteArea.placeholder = 'First row must contain headers. E.g.\nFirstName\tLastName\tEmail\nJohn\tDoe\tjohn.doe@example.com';
-    pasteArea.style.cssText = 'height: 100px; padding: 10px; border: 1px solid #d8dde6; border-radius: 4px; font-family: monospace; font-size: 12px; outline: none; resize: vertical;';
+    pasteArea.style.cssText = 'height: 100px; padding: 10px; border: 1px solid var(--sfdt-color-border); border-radius: 4px; font-family: monospace; font-size: 12px; outline: none; resize: vertical;';
     pasteDiv.appendChild(pasteLabel);
     pasteDiv.appendChild(pasteArea);
     body.appendChild(pasteDiv);
 
     // Mapping Grid Container
     const mappingContainer = doc.createElement('div');
-    mappingContainer.style.cssText = 'display: none; flex-direction: column; gap: 6px; border: 1px solid #d8dde6; border-radius: 4px; padding: 12px;';
+    mappingContainer.style.cssText = 'display: none; flex-direction: column; gap: 6px; border: 1px solid var(--sfdt-color-border); border-radius: 4px; padding: 12px;';
     const mappingHeader = doc.createElement('span');
     mappingHeader.textContent = 'Field Mappings';
-    mappingHeader.style.cssText = 'font-weight: 600; font-size: 13px; color: #16325c;';
+    mappingHeader.style.cssText = 'font-weight: 600; font-size: 13px; color: var(--sfdt-color-brand-deep);';
     mappingContainer.appendChild(mappingHeader);
     const mappingGrid = doc.createElement('div');
     mappingGrid.style.cssText = 'display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 10px; max-height: 200px; overflow-y: auto; padding: 4px;';
@@ -285,17 +285,17 @@ export function createDataImportFeature(options: {
 
     // Action Row (Import button, Cancel, Download error, etc.)
     const actionRow = doc.createElement('div');
-    actionRow.style.cssText = 'display: flex; gap: 10px; justify-content: flex-end; align-items: center; border-top: 1px solid #e0e0e0; padding-top: 16px;';
+    actionRow.style.cssText = 'display: flex; gap: 10px; justify-content: flex-end; align-items: center; border-top: 1px solid var(--sfdt-color-border-2); padding-top: 16px;';
     body.appendChild(actionRow);
 
     const importBtn = doc.createElement('button');
     importBtn.textContent = 'Start Import';
-    importBtn.style.cssText = 'padding: 8px 20px; background: #0070d2; color: #fff; border: 0; border-radius: 4px; cursor: pointer; font-size: 13px; font-weight: 600;';
+    importBtn.style.cssText = 'padding: 8px 20px; background: var(--sfdt-color-brand); color: var(--sfdt-color-surface); border: 0; border-radius: 4px; cursor: pointer; font-size: 13px; font-weight: 600;';
     importBtn.disabled = true;
 
     const downloadErrorsBtn = doc.createElement('button');
     downloadErrorsBtn.textContent = 'Download Errors CSV';
-    downloadErrorsBtn.style.cssText = 'padding: 8px 14px; background: #fff; color: #c23934; border: 1px solid #c23934; border-radius: 4px; cursor: pointer; font-size: 13px; font-weight: 600; display: none;';
+    downloadErrorsBtn.style.cssText = 'padding: 8px 14px; background: var(--sfdt-color-surface); color: var(--sfdt-color-error); border: 1px solid var(--sfdt-color-error); border-radius: 4px; cursor: pointer; font-size: 13px; font-weight: 600; display: none;';
 
     actionRow.appendChild(downloadErrorsBtn);
     actionRow.appendChild(importBtn);
@@ -308,32 +308,32 @@ export function createDataImportFeature(options: {
     const progressLabel = doc.createElement('span');
     progressLabel.textContent = 'Import Progress';
     const progressStats = doc.createElement('span');
-    progressStats.style.cssText = 'color: #54698d;';
+    progressStats.style.cssText = 'color: var(--sfdt-color-text-weak);';
     progressInfo.appendChild(progressLabel);
     progressInfo.appendChild(progressStats);
     progressSection.appendChild(progressInfo);
 
     const progressOuter = doc.createElement('div');
-    progressOuter.style.cssText = 'height: 8px; background: #e0e0e0; border-radius: 4px; overflow: hidden;';
+    progressOuter.style.cssText = 'height: 8px; background: var(--sfdt-color-border-2); border-radius: 4px; overflow: hidden;';
     const progressInner = doc.createElement('div');
-    progressInner.style.cssText = 'height: 100%; width: 0%; background: #0070d2; transition: width 0.2s;';
+    progressInner.style.cssText = 'height: 100%; width: 0%; background: var(--sfdt-color-brand); transition: width 0.2s;';
     progressOuter.appendChild(progressInner);
     progressSection.appendChild(progressOuter);
 
     const statsGrid = doc.createElement('div');
-    statsGrid.style.cssText = 'display: flex; gap: 20px; font-size: 12px; justify-content: flex-start; background: #fafaf9; padding: 10px; border-radius: 4px;';
+    statsGrid.style.cssText = 'display: flex; gap: 20px; font-size: 12px; justify-content: flex-start; background: var(--sfdt-color-surface-alt); padding: 10px; border-radius: 4px;';
     const queuedStat = doc.createElement('span');
     queuedStat.textContent = 'Queued: 0';
-    queuedStat.style.color = '#54698d';
+    queuedStat.style.color = 'var(--sfdt-color-text-weak)';
     const processingStat = doc.createElement('span');
     processingStat.textContent = 'Processing: 0';
-    processingStat.style.color = '#0070d2';
+    processingStat.style.color = 'var(--sfdt-color-brand)';
     const succeededStat = doc.createElement('span');
     succeededStat.textContent = 'Succeeded: 0';
-    succeededStat.style.color = '#04844b';
+    succeededStat.style.color = 'var(--sfdt-color-success)';
     const failedStat = doc.createElement('span');
     failedStat.textContent = 'Failed: 0';
-    failedStat.style.color = '#c23934';
+    failedStat.style.color = 'var(--sfdt-color-error)';
     statsGrid.appendChild(queuedStat);
     statsGrid.appendChild(processingStat);
     statsGrid.appendChild(succeededStat);
@@ -342,7 +342,7 @@ export function createDataImportFeature(options: {
 
     // Results Table Container
     const resultsContainer = doc.createElement('div');
-    resultsContainer.style.cssText = 'display: none; border: 1px solid #d8dde6; border-radius: 4px; overflow: auto; max-height: 250px;';
+    resultsContainer.style.cssText = 'display: none; border: 1px solid var(--sfdt-color-border); border-radius: 4px; overflow: auto; max-height: 250px;';
     const resultsTable = doc.createElement('table');
     resultsTable.style.cssText = 'width: 100%; border-collapse: collapse; font-size: 11px; text-align: left;';
     const resultsTHead = doc.createElement('thead');
@@ -351,7 +351,7 @@ export function createDataImportFeature(options: {
     for (const hCol of headerCols) {
       const th = doc.createElement('th');
       th.textContent = hCol;
-      th.style.cssText = 'padding: 6px 10px; background: #fafaf9; border-bottom: 1px solid #d8dde6; font-weight: 600; position: sticky; top: 0; z-index: 1;';
+      th.style.cssText = 'padding: 6px 10px; background: var(--sfdt-color-surface-alt); border-bottom: 1px solid var(--sfdt-color-border); font-weight: 600; position: sticky; top: 0; z-index: 1;';
       headTr.appendChild(th);
     }
     resultsTHead.appendChild(headTr);
@@ -549,14 +549,14 @@ export function createDataImportFeature(options: {
 
       headers.forEach((h, idx) => {
         const colDiv = doc.createElement('div');
-        colDiv.style.cssText = 'display: flex; flex-direction: column; gap: 2px; border: 1px solid #f3f3f3; padding: 6px; border-radius: 4px; background: #fafaf9;';
+        colDiv.style.cssText = 'display: flex; flex-direction: column; gap: 2px; border: 1px solid var(--sfdt-color-bg); padding: 6px; border-radius: 4px; background: var(--sfdt-color-surface-alt);';
         
         const headerLabel = doc.createElement('span');
         headerLabel.textContent = h;
         headerLabel.style.cssText = 'font-weight: 600; font-size: 11px; text-overflow: ellipsis; overflow: hidden; white-space: nowrap;';
         
         const select = doc.createElement('select');
-        select.style.cssText = 'padding: 4px; font-size: 11px; border: 1px solid #d8dde6; border-radius: 4px; outline: none;';
+        select.style.cssText = 'padding: 4px; font-size: 11px; border: 1px solid var(--sfdt-color-border); border-radius: 4px; outline: none;';
         
         const optSkip = doc.createElement('option');
         optSkip.value = '';
@@ -674,34 +674,34 @@ export function createDataImportFeature(options: {
       const slice = importRows.slice(0, 1000);
       for (const row of slice) {
         const tr = doc.createElement('tr');
-        tr.style.cssText = 'border-bottom: 1px solid #f3f3f3;';
+        tr.style.cssText = 'border-bottom: 1px solid var(--sfdt-color-bg);';
         if (row.status === 'Succeeded') {
-          tr.style.background = '#f4fbf7';
+          tr.style.background = 'var(--sfdt-color-success-bg-2)';
         } else if (row.status === 'Failed') {
-          tr.style.background = '#fdf3f2';
+          tr.style.background = 'var(--sfdt-color-error-bg-2)';
         }
 
         const tdIndex = doc.createElement('td');
         tdIndex.textContent = String(row.index);
-        tdIndex.style.cssText = 'padding: 6px 10px; font-weight: bold; color: #54698d;';
+        tdIndex.style.cssText = 'padding: 6px 10px; font-weight: bold; color: var(--sfdt-color-text-weak);';
 
         const tdStatus = doc.createElement('td');
         tdStatus.textContent = row.status;
         tdStatus.style.cssText = 'padding: 6px 10px; font-weight: 600;';
-        if (row.status === 'Succeeded') tdStatus.style.color = '#04844b';
-        else if (row.status === 'Failed') tdStatus.style.color = '#c23934';
-        else if (row.status === 'Processing') tdStatus.style.color = '#0070d2';
+        if (row.status === 'Succeeded') tdStatus.style.color = 'var(--sfdt-color-success)';
+        else if (row.status === 'Failed') tdStatus.style.color = 'var(--sfdt-color-error)';
+        else if (row.status === 'Processing') tdStatus.style.color = 'var(--sfdt-color-brand)';
 
         const tdAction = doc.createElement('td');
         tdAction.textContent = row.action || '-';
-        tdAction.style.cssText = 'padding: 6px 10px; color: #54698d;';
+        tdAction.style.cssText = 'padding: 6px 10px; color: var(--sfdt-color-text-weak);';
 
         const tdId = doc.createElement('td');
         tdId.style.cssText = 'padding: 6px 10px;';
         if (row.resultId) {
           const idLink = doc.createElement('span');
           idLink.textContent = row.resultId;
-          idLink.style.cssText = 'color: #0070d2; text-decoration: underline; cursor: pointer;';
+          idLink.style.cssText = 'color: var(--sfdt-color-brand); text-decoration: underline; cursor: pointer;';
           idLink.addEventListener('click', () => {
             // open view-all-data or inspect-record
             // Just copy it or open a link
@@ -716,7 +716,7 @@ export function createDataImportFeature(options: {
         tdErrors.textContent = row.errors || '-';
         tdErrors.style.cssText = 'padding: 6px 10px;';
         if (row.errors) {
-          tdErrors.style.color = '#c23934';
+          tdErrors.style.color = 'var(--sfdt-color-error)';
           tdErrors.style.fontWeight = '500';
         }
 
@@ -733,7 +733,7 @@ export function createDataImportFeature(options: {
         const td = doc.createElement('td');
         td.colSpan = 5;
         td.textContent = `... and ${importRows.length - 1000} more rows (errors will still download completely) ...`;
-        td.style.cssText = 'padding: 8px; text-align: center; color: #80868d; font-style: italic; background: #fafaf9;';
+        td.style.cssText = 'padding: 8px; text-align: center; color: var(--sfdt-color-text-icon); font-style: italic; background: var(--sfdt-color-surface-alt);';
         tr.appendChild(td);
         resultsTBody.appendChild(tr);
       }

--- a/extension/features/debug-log-viewer.ts
+++ b/extension/features/debug-log-viewer.ts
@@ -80,11 +80,11 @@ export function createDebugLogViewerFeature(options: DebugLogViewerOptions = {})
     const toolbar = doc.createElement('div');
     toolbar.style.cssText = 'display: flex; align-items: center; gap: 10px;';
     const status = doc.createElement('div');
-    status.style.cssText = 'font-size: 12px; color: #54698d;';
+    status.style.cssText = 'font-size: 12px; color: var(--sfdt-color-text-weak);';
     const refreshBtn = doc.createElement('button');
     refreshBtn.textContent = '↻ Refresh';
     refreshBtn.style.cssText =
-      'margin-left: auto; padding: 4px 10px; border: 1px solid #d8dde6; background: #fff; border-radius: 4px; cursor: pointer; font-size: 12px;';
+      'margin-left: auto; padding: 4px 10px; border: 1px solid var(--sfdt-color-border); background: var(--sfdt-color-surface); border-radius: 4px; cursor: pointer; font-size: 12px;';
     toolbar.appendChild(status);
     toolbar.appendChild(refreshBtn);
     body.appendChild(toolbar);
@@ -95,7 +95,7 @@ export function createDebugLogViewerFeature(options: DebugLogViewerOptions = {})
 
     const logPane = doc.createElement('pre');
     logPane.style.cssText =
-      'margin: 0; padding: 10px; background: #1e1e1e; color: #d4d4d4; border-radius: 4px; overflow: auto; max-height: 360px; font-family: ui-monospace, monospace; font-size: 11px; display: none; white-space: pre-wrap;';
+      'margin: 0; padding: 10px; background: var(--sfdt-color-code-bg); color: var(--sfdt-color-border-3); border-radius: 4px; overflow: auto; max-height: 360px; font-family: ui-monospace, monospace; font-size: 11px; display: none; white-space: pre-wrap;';
     body.appendChild(logPane);
 
     view = presentView({
@@ -124,7 +124,7 @@ export function createDebugLogViewerFeature(options: DebugLogViewerOptions = {})
         status.textContent = `${result.records.length} log${result.records.length === 1 ? '' : 's'}`;
         if (result.records.length === 0) {
           const empty = doc.createElement('div');
-          empty.style.cssText = 'color: #80868d; font-size: 12px; padding: 8px;';
+          empty.style.cssText = 'color: var(--sfdt-color-text-icon); font-size: 12px; padding: 8px;';
           empty.textContent = 'No debug logs. Enable a trace flag in Setup to capture some.';
           table.appendChild(empty);
           return;
@@ -132,10 +132,10 @@ export function createDebugLogViewerFeature(options: DebugLogViewerOptions = {})
         for (const row of result.records) {
           const item = doc.createElement('div');
           item.style.cssText =
-            'display: flex; gap: 10px; padding: 6px 8px; border-bottom: 1px solid #f3f3f3; cursor: pointer; font-size: 12px; align-items: center;';
+            'display: flex; gap: 10px; padding: 6px 8px; border-bottom: 1px solid var(--sfdt-color-bg); cursor: pointer; font-size: 12px; align-items: center;';
           const time = doc.createElement('span');
           time.textContent = new Date(row.StartTime).toLocaleString();
-          time.style.cssText = 'min-width: 170px; color: #54698d;';
+          time.style.cssText = 'min-width: 170px; color: var(--sfdt-color-text-weak);';
           const user = doc.createElement('span');
           user.textContent = row.LogUser?.Name ?? '—';
           user.style.cssText = 'min-width: 140px;';
@@ -147,7 +147,7 @@ export function createDebugLogViewerFeature(options: DebugLogViewerOptions = {})
           status2.style.cssText = 'min-width: 90px;';
           const size = doc.createElement('span');
           size.textContent = formatBytes(row.LogLength);
-          size.style.cssText = 'min-width: 70px; text-align: right; color: #80868d;';
+          size.style.cssText = 'min-width: 70px; text-align: right; color: var(--sfdt-color-text-icon);';
           item.appendChild(time);
           item.appendChild(user);
           item.appendChild(op);
@@ -160,7 +160,7 @@ export function createDebugLogViewerFeature(options: DebugLogViewerOptions = {})
         status.textContent = '';
         const errPanel = doc.createElement('div');
         errPanel.style.cssText =
-          'border: 1px solid #c23934; background: #fef2f1; color: #c23934; padding: 8px 12px; border-radius: 4px; font-size: 13px;';
+          'border: 1px solid var(--sfdt-color-error); background: var(--sfdt-color-error-bg); color: var(--sfdt-color-error); padding: 8px 12px; border-radius: 4px; font-size: 13px;';
         errPanel.textContent = err instanceof Error ? err.message : String(err);
         table.appendChild(errPanel);
       }

--- a/extension/features/dependency-explorer.ts
+++ b/extension/features/dependency-explorer.ts
@@ -49,7 +49,7 @@ export function createDependencyExplorerFeature(
   function typeBadge(type: string): HTMLElement {
     const badge = doc.createElement('span');
     badge.style.cssText =
-      'display: inline-block; padding: 1px 7px; border-radius: 10px; background: #eef1f6; color: #54698d; font-size: 11px; font-weight: 600; white-space: nowrap;';
+      'display: inline-block; padding: 1px 7px; border-radius: 10px; background: var(--sfdt-color-surface-shade-5); color: var(--sfdt-color-text-weak); font-size: 11px; font-weight: 600; white-space: nowrap;';
     badge.textContent = type;
     return badge;
   }
@@ -61,13 +61,13 @@ export function createDependencyExplorerFeature(
     const count = groups.reduce((n, g) => n + g.names.length, 0);
     const heading = doc.createElement('div');
     heading.style.cssText =
-      'font-weight: 600; font-size: 13px; margin-bottom: 8px; border-bottom: 1px solid #d8dde6; padding-bottom: 4px;';
+      'font-weight: 600; font-size: 13px; margin-bottom: 8px; border-bottom: 1px solid var(--sfdt-color-border); padding-bottom: 4px;';
     heading.textContent = `${title} (${count})`;
     section.appendChild(heading);
 
     if (count === 0) {
       const empty = doc.createElement('div');
-      empty.style.cssText = 'padding: 6px 0; color: #80868d; font-size: 12px;';
+      empty.style.cssText = 'padding: 6px 0; color: var(--sfdt-color-text-icon); font-size: 12px;';
       empty.textContent = 'None.';
       section.appendChild(empty);
       return section;
@@ -107,7 +107,7 @@ export function createDependencyExplorerFeature(
       if (!id) {
         status.textContent = '';
         const msg = doc.createElement('div');
-        msg.style.cssText = 'padding: 12px; color: #80868d;';
+        msg.style.cssText = 'padding: 12px; color: var(--sfdt-color-text-icon);';
         msg.textContent = `No ${type} named "${name.trim()}" found in this org.`;
         results.appendChild(msg);
         return;
@@ -118,7 +118,7 @@ export function createDependencyExplorerFeature(
       if (type === 'CustomField' && resolved.records.length > 1) {
         const note = doc.createElement('div');
         note.style.cssText =
-          'padding: 8px 12px; margin-bottom: 6px; background: #fff8e5; border: 1px solid #f4d27a; border-radius: 4px; font-size: 12px; color: #6b5a1f;';
+          'padding: 8px 12px; margin-bottom: 6px; background: var(--sfdt-color-warning-bg); border: 1px solid var(--sfdt-color-warning-border); border-radius: 4px; font-size: 12px; color: var(--sfdt-color-warning-text-2);';
         note.textContent = `${resolved.records.length} fields share this name — showing dependencies for the first match (${id}).`;
         results.appendChild(note);
       }
@@ -135,7 +135,7 @@ export function createDependencyExplorerFeature(
 
       if (refs.records.length === 0 && refBy.records.length === 0) {
         const empty = doc.createElement('div');
-        empty.style.cssText = 'padding: 12px; color: #80868d;';
+        empty.style.cssText = 'padding: 12px; color: var(--sfdt-color-text-icon);';
         empty.textContent = 'No metadata dependencies recorded for this component.';
         results.appendChild(empty);
         return;
@@ -146,7 +146,7 @@ export function createDependencyExplorerFeature(
     } catch (err) {
       const errorPanel = doc.createElement('div');
       errorPanel.style.cssText =
-        'border: 1px solid #c23934; background: #fef2f1; color: #c23934; padding: 8px 12px; border-radius: 4px; font-size: 13px;';
+        'border: 1px solid var(--sfdt-color-error); background: var(--sfdt-color-error-bg); color: var(--sfdt-color-error); padding: 8px 12px; border-radius: 4px; font-size: 13px;';
       errorPanel.textContent = err instanceof Error ? err.message : String(err);
       results.appendChild(errorPanel);
       status.textContent = 'Failed';
@@ -169,11 +169,11 @@ export function createDependencyExplorerFeature(
     nameInput.type = 'text';
     nameInput.placeholder = 'Component name';
     nameInput.style.cssText =
-      'flex: 1; min-width: 180px; padding: 5px 8px; border: 1px solid #d8dde6; border-radius: 4px; font-size: 13px;';
+      'flex: 1; min-width: 180px; padding: 5px 8px; border: 1px solid var(--sfdt-color-border); border-radius: 4px; font-size: 13px;';
 
     const typeSelect = doc.createElement('select');
     typeSelect.style.cssText =
-      'padding: 5px 8px; border: 1px solid #d8dde6; border-radius: 4px; font-size: 13px;';
+      'padding: 5px 8px; border: 1px solid var(--sfdt-color-border); border-radius: 4px; font-size: 13px;';
     for (const t of METADATA_TYPES) {
       const opt = doc.createElement('option');
       opt.value = t;
@@ -184,10 +184,10 @@ export function createDependencyExplorerFeature(
     const findBtn = doc.createElement('button');
     findBtn.textContent = 'Find';
     findBtn.style.cssText =
-      'padding: 5px 14px; border: 1px solid #0070d2; background: #0070d2; color: #fff; border-radius: 4px; cursor: pointer; font-size: 13px;';
+      'padding: 5px 14px; border: 1px solid var(--sfdt-color-brand); background: var(--sfdt-color-brand); color: var(--sfdt-color-surface); border-radius: 4px; cursor: pointer; font-size: 13px;';
 
     const status = doc.createElement('span');
-    status.style.cssText = 'color: #54698d; font-size: 12px; margin-left: 4px;';
+    status.style.cssText = 'color: var(--sfdt-color-text-weak); font-size: 12px; margin-left: 4px;';
 
     searchRow.append(nameInput, typeSelect, findBtn, status);
     body.appendChild(searchRow);

--- a/extension/features/event-monitor.ts
+++ b/extension/features/event-monitor.ts
@@ -352,18 +352,18 @@ export function createEventMonitorFeature(options: {
     if (filtered.length === 0) {
       const empty = doc.createElement('div');
       empty.textContent = 'No events received yet';
-      empty.style.cssText = 'padding: 12px; color: #80868d; font-size: 13px; text-align: center;';
+      empty.style.cssText = 'padding: 12px; color: var(--sfdt-color-text-icon); font-size: 13px; text-align: center;';
       eventListContainer.appendChild(empty);
       return;
     }
 
     filtered.forEach((e) => {
       const item = doc.createElement('div');
-      item.style.cssText = 'padding: 8px; border-bottom: 1px solid #d8dde6; cursor: pointer; font-family: monospace; font-size: 11px; white-space: pre-wrap;';
+      item.style.cssText = 'padding: 8px; border-bottom: 1px solid var(--sfdt-color-border); cursor: pointer; font-family: monospace; font-size: 11px; white-space: pre-wrap;';
       
       if (selectedEvent === e) {
-        item.style.background = '#f3f3f3';
-        item.style.borderLeft = '3px solid #0070d2';
+        item.style.background = 'var(--sfdt-color-bg)';
+        item.style.borderLeft = '3px solid var(--sfdt-color-brand)';
       }
 
       item.textContent = JSON.stringify(e, null, 2);
@@ -407,7 +407,7 @@ export function createEventMonitorFeature(options: {
           const limit = res[k]!;
           const percentage = ((limit.Max - limit.Remaining) / limit.Max * 100).toFixed(1);
           const p = doc.createElement('p');
-          p.style.cssText = 'margin: 4px 0; font-size: 12px; color: #3e3e3c;';
+          p.style.cssText = 'margin: 4px 0; font-size: 12px; color: var(--sfdt-color-text);';
           p.textContent = `${k}: Remaining ${limit.Remaining} out of ${limit.Max} (${percentage}% consumed)`;
           limitsContainer!.appendChild(p);
         });
@@ -422,7 +422,7 @@ export function createEventMonitorFeature(options: {
   function updateStatus(status: string, isError: boolean): void {
     if (statusLabel) {
       statusLabel.textContent = status;
-      statusLabel.style.color = isError ? '#c23934' : '#54698d';
+      statusLabel.style.color = isError ? 'var(--sfdt-color-error)' : 'var(--sfdt-color-text-weak)';
     }
   }
 
@@ -435,16 +435,16 @@ export function createEventMonitorFeature(options: {
 
     // Filter Config Row
     const configRow = doc.createElement('div');
-    configRow.style.cssText = 'display: grid; grid-template-columns: 1.5fr 1fr 1.5fr 100px; gap: 8px; border-bottom: 1px solid #e0e0e0; padding-bottom: 16px;';
+    configRow.style.cssText = 'display: grid; grid-template-columns: 1.5fr 1fr 1.5fr 100px; gap: 8px; border-bottom: 1px solid var(--sfdt-color-border-2); padding-bottom: 16px;';
     body.appendChild(configRow);
 
     const typeDiv = doc.createElement('div');
     typeDiv.style.cssText = 'display: flex; flex-direction: column; gap: 4px;';
     const typeLabel = doc.createElement('label');
     typeLabel.textContent = 'Channel Type';
-    typeLabel.style.cssText = 'font-size: 11px; font-weight: 600; color: #54698d;';
+    typeLabel.style.cssText = 'font-size: 11px; font-weight: 600; color: var(--sfdt-color-text-weak);';
     const typeSelect = doc.createElement('select');
-    typeSelect.style.cssText = 'padding: 6px; border: 1px solid #d8dde6; border-radius: 4px; font-size: 13px; outline: none;';
+    typeSelect.style.cssText = 'padding: 6px; border: 1px solid var(--sfdt-color-border); border-radius: 4px; font-size: 13px; outline: none;';
     [
       { v: 'platformEvent', l: 'Custom Platform Event' },
       { v: 'standardPlatformEvent', l: 'Standard Platform Event' },
@@ -464,9 +464,9 @@ export function createEventMonitorFeature(options: {
     nameDiv.style.cssText = 'display: flex; flex-direction: column; gap: 4px;';
     const nameLabel = doc.createElement('label');
     nameLabel.textContent = 'Channel Name';
-    nameLabel.style.cssText = 'font-size: 11px; font-weight: 600; color: #54698d;';
+    nameLabel.style.cssText = 'font-size: 11px; font-weight: 600; color: var(--sfdt-color-text-weak);';
     channelSelect = doc.createElement('select');
-    channelSelect.style.cssText = 'padding: 6px; border: 1px solid #d8dde6; border-radius: 4px; font-size: 13px; outline: none;';
+    channelSelect.style.cssText = 'padding: 6px; border: 1px solid var(--sfdt-color-border); border-radius: 4px; font-size: 13px; outline: none;';
     nameDiv.appendChild(nameLabel);
     nameDiv.appendChild(channelSelect);
     configRow.appendChild(nameDiv);
@@ -475,11 +475,11 @@ export function createEventMonitorFeature(options: {
     customDiv.style.cssText = 'display: flex; flex-direction: column; gap: 4px;';
     const customLabel = doc.createElement('label');
     customLabel.textContent = 'Or Custom Channel Path';
-    customLabel.style.cssText = 'font-size: 11px; font-weight: 600; color: #54698d;';
+    customLabel.style.cssText = 'font-size: 11px; font-weight: 600; color: var(--sfdt-color-text-weak);';
     const customInput = doc.createElement('input');
     customInput.type = 'text';
     customInput.placeholder = '/event/MyCustomEvent__e';
-    customInput.style.cssText = 'padding: 6px; border: 1px solid #d8dde6; border-radius: 4px; font-size: 13px; outline: none;';
+    customInput.style.cssText = 'padding: 6px; border: 1px solid var(--sfdt-color-border); border-radius: 4px; font-size: 13px; outline: none;';
     customInput.addEventListener('input', () => {
       customChannelPath = customInput.value.trim();
     });
@@ -491,11 +491,11 @@ export function createEventMonitorFeature(options: {
     replayDiv.style.cssText = 'display: flex; flex-direction: column; gap: 4px;';
     const replayLabel = doc.createElement('label');
     replayLabel.textContent = 'Replay From';
-    replayLabel.style.cssText = 'font-size: 11px; font-weight: 600; color: #54698d;';
+    replayLabel.style.cssText = 'font-size: 11px; font-weight: 600; color: var(--sfdt-color-text-weak);';
     const replayInput = doc.createElement('input');
     replayInput.type = 'number';
     replayInput.value = '-1';
-    replayInput.style.cssText = 'padding: 6px; border: 1px solid #d8dde6; border-radius: 4px; font-size: 13px; outline: none;';
+    replayInput.style.cssText = 'padding: 6px; border: 1px solid var(--sfdt-color-border); border-radius: 4px; font-size: 13px; outline: none;';
     replayInput.addEventListener('change', () => {
       replayId = parseInt(replayInput.value, 10) || -1;
     });
@@ -521,20 +521,20 @@ export function createEventMonitorFeature(options: {
 
     const subscribeBtn = doc.createElement('button');
     subscribeBtn.textContent = 'Subscribe';
-    subscribeBtn.style.cssText = 'padding: 6px 16px; background: #0070d2; color: #fff; border: 0; border-radius: 4px; cursor: pointer; font-size: 13px; font-weight: 600;';
+    subscribeBtn.style.cssText = 'padding: 6px 16px; background: var(--sfdt-color-brand); color: var(--sfdt-color-surface); border: 0; border-radius: 4px; cursor: pointer; font-size: 13px; font-weight: 600;';
     
     const unsubscribeBtn = doc.createElement('button');
     unsubscribeBtn.textContent = 'Unsubscribe';
     unsubscribeBtn.disabled = true;
-    unsubscribeBtn.style.cssText = 'padding: 6px 16px; border: 1px solid #d8dde6; border-radius: 4px; background: #fff; cursor: pointer; font-size: 13px; color: #3e3e3c;';
+    unsubscribeBtn.style.cssText = 'padding: 6px 16px; border: 1px solid var(--sfdt-color-border); border-radius: 4px; background: var(--sfdt-color-surface); cursor: pointer; font-size: 13px; color: var(--sfdt-color-text);';
 
     statusLabel = doc.createElement('span');
-    statusLabel.style.cssText = 'font-size: 12px; color: #54698d; margin-left: 8px;';
+    statusLabel.style.cssText = 'font-size: 12px; color: var(--sfdt-color-text-weak); margin-left: 8px;';
     statusLabel.textContent = 'Ready to stream';
 
     const limitsBtn = doc.createElement('button');
     limitsBtn.textContent = 'Limits Metrics';
-    limitsBtn.style.cssText = 'padding: 6px 12px; border: 1px solid #d8dde6; border-radius: 4px; background: #fff; cursor: pointer; font-size: 12px; color: #54698d; margin-left: auto;';
+    limitsBtn.style.cssText = 'padding: 6px 12px; border: 1px solid var(--sfdt-color-border); border-radius: 4px; background: var(--sfdt-color-surface); cursor: pointer; font-size: 12px; color: var(--sfdt-color-text-weak); margin-left: auto;';
     limitsBtn.addEventListener('click', () => {
       void toggleMetrics();
     });
@@ -546,7 +546,7 @@ export function createEventMonitorFeature(options: {
 
     // Limits pane
     limitsContainer = doc.createElement('div');
-    limitsContainer.style.cssText = 'display: none; padding: 10px; background: #fef8f3; border: 1px solid #fe9339; border-radius: 4px; margin-bottom: 8px;';
+    limitsContainer.style.cssText = 'display: none; padding: 10px; background: var(--sfdt-color-warning-bg-4); border: 1px solid var(--sfdt-color-warning); border-radius: 4px; margin-bottom: 8px;';
     body.appendChild(limitsContainer);
 
     subscribeBtn.addEventListener('click', async () => {
@@ -612,22 +612,22 @@ export function createEventMonitorFeature(options: {
 
     // Left List Pane
     const listWrap = doc.createElement('div');
-    listWrap.style.cssText = 'flex: 1; display: flex; flex-direction: column; border: 1px solid #d8dde6; border-radius: 4px; overflow: hidden;';
+    listWrap.style.cssText = 'flex: 1; display: flex; flex-direction: column; border: 1px solid var(--sfdt-color-border); border-radius: 4px; overflow: hidden;';
     contentRow.appendChild(listWrap);
 
     const listBar = doc.createElement('div');
-    listBar.style.cssText = 'background: #fafaf9; border-bottom: 1px solid #d8dde6; padding: 6px 12px; display: flex; align-items: center; justify-content: space-between;';
+    listBar.style.cssText = 'background: var(--sfdt-color-surface-alt); border-bottom: 1px solid var(--sfdt-color-border); padding: 6px 12px; display: flex; align-items: center; justify-content: space-between;';
     const filterInput = doc.createElement('input');
     filterInput.type = 'text';
     filterInput.placeholder = 'Filter events...';
-    filterInput.style.cssText = 'padding: 4px 6px; border: 1px solid #d8dde6; border-radius: 4px; font-size: 12px; width: 150px;';
+    filterInput.style.cssText = 'padding: 4px 6px; border: 1px solid var(--sfdt-color-border); border-radius: 4px; font-size: 12px; width: 150px;';
     filterInput.addEventListener('input', () => {
       eventFilter = filterInput.value.toLowerCase();
       renderEvents();
     });
     const clearEventsBtn = doc.createElement('button');
     clearEventsBtn.textContent = 'Clear';
-    clearEventsBtn.style.cssText = 'padding: 4px 10px; border: 1px solid #d8dde6; border-radius: 4px; background: #fff; font-size: 11px; cursor: pointer; color: #54698d;';
+    clearEventsBtn.style.cssText = 'padding: 4px 10px; border: 1px solid var(--sfdt-color-border); border-radius: 4px; background: var(--sfdt-color-surface); font-size: 11px; cursor: pointer; color: var(--sfdt-color-text-weak);';
     clearEventsBtn.addEventListener('click', () => {
       events.length = 0;
       selectedEvent = null;
@@ -640,22 +640,22 @@ export function createEventMonitorFeature(options: {
     listWrap.appendChild(listBar);
 
     eventListContainer = doc.createElement('div');
-    eventListContainer.style.cssText = 'flex: 1; overflow-y: auto; background: #fff;';
+    eventListContainer.style.cssText = 'flex: 1; overflow-y: auto; background: var(--sfdt-color-surface);';
     listWrap.appendChild(eventListContainer);
 
     // Right Details Inspector Pane
     const detailsWrap = doc.createElement('div');
-    detailsWrap.style.cssText = 'width: 400px; display: flex; flex-direction: column; border: 1px solid #d8dde6; border-radius: 4px; overflow: hidden;';
+    detailsWrap.style.cssText = 'width: 400px; display: flex; flex-direction: column; border: 1px solid var(--sfdt-color-border); border-radius: 4px; overflow: hidden;';
     contentRow.appendChild(detailsWrap);
 
     const detailsBar = doc.createElement('div');
-    detailsBar.style.cssText = 'background: #fafaf9; border-bottom: 1px solid #d8dde6; padding: 6px 12px; display: flex; align-items: center; justify-content: space-between;';
+    detailsBar.style.cssText = 'background: var(--sfdt-color-surface-alt); border-bottom: 1px solid var(--sfdt-color-border); padding: 6px 12px; display: flex; align-items: center; justify-content: space-between;';
     const detailsTitle = doc.createElement('span');
     detailsTitle.textContent = 'Event Details';
-    detailsTitle.style.cssText = 'font-size: 12px; font-weight: 600; color: #3e3e3c;';
+    detailsTitle.style.cssText = 'font-size: 12px; font-weight: 600; color: var(--sfdt-color-text);';
     const copyJsonBtn = doc.createElement('button');
     copyJsonBtn.textContent = 'Copy JSON';
-    copyJsonBtn.style.cssText = 'padding: 4px 10px; border: 1px solid #d8dde6; border-radius: 4px; background: #fff; font-size: 11px; cursor: pointer; color: #54698d;';
+    copyJsonBtn.style.cssText = 'padding: 4px 10px; border: 1px solid var(--sfdt-color-border); border-radius: 4px; background: var(--sfdt-color-surface); font-size: 11px; cursor: pointer; color: var(--sfdt-color-text-weak);';
     copyJsonBtn.addEventListener('click', () => {
       if (selectedEvent) {
         void win.navigator.clipboard.writeText(JSON.stringify(selectedEvent, null, 2));
@@ -668,7 +668,7 @@ export function createEventMonitorFeature(options: {
     detailsWrap.appendChild(detailsBar);
 
     detailsPane = doc.createElement('pre');
-    detailsPane.style.cssText = 'flex: 1; overflow-y: auto; margin: 0; padding: 10px; background: #fafaf9; font-family: monospace; font-size: 11px; color: #16325c; white-space: pre-wrap; word-break: break-all;';
+    detailsPane.style.cssText = 'flex: 1; overflow-y: auto; margin: 0; padding: 10px; background: var(--sfdt-color-surface-alt); font-family: monospace; font-size: 11px; color: var(--sfdt-color-brand-deep); white-space: pre-wrap; word-break: break-all;';
     detailsWrap.appendChild(detailsPane);
 
     renderEvents();

--- a/extension/features/field-creator.ts
+++ b/extension/features/field-creator.ts
@@ -137,16 +137,16 @@ export function createFieldCreatorFeature(options: {
 
     // Top Controls
     const topRow = doc.createElement('div');
-    topRow.style.cssText = 'display: flex; gap: 16px; align-items: center; border-bottom: 1px solid #e0e0e0; padding-bottom: 16px;';
+    topRow.style.cssText = 'display: flex; gap: 16px; align-items: center; border-bottom: 1px solid var(--sfdt-color-border-2); padding-bottom: 16px;';
     body.appendChild(topRow);
 
     const sobjDiv = doc.createElement('div');
     sobjDiv.style.cssText = 'display: flex; flex-direction: column; gap: 4px; min-width: 250px;';
     const sobjLabel = doc.createElement('label');
     sobjLabel.textContent = 'Select Target SObject';
-    sobjLabel.style.cssText = 'font-size: 11px; font-weight: 600; color: #54698d;';
+    sobjLabel.style.cssText = 'font-size: 11px; font-weight: 600; color: var(--sfdt-color-text-weak);';
     const sobjSelect = doc.createElement('select');
-    sobjSelect.style.cssText = 'padding: 6px; border: 1px solid #d8dde6; border-radius: 4px; font-size: 13px; outline: none;';
+    sobjSelect.style.cssText = 'padding: 6px; border: 1px solid var(--sfdt-color-border); border-radius: 4px; font-size: 13px; outline: none;';
     sobjDiv.appendChild(sobjLabel);
     sobjDiv.appendChild(sobjSelect);
     topRow.appendChild(sobjDiv);
@@ -157,13 +157,13 @@ export function createFieldCreatorFeature(options: {
 
     const addFieldBtn = doc.createElement('button');
     addFieldBtn.textContent = '➕ Add Field';
-    addFieldBtn.style.cssText = 'padding: 6px 12px; background: #fff; color: #0070d2; border: 1px solid #d8dde6; border-radius: 4px; cursor: pointer; font-size: 12px; font-weight: 600;';
+    addFieldBtn.style.cssText = 'padding: 6px 12px; background: var(--sfdt-color-surface); color: var(--sfdt-color-brand); border: 1px solid var(--sfdt-color-border); border-radius: 4px; cursor: pointer; font-size: 12px; font-weight: 600;';
     const permAllBtn = doc.createElement('button');
     permAllBtn.textContent = '🔒 Permissions for All';
-    permAllBtn.style.cssText = 'padding: 6px 12px; background: #fff; color: #54698d; border: 1px solid #d8dde6; border-radius: 4px; cursor: pointer; font-size: 12px; font-weight: 600;';
+    permAllBtn.style.cssText = 'padding: 6px 12px; background: var(--sfdt-color-surface); color: var(--sfdt-color-text-weak); border: 1px solid var(--sfdt-color-border); border-radius: 4px; cursor: pointer; font-size: 12px; font-weight: 600;';
     const clearBtn = doc.createElement('button');
     clearBtn.textContent = '🗑 Clear All';
-    clearBtn.style.cssText = 'padding: 6px 12px; background: #fff; color: #c23934; border: 1px solid #c23934; border-radius: 4px; cursor: pointer; font-size: 12px; font-weight: 600;';
+    clearBtn.style.cssText = 'padding: 6px 12px; background: var(--sfdt-color-surface); color: var(--sfdt-color-error); border: 1px solid var(--sfdt-color-error); border-radius: 4px; cursor: pointer; font-size: 12px; font-weight: 600;';
 
     buttonGroup.appendChild(addFieldBtn);
     buttonGroup.appendChild(permAllBtn);
@@ -171,7 +171,7 @@ export function createFieldCreatorFeature(options: {
 
     // Table Container
     const tableContainer = doc.createElement('div');
-    tableContainer.style.cssText = 'border: 1px solid #d8dde6; border-radius: 4px; overflow: auto; max-height: 40vh;';
+    tableContainer.style.cssText = 'border: 1px solid var(--sfdt-color-border); border-radius: 4px; overflow: auto; max-height: 40vh;';
     body.appendChild(tableContainer);
 
     const table = doc.createElement('table');
@@ -182,7 +182,7 @@ export function createFieldCreatorFeature(options: {
     for (const c of cols) {
       const th = doc.createElement('th');
       th.textContent = c;
-      th.style.cssText = 'padding: 8px 12px; background: #fafaf9; border-bottom: 1px solid #d8dde6; font-weight: 600; position: sticky; top: 0; z-index: 1;';
+      th.style.cssText = 'padding: 8px 12px; background: var(--sfdt-color-surface-alt); border-bottom: 1px solid var(--sfdt-color-border); font-weight: 600; position: sticky; top: 0; z-index: 1;';
       headTr.appendChild(th);
     }
     thead.appendChild(headTr);
@@ -194,12 +194,12 @@ export function createFieldCreatorFeature(options: {
 
     // Bottom Action Row
     const actionRow = doc.createElement('div');
-    actionRow.style.cssText = 'display: flex; gap: 10px; justify-content: flex-end; align-items: center; border-top: 1px solid #e0e0e0; padding-top: 16px;';
+    actionRow.style.cssText = 'display: flex; gap: 10px; justify-content: flex-end; align-items: center; border-top: 1px solid var(--sfdt-color-border-2); padding-top: 16px;';
     body.appendChild(actionRow);
 
     const deployBtn = doc.createElement('button');
     deployBtn.textContent = 'Deploy Fields';
-    deployBtn.style.cssText = 'padding: 8px 20px; background: #04844b; color: #fff; border: 0; border-radius: 4px; cursor: pointer; font-size: 13px; font-weight: 600;';
+    deployBtn.style.cssText = 'padding: 8px 20px; background: var(--sfdt-color-success); color: var(--sfdt-color-surface); border: 0; border-radius: 4px; cursor: pointer; font-size: 13px; font-weight: 600;';
     deployBtn.disabled = true;
     actionRow.appendChild(deployBtn);
 
@@ -275,7 +275,7 @@ export function createFieldCreatorFeature(options: {
 
       fields.forEach((field, idx) => {
         const tr = doc.createElement('tr');
-        tr.style.cssText = 'border-bottom: 1px solid #f3f3f3;';
+        tr.style.cssText = 'border-bottom: 1px solid var(--sfdt-color-bg);';
 
         // Actions
         const tdActions = doc.createElement('td');
@@ -311,7 +311,7 @@ export function createFieldCreatorFeature(options: {
         labelInput.type = 'text';
         labelInput.value = field.label;
         labelInput.placeholder = 'Field Label...';
-        labelInput.style.cssText = 'width: 140px; padding: 4px 6px; border: 1px solid #d8dde6; border-radius: 4px; font-size: 12px;';
+        labelInput.style.cssText = 'width: 140px; padding: 4px 6px; border: 1px solid var(--sfdt-color-border); border-radius: 4px; font-size: 12px;';
         labelInput.addEventListener('input', () => {
           field.label = labelInput.value;
           field.name = formatApiName(labelInput.value);
@@ -327,7 +327,7 @@ export function createFieldCreatorFeature(options: {
         nameInput.type = 'text';
         nameInput.value = field.name;
         nameInput.placeholder = 'Developer_Name';
-        nameInput.style.cssText = 'width: 140px; padding: 4px 6px; border: 1px solid #d8dde6; border-radius: 4px; font-size: 12px;';
+        nameInput.style.cssText = 'width: 140px; padding: 4px 6px; border: 1px solid var(--sfdt-color-border); border-radius: 4px; font-size: 12px;';
         nameInput.addEventListener('input', () => {
           field.name = nameInput.value;
           validateReady();
@@ -338,7 +338,7 @@ export function createFieldCreatorFeature(options: {
         const tdType = doc.createElement('td');
         tdType.style.cssText = 'padding: 8px 12px;';
         const typeSelect = doc.createElement('select');
-        typeSelect.style.cssText = 'padding: 4px 6px; border: 1px solid #d8dde6; border-radius: 4px; font-size: 12px;';
+        typeSelect.style.cssText = 'padding: 4px 6px; border: 1px solid var(--sfdt-color-border); border-radius: 4px; font-size: 12px;';
         const types = [
           'Text', 'Checkbox', 'Currency', 'Date', 'DateTime', 'Email',
           'Location', 'Number', 'Percent', 'Phone', 'Picklist',
@@ -361,7 +361,7 @@ export function createFieldCreatorFeature(options: {
         tdOpt.style.cssText = 'padding: 8px 12px;';
         const optBtn = doc.createElement('button');
         optBtn.textContent = '⚙️ Options';
-        optBtn.style.cssText = 'padding: 4px 8px; background: #fff; border: 1px solid #d8dde6; border-radius: 4px; cursor: pointer; font-size: 11px;';
+        optBtn.style.cssText = 'padding: 4px 8px; background: var(--sfdt-color-surface); border: 1px solid var(--sfdt-color-border); border-radius: 4px; cursor: pointer; font-size: 11px;';
         optBtn.addEventListener('click', () => {
           openOptionsModal(field);
         });
@@ -372,11 +372,11 @@ export function createFieldCreatorFeature(options: {
         tdFLS.style.cssText = 'padding: 8px 12px;';
         const flsBtn = doc.createElement('button');
         flsBtn.textContent = '🔒 FLS';
-        flsBtn.style.cssText = 'padding: 4px 8px; background: #fff; border: 1px solid #d8dde6; border-radius: 4px; cursor: pointer; font-size: 11px;';
+        flsBtn.style.cssText = 'padding: 4px 8px; background: var(--sfdt-color-surface); border: 1px solid var(--sfdt-color-border); border-radius: 4px; cursor: pointer; font-size: 11px;';
         if (field.profiles && field.profiles.length > 0) {
           flsBtn.textContent = `🔒 FLS (${field.profiles.length})`;
-          flsBtn.style.color = '#04844b';
-          flsBtn.style.borderColor = '#04844b';
+          flsBtn.style.color = 'var(--sfdt-color-success)';
+          flsBtn.style.borderColor = 'var(--sfdt-color-success)';
         }
         flsBtn.addEventListener('click', () => {
           openFLSModal(field, () => {
@@ -390,17 +390,17 @@ export function createFieldCreatorFeature(options: {
         tdStatus.style.cssText = 'padding: 8px 12px; font-weight: bold;';
         if (field.deploymentStatus === 'pending') {
           tdStatus.textContent = '⏳ Pending';
-          tdStatus.style.color = '#0070d2';
+          tdStatus.style.color = 'var(--sfdt-color-brand)';
         } else if (field.deploymentStatus === 'success') {
           tdStatus.textContent = '✅ Success';
-          tdStatus.style.color = '#04844b';
+          tdStatus.style.color = 'var(--sfdt-color-success)';
         } else if (field.deploymentStatus === 'error') {
           tdStatus.textContent = '❌ Error';
-          tdStatus.style.color = '#c23934';
+          tdStatus.style.color = 'var(--sfdt-color-error)';
           tdStatus.title = field.deploymentError || 'Unknown error';
         } else {
           tdStatus.textContent = '-';
-          tdStatus.style.color = '#80868d';
+          tdStatus.style.color = 'var(--sfdt-color-text-icon)';
         }
         tr.appendChild(tdActions);
         tr.appendChild(tdLabel);
@@ -419,11 +419,11 @@ export function createFieldCreatorFeature(options: {
       optOverlay.style.cssText = 'position: fixed; inset: 0; background: rgba(0,0,0,0.3); z-index: 100030; display: flex; align-items: center; justify-content: center; font-family: system-ui, sans-serif;';
       
       const optModal = doc.createElement('div');
-      optModal.style.cssText = 'background: #fff; border-radius: 4px; width: 450px; max-height: 80vh; display: flex; flex-direction: column; padding: 16px; gap: 12px; box-shadow: 0 4px 15px rgba(0,0,0,0.1);';
+      optModal.style.cssText = 'background: var(--sfdt-color-surface); border-radius: 4px; width: 450px; max-height: 80vh; display: flex; flex-direction: column; padding: 16px; gap: 12px; box-shadow: 0 4px 15px rgba(0,0,0,0.1);';
       
       const optTitle = doc.createElement('span');
       optTitle.textContent = `Configure Field: ${field.label || 'New Field'} (${field.type})`;
-      optTitle.style.cssText = 'font-weight: 600; font-size: 14px; border-bottom: 1px solid #e0e0e0; padding-bottom: 8px;';
+      optTitle.style.cssText = 'font-weight: 600; font-size: 14px; border-bottom: 1px solid var(--sfdt-color-border-2); padding-bottom: 8px;';
       optModal.appendChild(optTitle);
 
       const fieldsContainer = doc.createElement('div');
@@ -436,14 +436,14 @@ export function createFieldCreatorFeature(options: {
         row.style.cssText = 'display: flex; flex-direction: column; gap: 2px;';
         const lbl = doc.createElement('label');
         lbl.textContent = labelVal;
-        lbl.style.cssText = 'font-size: 11px; font-weight: 600; color: #54698d;';
+        lbl.style.cssText = 'font-size: 11px; font-weight: 600; color: var(--sfdt-color-text-weak);';
         row.appendChild(lbl);
 
         if (typeVal === 'text') {
           const inp = doc.createElement('input');
           inp.type = 'text';
           inp.value = String(field[key] ?? defaultVal);
-          inp.style.cssText = 'padding: 4px 8px; border: 1px solid #d8dde6; border-radius: 4px; font-size: 12px;';
+          inp.style.cssText = 'padding: 4px 8px; border: 1px solid var(--sfdt-color-border); border-radius: 4px; font-size: 12px;';
           inp.addEventListener('input', () => {
             (field as any)[key] = inp.value;
           });
@@ -452,7 +452,7 @@ export function createFieldCreatorFeature(options: {
           const inp = doc.createElement('input');
           inp.type = 'number';
           inp.value = String(field[key] ?? defaultVal);
-          inp.style.cssText = 'padding: 4px 8px; border: 1px solid #d8dde6; border-radius: 4px; font-size: 12px;';
+          inp.style.cssText = 'padding: 4px 8px; border: 1px solid var(--sfdt-color-border); border-radius: 4px; font-size: 12px;';
           inp.addEventListener('input', () => {
             (field as any)[key] = parseInt(inp.value) || 0;
           });
@@ -495,9 +495,9 @@ export function createFieldCreatorFeature(options: {
         row.style.cssText = 'display: flex; flex-direction: column; gap: 2px;';
         const lbl = doc.createElement('label');
         lbl.textContent = 'Default Value';
-        lbl.style.cssText = 'font-size: 11px; font-weight: 600; color: #54698d;';
+        lbl.style.cssText = 'font-size: 11px; font-weight: 600; color: var(--sfdt-color-text-weak);';
         const sel = doc.createElement('select');
-        sel.style.cssText = 'padding: 4px 6px; border: 1px solid #d8dde6; border-radius: 4px; font-size: 12px;';
+        sel.style.cssText = 'padding: 4px 6px; border: 1px solid var(--sfdt-color-border); border-radius: 4px; font-size: 12px;';
         const optUnchecked = doc.createElement('option');
         optUnchecked.value = 'unchecked';
         optUnchecked.textContent = 'Unchecked';
@@ -519,9 +519,9 @@ export function createFieldCreatorFeature(options: {
         row.style.cssText = 'display: flex; flex-direction: column; gap: 2px;';
         const lbl = doc.createElement('label');
         lbl.textContent = 'Display Format';
-        lbl.style.cssText = 'font-size: 11px; font-weight: 600; color: #54698d;';
+        lbl.style.cssText = 'font-size: 11px; font-weight: 600; color: var(--sfdt-color-text-weak);';
         const sel = doc.createElement('select');
-        sel.style.cssText = 'padding: 4px 6px; border: 1px solid #d8dde6; border-radius: 4px; font-size: 12px;';
+        sel.style.cssText = 'padding: 4px 6px; border: 1px solid var(--sfdt-color-border); border-radius: 4px; font-size: 12px;';
         const optDec = doc.createElement('option');
         optDec.value = 'decimal';
         optDec.textContent = 'Decimal Degrees';
@@ -542,11 +542,11 @@ export function createFieldCreatorFeature(options: {
         row.style.cssText = 'display: flex; flex-direction: column; gap: 2px;';
         const lbl = doc.createElement('label');
         lbl.textContent = 'Picklist Values (Enter values, one per line)';
-        lbl.style.cssText = 'font-size: 11px; font-weight: 600; color: #54698d;';
+        lbl.style.cssText = 'font-size: 11px; font-weight: 600; color: var(--sfdt-color-text-weak);';
         const area = doc.createElement('textarea');
         area.value = field.picklistvalues || '';
         area.placeholder = 'Value1\nValue2\nValue3';
-        area.style.cssText = 'height: 80px; padding: 6px; border: 1px solid #d8dde6; border-radius: 4px; font-size: 12px; resize: vertical;';
+        area.style.cssText = 'height: 80px; padding: 6px; border: 1px solid var(--sfdt-color-border); border-radius: 4px; font-size: 12px; resize: vertical;';
         area.addEventListener('input', () => {
           field.picklistvalues = area.value;
         });
@@ -566,10 +566,10 @@ export function createFieldCreatorFeature(options: {
       }
 
       const buttons = doc.createElement('div');
-      buttons.style.cssText = 'display: flex; justify-content: flex-end; gap: 8px; border-top: 1px solid #e0e0e0; padding-top: 12px; margin-top: 8px;';
+      buttons.style.cssText = 'display: flex; justify-content: flex-end; gap: 8px; border-top: 1px solid var(--sfdt-color-border-2); padding-top: 12px; margin-top: 8px;';
       const saveBtn = doc.createElement('button');
       saveBtn.textContent = 'Save';
-      saveBtn.style.cssText = 'padding: 6px 14px; background: #0070d2; color: #fff; border: 0; border-radius: 4px; cursor: pointer; font-size: 12px; font-weight: 600;';
+      saveBtn.style.cssText = 'padding: 6px 14px; background: var(--sfdt-color-brand); color: var(--sfdt-color-surface); border: 0; border-radius: 4px; cursor: pointer; font-size: 12px; font-weight: 600;';
       saveBtn.addEventListener('click', () => {
         optOverlay.remove();
       });
@@ -585,22 +585,22 @@ export function createFieldCreatorFeature(options: {
       flsOverlay.style.cssText = 'position: fixed; inset: 0; background: rgba(0,0,0,0.3); z-index: 100030; display: flex; align-items: center; justify-content: center; font-family: system-ui, sans-serif;';
       
       const flsModal = doc.createElement('div');
-      flsModal.style.cssText = 'background: #fff; border-radius: 4px; width: 650px; height: 80vh; display: flex; flex-direction: column; padding: 16px; gap: 12px; box-shadow: 0 4px 15px rgba(0,0,0,0.1);';
+      flsModal.style.cssText = 'background: var(--sfdt-color-surface); border-radius: 4px; width: 650px; height: 80vh; display: flex; flex-direction: column; padding: 16px; gap: 12px; box-shadow: 0 4px 15px rgba(0,0,0,0.1);';
       
       const title = doc.createElement('span');
       title.textContent = targetField 
         ? `Field-Level Security (FLS) for ${targetField.label || 'New Field'}`
         : 'Grant Permissions to All Fields';
-      title.style.cssText = 'font-weight: 600; font-size: 14px; border-bottom: 1px solid #e0e0e0; padding-bottom: 8px;';
+      title.style.cssText = 'font-weight: 600; font-size: 14px; border-bottom: 1px solid var(--sfdt-color-border-2); padding-bottom: 8px;';
       flsModal.appendChild(title);
 
       const searchInp = doc.createElement('input');
       searchInp.placeholder = 'Search Profiles or Permission Sets...';
-      searchInp.style.cssText = 'padding: 6px 10px; border: 1px solid #d8dde6; border-radius: 4px; font-size: 12px; outline: none;';
+      searchInp.style.cssText = 'padding: 6px 10px; border: 1px solid var(--sfdt-color-border); border-radius: 4px; font-size: 12px; outline: none;';
       flsModal.appendChild(searchInp);
 
       const tableDiv = doc.createElement('div');
-      tableDiv.style.cssText = 'flex: 1; overflow-y: auto; border: 1px solid #d8dde6; border-radius: 4px;';
+      tableDiv.style.cssText = 'flex: 1; overflow-y: auto; border: 1px solid var(--sfdt-color-border); border-radius: 4px;';
       flsModal.appendChild(tableDiv);
 
       const flsTable = doc.createElement('table');
@@ -610,15 +610,15 @@ export function createFieldCreatorFeature(options: {
       const trHead = doc.createElement('tr');
       const thName = doc.createElement('th');
       thName.textContent = 'Name';
-      thName.style.cssText = 'padding: 6px 10px; background: #fafaf9; border-bottom: 1px solid #d8dde6; font-weight: 600; position: sticky; top: 0; z-index: 1;';
+      thName.style.cssText = 'padding: 6px 10px; background: var(--sfdt-color-surface-alt); border-bottom: 1px solid var(--sfdt-color-border); font-weight: 600; position: sticky; top: 0; z-index: 1;';
       
       const thType = doc.createElement('th');
       thType.textContent = 'Type';
-      thType.style.cssText = 'padding: 6px 10px; background: #fafaf9; border-bottom: 1px solid #d8dde6; font-weight: 600; position: sticky; top: 0; z-index: 1;';
+      thType.style.cssText = 'padding: 6px 10px; background: var(--sfdt-color-surface-alt); border-bottom: 1px solid var(--sfdt-color-border); font-weight: 600; position: sticky; top: 0; z-index: 1;';
 
       const thRead = doc.createElement('th');
       thRead.textContent = 'Visible';
-      thRead.style.cssText = 'padding: 6px 10px; background: #fafaf9; border-bottom: 1px solid #d8dde6; font-weight: 600; position: sticky; top: 0; z-index: 1; text-align: center;';
+      thRead.style.cssText = 'padding: 6px 10px; background: var(--sfdt-color-surface-alt); border-bottom: 1px solid var(--sfdt-color-border); font-weight: 600; position: sticky; top: 0; z-index: 1; text-align: center;';
       const readAll = doc.createElement('input');
       readAll.type = 'checkbox';
       thRead.appendChild(doc.createElement('br'));
@@ -626,7 +626,7 @@ export function createFieldCreatorFeature(options: {
 
       const thEdit = doc.createElement('th');
       thEdit.textContent = 'Read-Write';
-      thEdit.style.cssText = 'padding: 6px 10px; background: #fafaf9; border-bottom: 1px solid #d8dde6; font-weight: 600; position: sticky; top: 0; z-index: 1; text-align: center;';
+      thEdit.style.cssText = 'padding: 6px 10px; background: var(--sfdt-color-surface-alt); border-bottom: 1px solid var(--sfdt-color-border); font-weight: 600; position: sticky; top: 0; z-index: 1; text-align: center;';
       const editAll = doc.createElement('input');
       editAll.type = 'checkbox';
       thEdit.appendChild(doc.createElement('br'));
@@ -687,7 +687,7 @@ export function createFieldCreatorFeature(options: {
 
         filtered.forEach(([name, profile]) => {
           const tr = doc.createElement('tr');
-          tr.style.cssText = 'border-bottom: 1px solid #f3f3f3;';
+          tr.style.cssText = 'border-bottom: 1px solid var(--sfdt-color-bg);';
 
           const tdName = doc.createElement('td');
           tdName.textContent = profile || name;
@@ -695,7 +695,7 @@ export function createFieldCreatorFeature(options: {
 
           const tdType = doc.createElement('td');
           tdType.textContent = profile ? 'Profile' : 'Permission Set';
-          tdType.style.cssText = 'padding: 6px 10px; color: #54698d;';
+          tdType.style.cssText = 'padding: 6px 10px; color: var(--sfdt-color-text-weak);';
 
           const tdReadVal = doc.createElement('td');
           tdReadVal.style.cssText = 'padding: 6px 10px; text-align: center;';
@@ -764,18 +764,18 @@ export function createFieldCreatorFeature(options: {
       });
 
       const buttons = doc.createElement('div');
-      buttons.style.cssText = 'display: flex; justify-content: flex-end; gap: 8px; border-top: 1px solid #e0e0e0; padding-top: 12px; margin-top: 8px;';
+      buttons.style.cssText = 'display: flex; justify-content: flex-end; gap: 8px; border-top: 1px solid var(--sfdt-color-border-2); padding-top: 12px; margin-top: 8px;';
       
       const cancelBtn = doc.createElement('button');
       cancelBtn.textContent = 'Cancel';
-      cancelBtn.style.cssText = 'padding: 6px 12px; background: #fff; border: 1px solid #d8dde6; border-radius: 4px; cursor: pointer; font-size: 12px;';
+      cancelBtn.style.cssText = 'padding: 6px 12px; background: var(--sfdt-color-surface); border: 1px solid var(--sfdt-color-border); border-radius: 4px; cursor: pointer; font-size: 12px;';
       cancelBtn.addEventListener('click', () => {
         flsOverlay.remove();
       });
 
       const saveBtn = doc.createElement('button');
       saveBtn.textContent = 'Save Permissions';
-      saveBtn.style.cssText = 'padding: 6px 14px; background: #0070d2; color: #fff; border: 0; border-radius: 4px; cursor: pointer; font-size: 12px; font-weight: 600;';
+      saveBtn.style.cssText = 'padding: 6px 14px; background: var(--sfdt-color-brand); color: var(--sfdt-color-surface); border: 0; border-radius: 4px; cursor: pointer; font-size: 12px; font-weight: 600;';
       saveBtn.addEventListener('click', () => {
         const mappedProfiles = Object.entries(permissionsLocal)
           .filter(([_, perm]) => perm.read || perm.edit)

--- a/extension/features/flow-deploy.ts
+++ b/extension/features/flow-deploy.ts
@@ -140,7 +140,7 @@ function showDeployModal(
   body.style.cssText = 'padding: 16px;';
 
   const intro = doc.createElement('p');
-  intro.style.cssText = 'margin: 0 0 12px; font-size: 13px; color: #54698d;';
+  intro.style.cssText = 'margin: 0 0 12px; font-size: 13px; color: var(--sfdt-color-text-weak);';
   intro.textContent = 'sfdt re-validates against the target org before pushing.';
   body.appendChild(intro);
 
@@ -149,7 +149,7 @@ function showDeployModal(
   const deployBtn = doc.createElement('button');
   deployBtn.textContent = 'Deploy';
   deployBtn.style.cssText =
-    'padding: 6px 12px; background: #0070d2; color: #fff; border: 0; border-radius: 4px; cursor: pointer;';
+    'padding: 6px 12px; background: var(--sfdt-color-brand); color: var(--sfdt-color-surface); border: 0; border-radius: 4px; cursor: pointer;';
   deployBtn.addEventListener('click', async () => {
     view.close();
     await onChoice('deploy');
@@ -157,7 +157,7 @@ function showDeployModal(
   const rollbackBtn = doc.createElement('button');
   rollbackBtn.textContent = 'Rollback';
   rollbackBtn.style.cssText =
-    'padding: 6px 12px; background: #c23934; color: #fff; border: 0; border-radius: 4px; cursor: pointer;';
+    'padding: 6px 12px; background: var(--sfdt-color-error); color: var(--sfdt-color-surface); border: 0; border-radius: 4px; cursor: pointer;';
   rollbackBtn.addEventListener('click', async () => {
     view.close();
     await onChoice('rollback');

--- a/extension/features/flow-quality.ts
+++ b/extension/features/flow-quality.ts
@@ -11,22 +11,22 @@ import { presentView, type ViewHandle } from '../ui/present-view.js';
 import { runFlowQuality, type FlowQualityReport } from '@sfdt/flow-core';
 
 function bandColour(score: number | null): string {
-  if (score === null) return '#b0adab';
-  if (score >= 80) return '#04844b';
-  if (score >= 60) return '#fe9339';
-  return '#c23934';
+  if (score === null) return 'var(--sfdt-color-text-disabled)';
+  if (score >= 80) return 'var(--sfdt-color-success)';
+  if (score >= 60) return 'var(--sfdt-color-warning)';
+  return 'var(--sfdt-color-error)';
 }
 
 function severityColour(sev: string): string {
   switch (sev) {
     case 'high':
-      return '#c23934';
+      return 'var(--sfdt-color-error)';
     case 'medium':
-      return '#fe9339';
+      return 'var(--sfdt-color-warning)';
     case 'low':
-      return '#0070d2';
+      return 'var(--sfdt-color-brand)';
     default:
-      return '#706e6b';
+      return 'var(--sfdt-color-text-muted)';
   }
 }
 
@@ -67,14 +67,14 @@ export function createFlowQualityFeature(options: FlowQualityFeatureOptions = {}
   function sectionHeading(text: string): HTMLElement {
     const h = doc.createElement('div');
     h.style.cssText =
-      'margin: 16px 0 8px; font-size: 12px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.4px; color: #54698d;';
+      'margin: 16px 0 8px; font-size: 12px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.4px; color: var(--sfdt-color-text-weak);';
     h.textContent = text;
     return h;
   }
 
   function sevBadge(sev: string): HTMLElement {
     const b = doc.createElement('span');
-    b.style.cssText = `display: inline-block; min-width: 44px; text-align: center; font-size: 10px; font-weight: 700; text-transform: uppercase; color: #fff; background: ${severityColour(sev)}; border-radius: 3px; padding: 1px 6px;`;
+    b.style.cssText = `display: inline-block; min-width: 44px; text-align: center; font-size: 10px; font-weight: 700; text-transform: uppercase; color: var(--sfdt-color-surface); background: ${severityColour(sev)}; border-radius: 3px; padding: 1px 6px;`;
     b.textContent = sev || 'info';
     return b;
   }
@@ -87,21 +87,21 @@ export function createFlowQualityFeature(options: FlowQualityFeatureOptions = {}
     const count = typeof family.instanceCount === 'number' ? family.instanceCount : findings.length;
 
     const details = doc.createElement('details');
-    details.style.cssText = 'border: 1px solid #d8dde6; border-radius: 4px; margin-bottom: 6px;';
+    details.style.cssText = 'border: 1px solid var(--sfdt-color-border); border-radius: 4px; margin-bottom: 6px;';
     const summary = doc.createElement('summary');
     summary.style.cssText =
       'display: flex; align-items: center; gap: 8px; padding: 8px 10px; cursor: pointer; font-size: 13px; list-style: none;';
     const name = doc.createElement('span');
-    name.style.cssText = 'flex: 1; font-weight: 600; color: #16325c;';
+    name.style.cssText = 'flex: 1; font-weight: 600; color: var(--sfdt-color-brand-deep);';
     name.textContent = family.title ?? family.scoreFamily ?? 'Issue';
     const meta = doc.createElement('span');
-    meta.style.cssText = 'font-size: 11px; color: #706e6b;';
+    meta.style.cssText = 'font-size: 11px; color: var(--sfdt-color-text-muted);';
     meta.textContent = `${count} · −${impact}`;
     summary.append(sevBadge(severity), name, meta);
     details.appendChild(summary);
 
     const inner = doc.createElement('div');
-    inner.style.cssText = 'padding: 4px 12px 10px; font-size: 12px; color: #3e3e3c;';
+    inner.style.cssText = 'padding: 4px 12px 10px; font-size: 12px; color: var(--sfdt-color-text);';
 
     if (affected.length > 0) {
       const ul = doc.createElement('ul');
@@ -113,7 +113,7 @@ export function createFlowQualityFeature(options: FlowQualityFeatureOptions = {}
       }
       if (affected.length > 20) {
         const li = doc.createElement('li');
-        li.style.cssText = 'color: #706e6b;';
+        li.style.cssText = 'color: var(--sfdt-color-text-muted);';
         li.textContent = `…and ${affected.length - 20} more`;
         ul.appendChild(li);
       }
@@ -124,7 +124,7 @@ export function createFlowQualityFeature(options: FlowQualityFeatureOptions = {}
     const rec = findings.find((f) => f.recommendation)?.recommendation;
     if (rec) {
       const p = doc.createElement('p');
-      p.style.cssText = 'margin: 6px 0 0; padding: 6px 8px; background: #f3f6f9; border-radius: 4px;';
+      p.style.cssText = 'margin: 6px 0 0; padding: 6px 8px; background: var(--sfdt-color-surface-shade-2); border-radius: 4px;';
       p.textContent = `💡 ${rec}`;
       inner.appendChild(p);
     }
@@ -135,12 +135,12 @@ export function createFlowQualityFeature(options: FlowQualityFeatureOptions = {}
   function renderReport(results: HTMLElement, report: FlowQualityReport): void {
     const score = typeof report.summary.overallScore === 'number' ? report.summary.overallScore : null;
     const banner = doc.createElement('div');
-    banner.style.cssText = `margin-bottom: 14px; padding: 12px 14px; border-radius: 6px; border: 1px solid #d8dde6; border-left: 4px solid ${bandColour(score)}; display: flex; align-items: baseline; gap: 10px;`;
+    banner.style.cssText = `margin-bottom: 14px; padding: 12px 14px; border-radius: 6px; border: 1px solid var(--sfdt-color-border); border-left: 4px solid ${bandColour(score)}; display: flex; align-items: baseline; gap: 10px;`;
     const big = doc.createElement('span');
     big.style.cssText = 'font-size: 22px; font-weight: 700;';
     big.textContent = score === null ? '—' : String(score);
     const cap = doc.createElement('span');
-    cap.style.cssText = 'font-size: 12px; color: #54698d;';
+    cap.style.cssText = 'font-size: 12px; color: var(--sfdt-color-text-weak);';
     const fams = report.issueFamilies.length;
     cap.textContent = `${report.summary.rating ?? 'quality score'} · ${fams} issue famil${fams === 1 ? 'y' : 'ies'}`;
     banner.append(big, cap);
@@ -153,7 +153,7 @@ export function createFlowQualityFeature(options: FlowQualityFeatureOptions = {}
       chips.style.cssText = 'display: flex; flex-wrap: wrap; gap: 6px;';
       for (const [sev, n] of entries) {
         const chip = doc.createElement('span');
-        chip.style.cssText = `font-size: 11px; color: #3e3e3c; border: 1px solid ${severityColour(sev)}; border-radius: 10px; padding: 1px 8px;`;
+        chip.style.cssText = `font-size: 11px; color: var(--sfdt-color-text); border: 1px solid ${severityColour(sev)}; border-radius: 10px; padding: 1px 8px;`;
         chip.textContent = `${sev}: ${n}`;
         chips.appendChild(chip);
       }
@@ -170,7 +170,7 @@ export function createFlowQualityFeature(options: FlowQualityFeatureOptions = {}
       for (const family of families) results.appendChild(renderFamily(family));
     } else {
       const clean = doc.createElement('p');
-      clean.style.cssText = 'margin: 12px 0; color: #04844b; font-size: 13px;';
+      clean.style.cssText = 'margin: 12px 0; color: var(--sfdt-color-success); font-size: 13px;';
       clean.textContent = '✓ No quality issues detected.';
       results.appendChild(clean);
     }
@@ -183,7 +183,7 @@ export function createFlowQualityFeature(options: FlowQualityFeatureOptions = {}
       for (const dep of deps) {
         const row = doc.createElement('div');
         row.style.cssText =
-          'display: flex; align-items: center; gap: 8px; padding: 3px 0; font-size: 12px; color: #3e3e3c;';
+          'display: flex; align-items: center; gap: 8px; padding: 3px 0; font-size: 12px; color: var(--sfdt-color-text);';
         const label = doc.createElement('span');
         label.style.cssText = 'flex: 1; word-break: break-all;';
         label.textContent = dep.count > 1 ? `${dep.type}: ${dep.name} ×${dep.count}` : `${dep.type}: ${dep.name}`;
@@ -195,7 +195,7 @@ export function createFlowQualityFeature(options: FlowQualityFeatureOptions = {}
           explore.textContent = '🔗 Explore';
           explore.title = `Open ${dep.name} in the Dependency Explorer`;
           explore.style.cssText =
-            'flex: none; padding: 2px 8px; border: 1px solid #d8dde6; background: #fff; color: #0070d2; border-radius: 4px; cursor: pointer; font-size: 11px;';
+            'flex: none; padding: 2px 8px; border: 1px solid var(--sfdt-color-border); background: var(--sfdt-color-surface); color: var(--sfdt-color-brand); border-radius: 4px; cursor: pointer; font-size: 11px;';
           explore.addEventListener('click', () => onExploreDependency({ type: metadataType, name: dep.name }));
           row.appendChild(explore);
         }
@@ -216,13 +216,13 @@ export function createFlowQualityFeature(options: FlowQualityFeatureOptions = {}
     input.type = 'text';
     input.placeholder = 'Flow API name, e.g. My_Flow';
     input.style.cssText =
-      'flex: 1; min-width: 180px; padding: 5px 8px; border: 1px solid #d8dde6; border-radius: 4px; font-size: 13px;';
+      'flex: 1; min-width: 180px; padding: 5px 8px; border: 1px solid var(--sfdt-color-border); border-radius: 4px; font-size: 13px;';
     const runBtn = doc.createElement('button');
     runBtn.textContent = 'Scan';
     runBtn.style.cssText =
-      'padding: 5px 14px; border: 1px solid #0070d2; background: #0070d2; color: #fff; border-radius: 4px; cursor: pointer; font-size: 13px;';
+      'padding: 5px 14px; border: 1px solid var(--sfdt-color-brand); background: var(--sfdt-color-brand); color: var(--sfdt-color-surface); border-radius: 4px; cursor: pointer; font-size: 13px;';
     const status = doc.createElement('span');
-    status.style.cssText = 'color: #54698d; font-size: 12px;';
+    status.style.cssText = 'color: var(--sfdt-color-text-weak); font-size: 12px;';
     toolbar.append(input, runBtn, status);
     body.appendChild(toolbar);
 
@@ -256,7 +256,7 @@ export function createFlowQualityFeature(options: FlowQualityFeatureOptions = {}
       } catch (err) {
         const panel = doc.createElement('div');
         panel.style.cssText =
-          'border: 1px solid #c23934; background: #fef2f1; color: #c23934; padding: 8px 12px; border-radius: 4px; font-size: 13px;';
+          'border: 1px solid var(--sfdt-color-error); background: var(--sfdt-color-error-bg); color: var(--sfdt-color-error); padding: 8px 12px; border-radius: 4px; font-size: 13px;';
         panel.textContent = err instanceof Error ? err.message : String(err);
         results.appendChild(panel);
         status.textContent = 'Failed';

--- a/extension/features/flow-trigger-explorer-enhancer.ts
+++ b/extension/features/flow-trigger-explorer-enhancer.ts
@@ -52,10 +52,10 @@ const TIMING_LABEL: Record<TriggerTiming, string> = {
 };
 
 const TIMING_COLOUR: Record<TriggerTiming, string> = {
-  BeforeSave: '#0070d2',
-  AfterSave: '#04844b',
-  BeforeDelete: '#c23934',
-  Other: '#706e6b',
+  BeforeSave: 'var(--sfdt-color-brand)',
+  AfterSave: 'var(--sfdt-color-success)',
+  BeforeDelete: 'var(--sfdt-color-error)',
+  Other: 'var(--sfdt-color-text-muted)',
 };
 
 export function triggerTiming(triggerType: string | undefined): TriggerTiming {
@@ -154,17 +154,17 @@ function renderGroups(doc: Document, results: HTMLElement, groups: ObjectGroup[]
 
     const header = doc.createElement('div');
     header.style.cssText =
-      'font-weight: 700; font-size: 13px; padding: 6px 0; border-bottom: 2px solid #d8dde6; margin-bottom: 8px;';
+      'font-weight: 700; font-size: 13px; padding: 6px 0; border-bottom: 2px solid var(--sfdt-color-border); margin-bottom: 8px;';
     header.textContent = `${group.object} · ${group.flows.length} flow${group.flows.length === 1 ? '' : 's'}`;
     section.appendChild(header);
 
     for (const flow of group.flows) {
       const row = doc.createElement('div');
       row.style.cssText =
-        'border: 1px solid #d8dde6; border-radius: 4px; padding: 8px 10px; margin-bottom: 6px; display: flex; align-items: baseline; gap: 8px; flex-wrap: wrap;';
+        'border: 1px solid var(--sfdt-color-border); border-radius: 4px; padding: 8px 10px; margin-bottom: 6px; display: flex; align-items: baseline; gap: 8px; flex-wrap: wrap;';
 
       const badge = doc.createElement('span');
-      badge.style.cssText = `flex: 0 0 auto; font-size: 10px; font-weight: 700; color: #fff; background: ${TIMING_COLOUR[flow.timing]}; border-radius: 3px; padding: 2px 6px;`;
+      badge.style.cssText = `flex: 0 0 auto; font-size: 10px; font-weight: 700; color: var(--sfdt-color-surface); background: ${TIMING_COLOUR[flow.timing]}; border-radius: 3px; padding: 2px 6px;`;
       badge.textContent = flow.timingLabel;
 
       const name = doc.createElement('span');
@@ -172,7 +172,7 @@ function renderGroups(doc: Document, results: HTMLElement, groups: ObjectGroup[]
       name.textContent = flow.label;
 
       const meta = doc.createElement('span');
-      meta.style.cssText = 'color: #54698d; font-size: 11px;';
+      meta.style.cssText = 'color: var(--sfdt-color-text-weak); font-size: 11px;';
       meta.textContent = [flow.event, flow.processType].filter(Boolean).join(' · ');
 
       row.append(badge, name, meta);
@@ -183,13 +183,13 @@ function renderGroups(doc: Document, results: HTMLElement, groups: ObjectGroup[]
         link.target = '_blank';
         link.rel = 'noopener';
         link.textContent = 'Open in Builder ↗';
-        link.style.cssText = 'margin-left: auto; font-size: 11px; color: #0070d2; text-decoration: none;';
+        link.style.cssText = 'margin-left: auto; font-size: 11px; color: var(--sfdt-color-brand); text-decoration: none;';
         row.appendChild(link);
       }
 
       if (flow.description) {
         const desc = doc.createElement('div');
-        desc.style.cssText = 'flex: 1 0 100%; color: #3e3e3c; font-size: 11px; margin-top: 2px;';
+        desc.style.cssText = 'flex: 1 0 100%; color: var(--sfdt-color-text); font-size: 11px; margin-top: 2px;';
         desc.textContent = flow.description;
         row.appendChild(desc);
       }
@@ -229,7 +229,7 @@ export function createFlowTriggerExplorerEnhancerFeature(
       status.textContent = `${total} flow${total === 1 ? '' : 's'} · ${groups.length} object${groups.length === 1 ? '' : 's'}`;
       if (total === 0) {
         const empty = doc.createElement('div');
-        empty.style.cssText = 'padding: 12px; color: #80868d;';
+        empty.style.cssText = 'padding: 12px; color: var(--sfdt-color-text-icon);';
         empty.textContent = 'No active record-triggered flows in this org.';
         results.appendChild(empty);
         return;
@@ -238,7 +238,7 @@ export function createFlowTriggerExplorerEnhancerFeature(
     } catch (err) {
       const panel = doc.createElement('div');
       panel.style.cssText =
-        'border: 1px solid #c23934; background: #fef2f1; color: #c23934; padding: 8px 12px; border-radius: 4px; font-size: 13px;';
+        'border: 1px solid var(--sfdt-color-error); background: var(--sfdt-color-error-bg); color: var(--sfdt-color-error); padding: 8px 12px; border-radius: 4px; font-size: 13px;';
       panel.textContent = err instanceof Error ? err.message : String(err);
       results.appendChild(panel);
       status.textContent = 'Failed';
@@ -254,11 +254,11 @@ export function createFlowTriggerExplorerEnhancerFeature(
     const toolbar = doc.createElement('div');
     toolbar.style.cssText = 'display: flex; align-items: center; gap: 10px; margin-bottom: 12px;';
     const status = doc.createElement('span');
-    status.style.cssText = 'color: #54698d; font-size: 12px;';
+    status.style.cssText = 'color: var(--sfdt-color-text-weak); font-size: 12px;';
     const refreshBtn = doc.createElement('button');
     refreshBtn.textContent = 'Refresh';
     refreshBtn.style.cssText =
-      'margin-left: auto; padding: 4px 10px; border: 1px solid #d8dde6; background: #fff; border-radius: 4px; cursor: pointer; font-size: 12px;';
+      'margin-left: auto; padding: 4px 10px; border: 1px solid var(--sfdt-color-border); background: var(--sfdt-color-surface); border-radius: 4px; cursor: pointer; font-size: 12px;';
     toolbar.append(status, refreshBtn);
     body.appendChild(toolbar);
 

--- a/extension/features/flow-version-manager.ts
+++ b/extension/features/flow-version-manager.ts
@@ -77,7 +77,7 @@ async function confirmModal(doc: Document, selected: RowMeta[]): Promise<boolean
     modal.className = 'sfdt-version-manager-modal';
     modal.setAttribute('role', 'dialog');
     modal.style.cssText =
-      'background: #fff; border-radius: 4px; padding: 16px; min-width: 360px; max-width: 480px; font-family: system-ui, sans-serif;';
+      'background: var(--sfdt-color-surface); border-radius: 4px; padding: 16px; min-width: 360px; max-width: 480px; font-family: system-ui, sans-serif;';
 
     const title = doc.createElement('h2');
     title.textContent = 'Delete Selected Versions';
@@ -116,7 +116,7 @@ async function confirmModal(doc: Document, selected: RowMeta[]): Promise<boolean
     confirm.type = 'button';
     confirm.textContent = 'Delete Selected Versions';
     confirm.disabled = true;
-    confirm.style.cssText = 'padding: 6px 12px; background: #c23934; color: #fff; border: 0;';
+    confirm.style.cssText = 'padding: 6px 12px; background: var(--sfdt-color-error); color: var(--sfdt-color-surface); border: 0;';
     footer.appendChild(cancel);
     footer.appendChild(confirm);
     modal.appendChild(footer);

--- a/extension/features/inspect-record.ts
+++ b/extension/features/inspect-record.ts
@@ -126,10 +126,10 @@ export function createInspectRecordFeature(options: InspectRecordOptions = {}): 
     searchRow.style.cssText = 'display: flex; gap: 8px; align-items: center;';
     const idInput = doc.createElement('input');
     idInput.placeholder = 'Paste Salesforce Record ID (e.g. 001800000000001AAA)';
-    idInput.style.cssText = 'flex: 1; padding: 6px 10px; border: 1px solid #d8dde6; border-radius: 4px; font-size: 13px; outline: none;';
+    idInput.style.cssText = 'flex: 1; padding: 6px 10px; border: 1px solid var(--sfdt-color-border); border-radius: 4px; font-size: 13px; outline: none;';
     const inspectBtn = doc.createElement('button');
     inspectBtn.textContent = 'Inspect';
-    inspectBtn.style.cssText = 'padding: 6px 14px; background: #0070d2; color: #fff; border: 0; border-radius: 4px; cursor: pointer; font-size: 13px; font-weight: 600;';
+    inspectBtn.style.cssText = 'padding: 6px 14px; background: var(--sfdt-color-brand); color: var(--sfdt-color-surface); border: 0; border-radius: 4px; cursor: pointer; font-size: 13px; font-weight: 600;';
     searchRow.appendChild(idInput);
     searchRow.appendChild(inspectBtn);
     body.appendChild(searchRow);
@@ -138,9 +138,9 @@ export function createInspectRecordFeature(options: InspectRecordOptions = {}): 
     filterRow.style.cssText = 'display: none; justify-content: space-between; align-items: center; gap: 12px; margin-top: 4px;';
     const filterInput = doc.createElement('input');
     filterInput.placeholder = 'Filter fields by label, API name, or value...';
-    filterInput.style.cssText = 'flex: 1; max-width: 400px; padding: 5px 8px; border: 1px solid #d8dde6; border-radius: 4px; font-size: 12px; outline: none;';
+    filterInput.style.cssText = 'flex: 1; max-width: 400px; padding: 5px 8px; border: 1px solid var(--sfdt-color-border); border-radius: 4px; font-size: 12px; outline: none;';
     const checkboxLabel = doc.createElement('label');
-    checkboxLabel.style.cssText = 'display: inline-flex; align-items: center; gap: 6px; font-size: 12px; color: #54698d; cursor: pointer;';
+    checkboxLabel.style.cssText = 'display: inline-flex; align-items: center; gap: 6px; font-size: 12px; color: var(--sfdt-color-text-weak); cursor: pointer;';
     const showNullsCheckbox = doc.createElement('input');
     showNullsCheckbox.type = 'checkbox';
     showNullsCheckbox.checked = true;
@@ -151,17 +151,17 @@ export function createInspectRecordFeature(options: InspectRecordOptions = {}): 
     body.appendChild(filterRow);
 
     const tableContainer = doc.createElement('div');
-    tableContainer.style.cssText = 'border: 1px solid #d8dde6; border-radius: 4px; overflow: auto; max-height: 50vh; display: none;';
+    tableContainer.style.cssText = 'border: 1px solid var(--sfdt-color-border); border-radius: 4px; overflow: auto; max-height: 50vh; display: none;';
     body.appendChild(tableContainer);
 
     const saveBar = doc.createElement('div');
-    saveBar.style.cssText = 'display: none; justify-content: flex-end; gap: 8px; padding: 12px 16px; border-top: 1px solid #d8dde6; background: #fafaf9;';
+    saveBar.style.cssText = 'display: none; justify-content: flex-end; gap: 8px; padding: 12px 16px; border-top: 1px solid var(--sfdt-color-border); background: var(--sfdt-color-surface-alt);';
     const cancelChangesBtn = doc.createElement('button');
     cancelChangesBtn.textContent = 'Cancel';
-    cancelChangesBtn.style.cssText = 'padding: 6px 12px; background: #fff; color: #54698d; border: 1px solid #d8dde6; border-radius: 4px; cursor: pointer; font-size: 13px;';
+    cancelChangesBtn.style.cssText = 'padding: 6px 12px; background: var(--sfdt-color-surface); color: var(--sfdt-color-text-weak); border: 1px solid var(--sfdt-color-border); border-radius: 4px; cursor: pointer; font-size: 13px;';
     const saveChangesBtn = doc.createElement('button');
     saveChangesBtn.textContent = 'Save Changes';
-    saveChangesBtn.style.cssText = 'padding: 6px 14px; background: #04844b; color: #fff; border: 0; border-radius: 4px; cursor: pointer; font-size: 13px; font-weight: 600;';
+    saveChangesBtn.style.cssText = 'padding: 6px 14px; background: var(--sfdt-color-success); color: var(--sfdt-color-surface); border: 0; border-radius: 4px; cursor: pointer; font-size: 13px; font-weight: 600;';
     saveBar.appendChild(cancelChangesBtn);
     saveBar.appendChild(saveChangesBtn);
 
@@ -196,7 +196,7 @@ export function createInspectRecordFeature(options: InspectRecordOptions = {}): 
       for (const h of headers) {
         const th = doc.createElement('th');
         th.textContent = h;
-        th.style.cssText = 'padding: 8px 12px; background: #fafaf9; border-bottom: 1px solid #d8dde6; font-weight: 600; position: sticky; top: 0; z-index: 1;';
+        th.style.cssText = 'padding: 8px 12px; background: var(--sfdt-color-surface-alt); border-bottom: 1px solid var(--sfdt-color-border); font-weight: 600; position: sticky; top: 0; z-index: 1;';
         headRow.appendChild(th);
       }
       thead.appendChild(headRow);
@@ -221,27 +221,27 @@ export function createInspectRecordFeature(options: InspectRecordOptions = {}): 
         if (filterText && !matchesFilter) continue;
 
         const tr = doc.createElement('tr');
-        tr.style.cssText = 'border-bottom: 1px solid #f3f3f3;';
+        tr.style.cssText = 'border-bottom: 1px solid var(--sfdt-color-bg);';
 
         const tdLabel = doc.createElement('td');
         tdLabel.textContent = field.label;
-        tdLabel.style.cssText = 'padding: 8px 12px; color: #16325c;';
+        tdLabel.style.cssText = 'padding: 8px 12px; color: var(--sfdt-color-brand-deep);';
 
         const tdApi = doc.createElement('td');
         tdApi.textContent = field.name;
-        tdApi.style.cssText = 'padding: 8px 12px; font-family: ui-monospace, monospace; color: #54698d;';
+        tdApi.style.cssText = 'padding: 8px 12px; font-family: ui-monospace, monospace; color: var(--sfdt-color-text-weak);';
 
         const tdType = doc.createElement('td');
         const icon = getIconForType(field.type);
         tdType.textContent = `${icon} ${field.type}`;
-        tdType.style.cssText = 'padding: 8px 12px; color: #54698d;';
+        tdType.style.cssText = 'padding: 8px 12px; color: var(--sfdt-color-text-weak);';
 
         const tdValue = doc.createElement('td');
         tdValue.style.cssText = 'padding: 8px 12px; position: relative;';
 
         const isDirty = originalRecordData[field.name] !== rawValue;
         if (isDirty) {
-          tr.style.background = '#fff8e1';
+          tr.style.background = 'var(--sfdt-color-warning-bg-2)';
         }
 
         if (field.type === 'boolean') {
@@ -260,9 +260,9 @@ export function createInspectRecordFeature(options: InspectRecordOptions = {}): 
           editWrapper.style.cssText = 'display: flex; align-items: center; justify-content: space-between; gap: 8px; width: 100%;';
           const valSpan = doc.createElement('span');
           valSpan.textContent = isNull ? '(null)' : valStr;
-          valSpan.style.cssText = isNull ? 'color: #c23934; font-style: italic; cursor: pointer; flex: 1;' : 'cursor: pointer; flex: 1;';
+          valSpan.style.cssText = isNull ? 'color: var(--sfdt-color-error); font-style: italic; cursor: pointer; flex: 1;' : 'cursor: pointer; flex: 1;';
           if (isRecordId(valStr)) {
-            valSpan.style.color = '#0070d2';
+            valSpan.style.color = 'var(--sfdt-color-brand)';
             valSpan.style.textDecoration = 'underline';
           }
           
@@ -271,7 +271,7 @@ export function createInspectRecordFeature(options: InspectRecordOptions = {}): 
           const editInput = doc.createElement('input');
           editInput.type = 'text';
           editInput.value = isNull ? '' : valStr;
-          editInput.style.cssText = 'display: none; flex: 1; padding: 2px 6px; border: 1px solid #0070d2; border-radius: 4px; font-size: 12px; outline: none;';
+          editInput.style.cssText = 'display: none; flex: 1; padding: 2px 6px; border: 1px solid var(--sfdt-color-brand); border-radius: 4px; font-size: 12px; outline: none;';
           editWrapper.appendChild(editInput);
 
           const startEdit = () => {
@@ -316,9 +316,9 @@ export function createInspectRecordFeature(options: InspectRecordOptions = {}): 
           const readSpan = doc.createElement('span');
           readSpan.textContent = isNull ? '(null)' : valStr;
           if (isNull) {
-            readSpan.style.cssText = 'color: #80868d; font-style: italic;';
+            readSpan.style.cssText = 'color: var(--sfdt-color-text-icon); font-style: italic;';
           } else if (isRecordId(valStr)) {
-            readSpan.style.cssText = 'color: #0070d2; text-decoration: underline; cursor: pointer;';
+            readSpan.style.cssText = 'color: var(--sfdt-color-brand); text-decoration: underline; cursor: pointer;';
             readSpan.addEventListener('click', () => void navigateToRecord(valStr));
           }
           tdValue.appendChild(readSpan);
@@ -401,7 +401,7 @@ export function createInspectRecordFeature(options: InspectRecordOptions = {}): 
 
         recordInfo.textContent = '🔍 Inspect Record: ';
         const idSpan = doc.createElement('span');
-        idSpan.style.cssText = 'color:#0070d2; font-family:ui-monospace, monospace; margin-left: 6px;';
+        idSpan.style.cssText = 'color:var(--sfdt-color-brand); font-family:ui-monospace, monospace; margin-left: 6px;';
         idSpan.textContent = `${sobject} · ${recordId}`;
         recordInfo.appendChild(idSpan);
         

--- a/extension/features/metadata-retrieve.ts
+++ b/extension/features/metadata-retrieve.ts
@@ -90,18 +90,18 @@ export function createMetadataRetrieveFeature(options: {
     logsContainer.replaceChildren();
     for (const msg of logMessages) {
       const item = doc.createElement('div');
-      item.style.cssText = 'padding: 2px 0; font-family: monospace; font-size: 11px; border-bottom: 1px solid #f3f3f3;';
+      item.style.cssText = 'padding: 2px 0; font-family: monospace; font-size: 11px; border-bottom: 1px solid var(--sfdt-color-bg);';
       if (msg.level === 'error') {
-        item.style.color = '#c23934';
+        item.style.color = 'var(--sfdt-color-error)';
         item.textContent = `❌ ${msg.text}`;
       } else if (msg.level === 'success') {
-        item.style.color = '#04844b';
+        item.style.color = 'var(--sfdt-color-success)';
         item.textContent = `✅ ${msg.text}`;
       } else if (msg.level === 'working') {
-        item.style.color = '#0070d2';
+        item.style.color = 'var(--sfdt-color-brand)';
         item.textContent = `⏳ ${msg.text}`;
       } else {
-        item.style.color = '#54698d';
+        item.style.color = 'var(--sfdt-color-text-weak)';
         item.textContent = `ℹ️ ${msg.text}`;
       }
       logsContainer.appendChild(item);
@@ -517,7 +517,7 @@ export function createMetadataRetrieveFeature(options: {
     if (filtered.length === 0) {
       const empty = doc.createElement('li');
       empty.textContent = 'No matching metadata types';
-      empty.style.cssText = 'color: #80868d; font-size: 12px; padding: 4px;';
+      empty.style.cssText = 'color: var(--sfdt-color-text-icon); font-size: 12px; padding: 4px;';
       list.appendChild(empty);
       treeContainer.appendChild(list);
       return;
@@ -525,14 +525,14 @@ export function createMetadataRetrieveFeature(options: {
 
     filtered.forEach(obj => {
       const li = doc.createElement('li');
-      li.style.cssText = 'margin-bottom: 4px; border-bottom: 1px solid #f3f3f3; padding-bottom: 4px;';
+      li.style.cssText = 'margin-bottom: 4px; border-bottom: 1px solid var(--sfdt-color-bg); padding-bottom: 4px;';
 
       const row = doc.createElement('div');
       row.style.cssText = 'display: flex; align-items: center; gap: 6px; cursor: pointer;';
 
       const expBtn = doc.createElement('button');
       expBtn.textContent = obj.expanded ? '▼' : '▶';
-      expBtn.style.cssText = 'background: none; border: 0; padding: 0; font-size: 10px; cursor: pointer; width: 16px; color: #54698d;';
+      expBtn.style.cssText = 'background: none; border: 0; padding: 0; font-size: 10px; cursor: pointer; width: 16px; color: var(--sfdt-color-text-weak);';
       expBtn.addEventListener('click', (e) => {
         e.stopPropagation();
         void toggleExpand(obj);
@@ -551,7 +551,7 @@ export function createMetadataRetrieveFeature(options: {
 
       const label = doc.createElement('span');
       label.textContent = obj.xmlName;
-      label.style.cssText = 'font-size: 12px; font-weight: 500; color: #3e3e3c; flex: 1;';
+      label.style.cssText = 'font-size: 12px; font-weight: 500; color: var(--sfdt-color-text); flex: 1;';
       row.appendChild(label);
 
       row.addEventListener('click', () => {
@@ -581,7 +581,7 @@ export function createMetadataRetrieveFeature(options: {
 
             const childLabel = doc.createElement('span');
             childLabel.textContent = child.fullName;
-            childLabel.style.cssText = 'font-size: 11px; color: #54698d;';
+            childLabel.style.cssText = 'font-size: 11px; color: var(--sfdt-color-text-weak);';
             childLi.appendChild(childLabel);
 
             childList.appendChild(childLi);
@@ -615,7 +615,7 @@ export function createMetadataRetrieveFeature(options: {
     const spinnerRow = doc.createElement('div');
     spinnerRow.style.cssText = 'padding: 6px 16px 0; display: flex; justify-content: flex-end;';
     spinnerEl = doc.createElement('div');
-    spinnerEl.style.cssText = 'border: 2px solid #f3f3f3; border-top: 2px solid #0070d2; border-radius: 50%; width: 14px; height: 14px; animation: spin 1s linear infinite; display: none;';
+    spinnerEl.style.cssText = 'border: 2px solid var(--sfdt-color-bg); border-top: 2px solid var(--sfdt-color-brand); border-radius: 50%; width: 14px; height: 14px; animation: spin 1s linear infinite; display: none;';
     const style = doc.createElement('style');
     style.textContent = '@keyframes spin { 0% { transform: rotate(0deg); } 100% { transform: rotate(360deg); } }';
     doc.head.appendChild(style);
@@ -624,13 +624,13 @@ export function createMetadataRetrieveFeature(options: {
 
     // Tab Header
     const tabsRow = doc.createElement('div');
-    tabsRow.style.cssText = 'display: flex; border-bottom: 1px solid #d8dde6; background: #fafaf9;';
+    tabsRow.style.cssText = 'display: flex; border-bottom: 1px solid var(--sfdt-color-border); background: var(--sfdt-color-surface-alt);';
     const rTab = doc.createElement('button');
     rTab.textContent = 'Retrieve';
-    rTab.style.cssText = 'padding: 10px 20px; border: 0; background: #fff; border-right: 1px solid #d8dde6; border-bottom: 2px solid #0070d2; font-weight: 600; cursor: pointer;';
+    rTab.style.cssText = 'padding: 10px 20px; border: 0; background: var(--sfdt-color-surface); border-right: 1px solid var(--sfdt-color-border); border-bottom: 2px solid var(--sfdt-color-brand); font-weight: 600; cursor: pointer;';
     const dTab = doc.createElement('button');
     dTab.textContent = 'Deploy';
-    dTab.style.cssText = 'padding: 10px 20px; border: 0; background: none; border-right: 1px solid #d8dde6; font-weight: 600; cursor: pointer; color: #54698d;';
+    dTab.style.cssText = 'padding: 10px 20px; border: 0; background: none; border-right: 1px solid var(--sfdt-color-border); font-weight: 600; cursor: pointer; color: var(--sfdt-color-text-weak);';
 
     tabsRow.appendChild(rTab);
     tabsRow.appendChild(dTab);
@@ -648,7 +648,7 @@ export function createMetadataRetrieveFeature(options: {
 
     // Left half (Tree & Filter)
     const treeDiv = doc.createElement('div');
-    treeDiv.style.cssText = 'flex: 1; display: flex; flex-direction: column; gap: 10px; border-right: 1px solid #e0e0e0; padding-right: 16px; overflow: hidden;';
+    treeDiv.style.cssText = 'flex: 1; display: flex; flex-direction: column; gap: 10px; border-right: 1px solid var(--sfdt-color-border-2); padding-right: 16px; overflow: hidden;';
     rPanel.appendChild(treeDiv);
 
     const filterRow = doc.createElement('div');
@@ -656,7 +656,7 @@ export function createMetadataRetrieveFeature(options: {
     const search = doc.createElement('input');
     search.type = 'text';
     search.placeholder = 'Filter metadata type or member...';
-    search.style.cssText = 'flex: 1; padding: 6px 8px; border: 1px solid #d8dde6; border-radius: 4px; font-size: 13px;';
+    search.style.cssText = 'flex: 1; padding: 6px 8px; border: 1px solid var(--sfdt-color-border); border-radius: 4px; font-size: 13px;';
     search.addEventListener('input', () => {
       metadataFilter = search.value.toLowerCase();
       renderTree();
@@ -664,7 +664,7 @@ export function createMetadataRetrieveFeature(options: {
     filterRow.appendChild(search);
 
     const managedLabel = doc.createElement('label');
-    managedLabel.style.cssText = 'font-size: 11px; color: #54698d; display: flex; align-items: center; gap: 4px; cursor: pointer;';
+    managedLabel.style.cssText = 'font-size: 11px; color: var(--sfdt-color-text-weak); display: flex; align-items: center; gap: 4px; cursor: pointer;';
     const managedChk = doc.createElement('input');
     managedChk.type = 'checkbox';
     managedChk.checked = includeManagedPackage;
@@ -679,7 +679,7 @@ export function createMetadataRetrieveFeature(options: {
     treeDiv.appendChild(filterRow);
 
     treeContainer = doc.createElement('div');
-    treeContainer.style.cssText = 'flex: 1; overflow-y: auto; border: 1px solid #d8dde6; border-radius: 4px; padding: 8px;';
+    treeContainer.style.cssText = 'flex: 1; overflow-y: auto; border: 1px solid var(--sfdt-color-border); border-radius: 4px; padding: 8px;';
     treeDiv.appendChild(treeContainer);
 
     // Right half (XML Output)
@@ -689,14 +689,14 @@ export function createMetadataRetrieveFeature(options: {
 
     const xmlLabel = doc.createElement('span');
     xmlLabel.textContent = 'package.xml preview';
-    xmlLabel.style.cssText = 'font-size: 12px; font-weight: 600; color: #3e3e3c;';
+    xmlLabel.style.cssText = 'font-size: 12px; font-weight: 600; color: var(--sfdt-color-text);';
     xmlDiv.appendChild(xmlLabel);
 
     const xmlTextarea = doc.createElement('textarea');
     xmlTextarea.id = 'sfdt-meta-xml-textarea';
     xmlTextarea.readOnly = true;
     xmlTextarea.value = packageXml;
-    xmlTextarea.style.cssText = 'flex: 1; padding: 8px; border: 1px solid #d8dde6; border-radius: 4px; font-family: monospace; font-size: 11px; background: #fafaf9; resize: none; outline: none;';
+    xmlTextarea.style.cssText = 'flex: 1; padding: 8px; border: 1px solid var(--sfdt-color-border); border-radius: 4px; font-family: monospace; font-size: 11px; background: var(--sfdt-color-surface-alt); resize: none; outline: none;';
     xmlTextareaEl = xmlTextarea;
     xmlDiv.appendChild(xmlTextarea);
 
@@ -704,14 +704,14 @@ export function createMetadataRetrieveFeature(options: {
     rActions.style.cssText = 'display: flex; gap: 8px;';
     const copyXmlBtn = doc.createElement('button');
     copyXmlBtn.textContent = 'Copy XML';
-    copyXmlBtn.style.cssText = 'padding: 6px 12px; border: 1px solid #d8dde6; border-radius: 4px; background: #fff; cursor: pointer; font-size: 12px;';
+    copyXmlBtn.style.cssText = 'padding: 6px 12px; border: 1px solid var(--sfdt-color-border); border-radius: 4px; background: var(--sfdt-color-surface); cursor: pointer; font-size: 12px;';
     copyXmlBtn.addEventListener('click', () => {
       void win.navigator.clipboard.writeText(packageXml);
       showToast('package.xml copied to clipboard', { doc, kind: 'success' });
     });
     const downloadXmlBtn = doc.createElement('button');
     downloadXmlBtn.textContent = 'Download XML';
-    downloadXmlBtn.style.cssText = 'padding: 6px 12px; border: 1px solid #d8dde6; border-radius: 4px; background: #fff; cursor: pointer; font-size: 12px;';
+    downloadXmlBtn.style.cssText = 'padding: 6px 12px; border: 1px solid var(--sfdt-color-border); border-radius: 4px; background: var(--sfdt-color-surface); cursor: pointer; font-size: 12px;';
     downloadXmlBtn.addEventListener('click', () => {
       const blob = new Blob([packageXml], { type: 'text/xml' });
       const a = doc.createElement('a');
@@ -741,14 +741,14 @@ export function createMetadataRetrieveFeature(options: {
 
     const importXmlBtn = doc.createElement('button');
     importXmlBtn.textContent = 'Import XML';
-    importXmlBtn.style.cssText = 'padding: 6px 12px; border: 1px solid #d8dde6; border-radius: 4px; background: #fff; cursor: pointer; font-size: 12px;';
+    importXmlBtn.style.cssText = 'padding: 6px 12px; border: 1px solid var(--sfdt-color-border); border-radius: 4px; background: var(--sfdt-color-surface); cursor: pointer; font-size: 12px;';
     importXmlBtn.addEventListener('click', () => {
       fileUploadXml.click();
     });
 
     const retrieveBtn = doc.createElement('button');
     retrieveBtn.textContent = 'Retrieve Zip';
-    retrieveBtn.style.cssText = 'padding: 6px 16px; background: #0070d2; color: #fff; border: 0; border-radius: 4px; cursor: pointer; font-size: 12px; font-weight: 600; margin-left: auto;';
+    retrieveBtn.style.cssText = 'padding: 6px 16px; background: var(--sfdt-color-brand); color: var(--sfdt-color-surface); border: 0; border-radius: 4px; cursor: pointer; font-size: 12px; font-weight: 600; margin-left: auto;';
     retrieveBtn.addEventListener('click', () => {
       void runRetrieve();
     });
@@ -772,7 +772,7 @@ export function createMetadataRetrieveFeature(options: {
     fileRow.style.cssText = 'display: flex; flex-direction: column; gap: 4px;';
     const fileLabel = doc.createElement('label');
     fileLabel.textContent = 'Select Metadata ZIP File';
-    fileLabel.style.cssText = 'font-size: 12px; font-weight: 600; color: #3e3e3c;';
+    fileLabel.style.cssText = 'font-size: 12px; font-weight: 600; color: var(--sfdt-color-text);';
     const fileInput = doc.createElement('input');
     fileInput.type = 'file';
     fileInput.accept = '.zip';
@@ -797,7 +797,7 @@ export function createMetadataRetrieveFeature(options: {
 
     optsList.forEach(opt => {
       const label = doc.createElement('label');
-      label.style.cssText = 'display: flex; align-items: center; gap: 6px; font-size: 12px; cursor: pointer; color: #3e3e3c;';
+      label.style.cssText = 'display: flex; align-items: center; gap: 6px; font-size: 12px; cursor: pointer; color: var(--sfdt-color-text);';
       const chk = doc.createElement('input');
       chk.type = 'checkbox';
       chk.checked = !!(deployOptions as any)[opt.key];
@@ -813,9 +813,9 @@ export function createMetadataRetrieveFeature(options: {
     testLevelRow.style.cssText = 'display: flex; flex-direction: column; gap: 4px;';
     const testLevelLabel = doc.createElement('label');
     testLevelLabel.textContent = 'Test Level';
-    testLevelLabel.style.cssText = 'font-size: 11px; font-weight: 600; color: #54698d;';
+    testLevelLabel.style.cssText = 'font-size: 11px; font-weight: 600; color: var(--sfdt-color-text-weak);';
     const testLevelSelect = doc.createElement('select');
-    testLevelSelect.style.cssText = 'padding: 6px; border: 1px solid #d8dde6; border-radius: 4px; font-size: 13px; outline: none;';
+    testLevelSelect.style.cssText = 'padding: 6px; border: 1px solid var(--sfdt-color-border); border-radius: 4px; font-size: 13px; outline: none;';
     ['NoTestRun', 'RunSpecifiedTests', 'RunLocalTests', 'RunAllTestsInOrg'].forEach(v => {
       const opt = doc.createElement('option');
       opt.value = v;
@@ -831,11 +831,11 @@ export function createMetadataRetrieveFeature(options: {
     runTestsRow.style.cssText = 'display: none; flex-direction: column; gap: 4px;';
     const runTestsLabel = doc.createElement('label');
     runTestsLabel.textContent = 'Specified Tests (comma-separated class names)';
-    runTestsLabel.style.cssText = 'font-size: 11px; font-weight: 600; color: #54698d;';
+    runTestsLabel.style.cssText = 'font-size: 11px; font-weight: 600; color: var(--sfdt-color-text-weak);';
     const runTestsInput = doc.createElement('input');
     runTestsInput.type = 'text';
     runTestsInput.placeholder = 'MyTestClass1, MyTestClass2';
-    runTestsInput.style.cssText = 'padding: 6px; border: 1px solid #d8dde6; border-radius: 4px; font-size: 13px; outline: none;';
+    runTestsInput.style.cssText = 'padding: 6px; border: 1px solid var(--sfdt-color-border); border-radius: 4px; font-size: 13px; outline: none;';
     runTestsInput.addEventListener('input', () => {
       deployOptions.runTests = runTestsInput.value;
     });
@@ -850,7 +850,7 @@ export function createMetadataRetrieveFeature(options: {
 
     const deployBtn = doc.createElement('button');
     deployBtn.textContent = 'Deploy ZIP';
-    deployBtn.style.cssText = 'padding: 8px 16px; background: #04844b; color: #fff; border: 0; border-radius: 4px; cursor: pointer; font-size: 13px; font-weight: 600; align-self: flex-start;';
+    deployBtn.style.cssText = 'padding: 8px 16px; background: var(--sfdt-color-success); color: var(--sfdt-color-surface); border: 0; border-radius: 4px; cursor: pointer; font-size: 13px; font-weight: 600; align-self: flex-start;';
     deployBtn.addEventListener('click', () => {
       if (!fileInput.files?.length) {
         showToast('Please select a metadata ZIP file first.', { doc, kind: 'warning' });
@@ -870,42 +870,42 @@ export function createMetadataRetrieveFeature(options: {
 
     // Logs Container (Shared bottom panel)
     const logsWrap = doc.createElement('div');
-    logsWrap.style.cssText = 'border-top: 1px solid #d8dde6; height: 140px; padding: 12px 16px; display: flex; flex-direction: column; gap: 6px; background: #fafaf9;';
+    logsWrap.style.cssText = 'border-top: 1px solid var(--sfdt-color-border); height: 140px; padding: 12px 16px; display: flex; flex-direction: column; gap: 6px; background: var(--sfdt-color-surface-alt);';
     body.appendChild(logsWrap);
 
     const logsLabel = doc.createElement('div');
-    logsLabel.style.cssText = 'font-size: 11px; font-weight: 600; color: #54698d; display: flex; justify-content: space-between;';
+    logsLabel.style.cssText = 'font-size: 11px; font-weight: 600; color: var(--sfdt-color-text-weak); display: flex; justify-content: space-between;';
     logsLabel.textContent = 'Execution Log';
     const clearLogsBtn = doc.createElement('button');
     clearLogsBtn.textContent = 'Clear Logs';
-    clearLogsBtn.style.cssText = 'background: none; border: 0; color: #0070d2; font-size: 11px; cursor: pointer; padding: 0;';
+    clearLogsBtn.style.cssText = 'background: none; border: 0; color: var(--sfdt-color-brand); font-size: 11px; cursor: pointer; padding: 0;';
     clearLogsBtn.addEventListener('click', clearLogs);
     logsLabel.appendChild(clearLogsBtn);
     logsWrap.appendChild(logsLabel);
 
     logsContainer = doc.createElement('div');
-    logsContainer.style.cssText = 'flex: 1; overflow-y: auto; background: #fff; border: 1px solid #d8dde6; border-radius: 4px; padding: 6px;';
+    logsContainer.style.cssText = 'flex: 1; overflow-y: auto; background: var(--sfdt-color-surface); border: 1px solid var(--sfdt-color-border); border-radius: 4px; padding: 6px;';
     logsWrap.appendChild(logsContainer);
 
     // Tab Event listeners
     rTab.addEventListener('click', () => {
-      rTab.style.background = '#fff';
-      rTab.style.borderBottom = '2px solid #0070d2';
-      rTab.style.color = '#3e3e3c';
+      rTab.style.background = 'var(--sfdt-color-surface)';
+      rTab.style.borderBottom = '2px solid var(--sfdt-color-brand)';
+      rTab.style.color = 'var(--sfdt-color-text)';
       dTab.style.background = 'none';
       dTab.style.borderBottom = '0';
-      dTab.style.color = '#54698d';
+      dTab.style.color = 'var(--sfdt-color-text-weak)';
       rPanel.style.display = 'flex';
       dPanel.style.display = 'none';
     });
 
     dTab.addEventListener('click', () => {
-      dTab.style.background = '#fff';
-      dTab.style.borderBottom = '2px solid #0070d2';
-      dTab.style.color = '#3e3e3c';
+      dTab.style.background = 'var(--sfdt-color-surface)';
+      dTab.style.borderBottom = '2px solid var(--sfdt-color-brand)';
+      dTab.style.color = 'var(--sfdt-color-text)';
       rTab.style.background = 'none';
       rTab.style.borderBottom = '0';
-      rTab.style.color = '#54698d';
+      rTab.style.color = 'var(--sfdt-color-text-weak)';
       dPanel.style.display = 'flex';
       rPanel.style.display = 'none';
     });

--- a/extension/features/missing-description-flags.ts
+++ b/extension/features/missing-description-flags.ts
@@ -141,7 +141,7 @@ function flagCanvas(doc: Document, missing: readonly MissingItem[]): number {
     flag.setAttribute('aria-label', `Warning: ${text} has no description`);
     flag.textContent = '⚠';
     flag.style.cssText =
-      'position: absolute; top: 4px; right: 4px; color: #fe9339; font-size: 14px; z-index: 5;';
+      'position: absolute; top: 4px; right: 4px; color: var(--sfdt-color-warning); font-size: 14px; z-index: 5;';
     (card as HTMLElement).style.position = 'relative';
     card.appendChild(flag);
     seen.add(cardKey);
@@ -158,7 +158,7 @@ function flagCanvas(doc: Document, missing: readonly MissingItem[]): number {
       flag.title = 'This flow has no description';
       flag.setAttribute('aria-label', 'Warning: This flow has no description');
       flag.textContent = ' ⚠';
-      flag.style.cssText = 'color: #fe9339; margin-left: 4px;';
+      flag.style.cssText = 'color: var(--sfdt-color-warning); margin-left: 4px;';
       parent.appendChild(flag);
       count += 1;
     }

--- a/extension/features/org-health-live.ts
+++ b/extension/features/org-health-live.ts
@@ -39,9 +39,9 @@ export interface CheckResult extends CheckBody {
 }
 
 const BAND_COLOUR: Record<Band, string> = {
-  green: '#04844b',
-  amber: '#fe9339',
-  red: '#c23934',
+  green: 'var(--sfdt-color-success)',
+  amber: 'var(--sfdt-color-warning)',
+  red: 'var(--sfdt-color-error)',
 };
 
 // ---------------------------------------------------------------------------
@@ -124,7 +124,7 @@ export function createOrgHealthLiveFeature(options: OrgHealthLiveOptions = {}): 
 
   function renderRow(results: HTMLElement, check: CheckResult): void {
     const row = doc.createElement('div');
-    row.style.cssText = 'border: 1px solid #d8dde6; border-radius: 4px; padding: 8px 10px; margin-bottom: 6px;';
+    row.style.cssText = 'border: 1px solid var(--sfdt-color-border); border-radius: 4px; padding: 8px 10px; margin-bottom: 6px;';
 
     const head = doc.createElement('div');
     head.style.cssText = 'display: flex; align-items: center; gap: 8px;';
@@ -134,14 +134,14 @@ export function createOrgHealthLiveFeature(options: OrgHealthLiveOptions = {}): 
     titleEl.style.cssText = 'font-weight: 600; font-size: 12px;';
     titleEl.textContent = check.title;
     const summaryEl = doc.createElement('span');
-    summaryEl.style.cssText = 'color: #54698d; font-size: 11px;';
+    summaryEl.style.cssText = 'color: var(--sfdt-color-text-weak); font-size: 11px;';
     summaryEl.textContent = check.summary;
     head.append(dot, titleEl, summaryEl);
     row.appendChild(head);
 
     if (check.findings.length > 0) {
       const list = doc.createElement('ul');
-      list.style.cssText = 'margin: 6px 0 0; padding-left: 18px; color: #3e3e3c; font-size: 11px;';
+      list.style.cssText = 'margin: 6px 0 0; padding-left: 18px; color: var(--sfdt-color-text); font-size: 11px;';
       for (const f of check.findings.slice(0, 25)) {
         const li = doc.createElement('li');
         li.textContent = f;
@@ -175,7 +175,7 @@ export function createOrgHealthLiveFeature(options: OrgHealthLiveOptions = {}): 
     } catch (err) {
       const errorPanel = doc.createElement('div');
       errorPanel.style.cssText =
-        'border: 1px solid #c23934; background: #fef2f1; color: #c23934; padding: 8px 12px; border-radius: 4px; font-size: 13px;';
+        'border: 1px solid var(--sfdt-color-error); background: var(--sfdt-color-error-bg); color: var(--sfdt-color-error); padding: 8px 12px; border-radius: 4px; font-size: 13px;';
       errorPanel.textContent = err instanceof Error ? err.message : String(err);
       results.appendChild(errorPanel);
       status.textContent = 'Failed';
@@ -193,11 +193,11 @@ export function createOrgHealthLiveFeature(options: OrgHealthLiveOptions = {}): 
     const toolbar = doc.createElement('div');
     toolbar.style.cssText = 'display: flex; align-items: center; gap: 10px; margin-bottom: 12px;';
     const status = doc.createElement('span');
-    status.style.cssText = 'color: #54698d; font-size: 12px;';
+    status.style.cssText = 'color: var(--sfdt-color-text-weak); font-size: 12px;';
     const refreshBtn = doc.createElement('button');
     refreshBtn.textContent = 'Refresh';
     refreshBtn.style.cssText =
-      'margin-left: auto; padding: 4px 10px; border: 1px solid #d8dde6; background: #fff; border-radius: 4px; cursor: pointer; font-size: 12px;';
+      'margin-left: auto; padding: 4px 10px; border: 1px solid var(--sfdt-color-border); background: var(--sfdt-color-surface); border-radius: 4px; cursor: pointer; font-size: 12px;';
     toolbar.append(status, refreshBtn);
     body.appendChild(toolbar);
 

--- a/extension/features/org-health.ts
+++ b/extension/features/org-health.ts
@@ -33,10 +33,10 @@ interface Snapshot {
 // ---------------------------------------------------------------------------
 
 const BAND_COLOUR: Record<'green' | 'amber' | 'red' | 'grey', string> = {
-  green: '#04844b',
-  amber: '#fe9339',
-  red: '#c23934',
-  grey: '#80868d',
+  green: 'var(--sfdt-color-success)',
+  amber: 'var(--sfdt-color-warning)',
+  red: 'var(--sfdt-color-error)',
+  grey: 'var(--sfdt-color-text-icon)',
 };
 
 export function bandFor(status: string): 'green' | 'amber' | 'red' | 'grey' {
@@ -114,7 +114,7 @@ export function createOrgHealthFeature(options: OrgHealthOptions = {}): Feature 
     const checks = shapeChecks(snapshot);
     if (checks.length === 0) {
       const empty = doc.createElement('div');
-      empty.style.cssText = 'padding: 8px 0; color: #80868d; font-size: 12px;';
+      empty.style.cssText = 'padding: 8px 0; color: var(--sfdt-color-text-icon); font-size: 12px;';
       empty.textContent = `No data. Run \`sfdt ${command} all\` to populate.`;
       section.appendChild(empty);
       container.appendChild(section);
@@ -123,7 +123,7 @@ export function createOrgHealthFeature(options: OrgHealthOptions = {}): Feature 
 
     for (const c of checks) {
       const row = doc.createElement('div');
-      row.style.cssText = 'border: 1px solid #d8dde6; border-radius: 4px; padding: 8px 10px; margin-bottom: 6px;';
+      row.style.cssText = 'border: 1px solid var(--sfdt-color-border); border-radius: 4px; padding: 8px 10px; margin-bottom: 6px;';
 
       const head = doc.createElement('div');
       head.style.cssText = 'display: flex; align-items: center; gap: 8px;';
@@ -133,7 +133,7 @@ export function createOrgHealthFeature(options: OrgHealthOptions = {}): Feature 
       titleEl.style.cssText = 'font-weight: 600; font-size: 12px;';
       titleEl.textContent = c.title;
       const summaryEl = doc.createElement('span');
-      summaryEl.style.cssText = 'color: #54698d; font-size: 11px;';
+      summaryEl.style.cssText = 'color: var(--sfdt-color-text-weak); font-size: 11px;';
       summaryEl.textContent = c.summary;
       head.appendChild(dot);
       head.appendChild(titleEl);
@@ -142,7 +142,7 @@ export function createOrgHealthFeature(options: OrgHealthOptions = {}): Feature 
 
       if (c.findings.length > 0) {
         const list = doc.createElement('ul');
-        list.style.cssText = 'margin: 6px 0 0; padding-left: 18px; color: #3e3e3c; font-size: 11px;';
+        list.style.cssText = 'margin: 6px 0 0; padding-left: 18px; color: var(--sfdt-color-text); font-size: 11px;';
         for (const f of c.findings.slice(0, 25)) {
           const li = doc.createElement('li');
           li.textContent = describeFinding(f);
@@ -176,7 +176,7 @@ export function createOrgHealthFeature(options: OrgHealthOptions = {}): Feature 
               : '';
         const errorPanel = doc.createElement('div');
         errorPanel.style.cssText =
-          'border: 1px solid #c23934; background: #fef2f1; color: #c23934; padding: 8px 12px; border-radius: 4px; font-size: 13px;';
+          'border: 1px solid var(--sfdt-color-error); background: var(--sfdt-color-error-bg); color: var(--sfdt-color-error); padding: 8px 12px; border-radius: 4px; font-size: 13px;';
         errorPanel.textContent = `${response.error}${hint}`;
         body.appendChild(errorPanel);
         status.textContent = 'Failed';
@@ -200,7 +200,7 @@ export function createOrgHealthFeature(options: OrgHealthOptions = {}): Feature 
     } catch (err) {
       const errorPanel = doc.createElement('div');
       errorPanel.style.cssText =
-        'border: 1px solid #c23934; background: #fef2f1; color: #c23934; padding: 8px 12px; border-radius: 4px; font-size: 13px;';
+        'border: 1px solid var(--sfdt-color-error); background: var(--sfdt-color-error-bg); color: var(--sfdt-color-error); padding: 8px 12px; border-radius: 4px; font-size: 13px;';
       errorPanel.textContent = err instanceof Error ? err.message : String(err);
       body.appendChild(errorPanel);
       status.textContent = 'Failed';
@@ -219,17 +219,17 @@ export function createOrgHealthFeature(options: OrgHealthOptions = {}): Feature 
     const toolbar = doc.createElement('div');
     toolbar.style.cssText = 'display: flex; gap: 12px; align-items: center;';
     const status = doc.createElement('span');
-    status.style.cssText = 'color: #54698d; font-size: 12px;';
+    status.style.cssText = 'color: var(--sfdt-color-text-weak); font-size: 12px;';
     const actions = doc.createElement('div');
     actions.style.cssText = 'display: flex; gap: 6px; margin-left: auto;';
     const refreshBtn = doc.createElement('button');
     refreshBtn.textContent = 'Refresh';
     refreshBtn.style.cssText =
-      'padding: 4px 10px; border: 1px solid #d8dde6; background: #fff; border-radius: 4px; cursor: pointer; font-size: 12px;';
+      'padding: 4px 10px; border: 1px solid var(--sfdt-color-border); background: var(--sfdt-color-surface); border-radius: 4px; cursor: pointer; font-size: 12px;';
     const copyBtn = doc.createElement('button');
     copyBtn.textContent = 'Copy JSON';
     copyBtn.style.cssText =
-      'padding: 4px 10px; border: 1px solid #d8dde6; background: #fff; border-radius: 4px; cursor: pointer; font-size: 12px;';
+      'padding: 4px 10px; border: 1px solid var(--sfdt-color-border); background: var(--sfdt-color-surface); border-radius: 4px; cursor: pointer; font-size: 12px;';
     actions.appendChild(refreshBtn);
     actions.appendChild(copyBtn);
     toolbar.appendChild(status);

--- a/extension/features/org-limits.ts
+++ b/extension/features/org-limits.ts
@@ -36,9 +36,9 @@ export function bandFor(pct: number): 'green' | 'amber' | 'red' {
 }
 
 const BAND_COLOUR: Record<'green' | 'amber' | 'red', string> = {
-  green: '#04844b',
-  amber: '#fe9339',
-  red: '#c23934',
+  green: 'var(--sfdt-color-success)',
+  amber: 'var(--sfdt-color-warning)',
+  red: 'var(--sfdt-color-error)',
 };
 
 function humaniseName(camel: string): string {
@@ -72,7 +72,7 @@ export function createOrgLimitsFeature(options: OrgLimitsOptions = {}): Feature 
       status.textContent = `${rows.length} limits`;
       if (rows.length === 0) {
         const empty = doc.createElement('div');
-        empty.style.cssText = 'padding: 12px; color: #80868d;';
+        empty.style.cssText = 'padding: 12px; color: var(--sfdt-color-text-icon);';
         empty.textContent = 'No limits returned.';
         body.appendChild(empty);
         return raw;
@@ -83,16 +83,16 @@ export function createOrgLimitsFeature(options: OrgLimitsOptions = {}): Feature 
       for (const r of rows) {
         const card = doc.createElement('div');
         card.style.cssText =
-          'border: 1px solid #d8dde6; border-radius: 4px; padding: 10px; display: flex; flex-direction: column; gap: 6px;';
+          'border: 1px solid var(--sfdt-color-border); border-radius: 4px; padding: 10px; display: flex; flex-direction: column; gap: 6px;';
         const title = doc.createElement('div');
         title.style.cssText = 'font-weight: 600; font-size: 12px;';
         title.textContent = humaniseName(r.name);
         const usage = doc.createElement('div');
-        usage.style.cssText = 'font-size: 11px; color: #54698d;';
+        usage.style.cssText = 'font-size: 11px; color: var(--sfdt-color-text-weak);';
         usage.textContent = `${r.used.toLocaleString()} / ${r.max.toLocaleString()}  (${(r.pct * 100).toFixed(1)}%)`;
         const bar = doc.createElement('div');
         bar.style.cssText =
-          'height: 6px; background: #f3f3f3; border-radius: 3px; overflow: hidden;';
+          'height: 6px; background: var(--sfdt-color-bg); border-radius: 3px; overflow: hidden;';
         const fill = doc.createElement('div');
         const band = bandFor(r.pct);
         fill.style.cssText = `height: 100%; width: ${Math.min(100, r.pct * 100).toFixed(1)}%; background: ${BAND_COLOUR[band]};`;
@@ -107,7 +107,7 @@ export function createOrgLimitsFeature(options: OrgLimitsOptions = {}): Feature 
     } catch (err) {
       const errorPanel = doc.createElement('div');
       errorPanel.style.cssText =
-        'border: 1px solid #c23934; background: #fef2f1; color: #c23934; padding: 8px 12px; border-radius: 4px; font-size: 13px;';
+        'border: 1px solid var(--sfdt-color-error); background: var(--sfdt-color-error-bg); color: var(--sfdt-color-error); padding: 8px 12px; border-radius: 4px; font-size: 13px;';
       errorPanel.textContent = err instanceof Error ? err.message : String(err);
       body.appendChild(errorPanel);
       status.textContent = 'Failed';
@@ -126,17 +126,17 @@ export function createOrgLimitsFeature(options: OrgLimitsOptions = {}): Feature 
     const toolbar = doc.createElement('div');
     toolbar.style.cssText = 'display: flex; align-items: center; gap: 12px; margin-bottom: 12px;';
     const status = doc.createElement('span');
-    status.style.cssText = 'color: #54698d; font-size: 12px;';
+    status.style.cssText = 'color: var(--sfdt-color-text-weak); font-size: 12px;';
     const actions = doc.createElement('div');
     actions.style.cssText = 'display: flex; gap: 6px; margin-left: auto;';
     const refreshBtn = doc.createElement('button');
     refreshBtn.textContent = 'Refresh';
     refreshBtn.style.cssText =
-      'padding: 4px 10px; border: 1px solid #d8dde6; background: #fff; border-radius: 4px; cursor: pointer; font-size: 12px;';
+      'padding: 4px 10px; border: 1px solid var(--sfdt-color-border); background: var(--sfdt-color-surface); border-radius: 4px; cursor: pointer; font-size: 12px;';
     const copyBtn = doc.createElement('button');
     copyBtn.textContent = 'Copy JSON';
     copyBtn.style.cssText =
-      'padding: 4px 10px; border: 1px solid #d8dde6; background: #fff; border-radius: 4px; cursor: pointer; font-size: 12px;';
+      'padding: 4px 10px; border: 1px solid var(--sfdt-color-border); background: var(--sfdt-color-surface); border-radius: 4px; cursor: pointer; font-size: 12px;';
     actions.appendChild(refreshBtn);
     actions.appendChild(copyBtn);
     toolbar.appendChild(status);

--- a/extension/features/org-release-badge.ts
+++ b/extension/features/org-release-badge.ts
@@ -12,8 +12,8 @@ import { getSalesforceApi, type SalesforceApiClient } from '../lib/salesforce-ap
 // API, so it's deliberately out of scope — version + preview only.
 
 const BADGE_CLASS = 'sfdt-org-release-badge';
-const PREVIEW_COLOUR = '#fe9339'; // amber — matches org-health-live's preview/amber band
-const GA_COLOUR = '#706e6b'; // neutral grey
+const PREVIEW_COLOUR = 'var(--sfdt-color-warning)'; // amber — matches org-health-live's preview/amber band
+const GA_COLOUR = 'var(--sfdt-color-text-muted)'; // neutral grey
 
 interface OrgRow {
   InstanceName?: string | null;
@@ -85,7 +85,7 @@ function buildBadge(doc: Document, data: BadgeData): HTMLLIElement {
     'font-weight: 700',
     'text-transform: uppercase',
     'letter-spacing: 0.02em',
-    'color: #fff',
+    'color: var(--sfdt-color-surface)',
     `background: ${preview ? PREVIEW_COLOUR : GA_COLOUR}`,
     'border-radius: 3px',
     'padding: 2px 8px',

--- a/extension/features/org-switcher.ts
+++ b/extension/features/org-switcher.ts
@@ -85,7 +85,7 @@ export function createOrgSwitcherFeature(options: OrgSwitcherOptions = {}): Feat
     list.style.cssText =
       'padding: 8px; overflow-y: auto; flex: 1; display: flex; flex-direction: column; gap: 4px;';
     const loading = doc.createElement('div');
-    loading.style.cssText = 'padding: 12px; color: #54698d; font-size: 12px;';
+    loading.style.cssText = 'padding: 12px; color: var(--sfdt-color-text-weak); font-size: 12px;';
     loading.textContent = 'Finding logged-in orgs…';
     list.appendChild(loading);
 
@@ -103,7 +103,7 @@ export function createOrgSwitcherFeature(options: OrgSwitcherOptions = {}): Feat
     while (list.firstChild) list.removeChild(list.firstChild);
     if (orgs.length === 0) {
       const empty = doc.createElement('div');
-      empty.style.cssText = 'padding: 12px; color: #80868d; font-size: 12px;';
+      empty.style.cssText = 'padding: 12px; color: var(--sfdt-color-text-icon); font-size: 12px;';
       empty.textContent =
         'No logged-in Salesforce orgs found. Log in to an org in another tab, then retry.';
       list.appendChild(empty);
@@ -112,13 +112,13 @@ export function createOrgSwitcherFeature(options: OrgSwitcherOptions = {}): Feat
     for (const org of orgs) {
       const item = doc.createElement('button');
       item.style.cssText =
-        'text-align: left; padding: 10px 12px; border: 1px solid #eef1f4; background: #fff; border-radius: 4px; cursor: pointer; display: flex; flex-direction: column; gap: 2px;';
+        'text-align: left; padding: 10px 12px; border: 1px solid var(--sfdt-color-surface-shade-3); background: var(--sfdt-color-surface); border-radius: 4px; cursor: pointer; display: flex; flex-direction: column; gap: 2px;';
       const name = doc.createElement('span');
       name.textContent = org.displayName;
-      name.style.cssText = 'font-weight: 600; font-size: 13px; color: #16325c;';
+      name.style.cssText = 'font-weight: 600; font-size: 13px; color: var(--sfdt-color-brand-deep);';
       const host = doc.createElement('span');
       host.textContent = org.host;
-      host.style.cssText = 'font-size: 11px; color: #80868d; font-family: ui-monospace, monospace;';
+      host.style.cssText = 'font-size: 11px; color: var(--sfdt-color-text-icon); font-family: ui-monospace, monospace;';
       item.appendChild(name);
       item.appendChild(host);
       item.addEventListener('click', () => void apply(org.host));

--- a/extension/features/rest-explore.ts
+++ b/extension/features/rest-explore.ts
@@ -111,7 +111,7 @@ export function createRestExploreFeature(options: RestExploreOptions = {}): Feat
     form.style.cssText = 'display: flex; gap: 8px; align-items: center;';
     const methodSelect = doc.createElement('select');
     methodSelect.style.cssText =
-      'padding: 6px 8px; border: 1px solid #d8dde6; border-radius: 4px; font-size: 13px;';
+      'padding: 6px 8px; border: 1px solid var(--sfdt-color-border); border-radius: 4px; font-size: 13px;';
     for (const m of ['GET', 'POST', 'PATCH', 'PUT', 'DELETE'] as const) {
       const opt = doc.createElement('option');
       opt.value = m;
@@ -124,11 +124,11 @@ export function createRestExploreFeature(options: RestExploreOptions = {}): Feat
     pathInput.value = `/services/data/${DEFAULT_API_VERSION}/`;
     pathInput.placeholder = `/services/data/${DEFAULT_API_VERSION}/sobjects/Account/describe`;
     pathInput.style.cssText =
-      'flex: 1; padding: 6px 8px; border: 1px solid #d8dde6; border-radius: 4px; font-family: ui-monospace, monospace; font-size: 12px;';
+      'flex: 1; padding: 6px 8px; border: 1px solid var(--sfdt-color-border); border-radius: 4px; font-family: ui-monospace, monospace; font-size: 12px;';
     const sendBtn = doc.createElement('button');
     sendBtn.textContent = 'Send';
     sendBtn.style.cssText =
-      'padding: 6px 14px; background: #0070d2; color: #fff; border: 0; border-radius: 4px; cursor: pointer; font-size: 13px;';
+      'padding: 6px 14px; background: var(--sfdt-color-brand); color: var(--sfdt-color-surface); border: 0; border-radius: 4px; cursor: pointer; font-size: 13px;';
     form.appendChild(methodSelect);
     form.appendChild(pathInput);
     form.appendChild(sendBtn);
@@ -137,7 +137,7 @@ export function createRestExploreFeature(options: RestExploreOptions = {}): Feat
     const bodyTextarea = doc.createElement('textarea');
     bodyTextarea.placeholder = 'JSON body (POST / PATCH / PUT)';
     bodyTextarea.style.cssText =
-      'width: 100%; min-height: 100px; font-family: ui-monospace, monospace; font-size: 12px; padding: 8px; border: 1px solid #d8dde6; border-radius: 4px; resize: vertical; display: none;';
+      'width: 100%; min-height: 100px; font-family: ui-monospace, monospace; font-size: 12px; padding: 8px; border: 1px solid var(--sfdt-color-border); border-radius: 4px; resize: vertical; display: none;';
 
     function syncBodyVisibility(): void {
       bodyTextarea.style.display = METHODS_WITH_BODY.has(methodSelect.value as HttpMethod) ? 'block' : 'none';
@@ -147,17 +147,17 @@ export function createRestExploreFeature(options: RestExploreOptions = {}): Feat
     body.appendChild(bodyTextarea);
 
     const status = doc.createElement('div');
-    status.style.cssText = 'color: #54698d; font-size: 12px;';
+    status.style.cssText = 'color: var(--sfdt-color-text-weak); font-size: 12px;';
     body.appendChild(status);
 
     const errorPanel = doc.createElement('div');
     errorPanel.style.cssText =
-      'display: none; border: 1px solid #c23934; background: #fef2f1; color: #c23934; padding: 8px 12px; border-radius: 4px; font-size: 13px; white-space: pre-wrap;';
+      'display: none; border: 1px solid var(--sfdt-color-error); background: var(--sfdt-color-error-bg); color: var(--sfdt-color-error); padding: 8px 12px; border-radius: 4px; font-size: 13px; white-space: pre-wrap;';
     body.appendChild(errorPanel);
 
     const responsePane = doc.createElement('pre');
     responsePane.style.cssText =
-      'margin: 0; padding: 10px; background: #fafaf9; border: 1px solid #d8dde6; border-radius: 4px; overflow: auto; max-height: 360px; font-family: ui-monospace, monospace; font-size: 12px; display: none; white-space: pre-wrap;';
+      'margin: 0; padding: 10px; background: var(--sfdt-color-surface-alt); border: 1px solid var(--sfdt-color-border); border-radius: 4px; overflow: auto; max-height: 360px; font-family: ui-monospace, monospace; font-size: 12px; display: none; white-space: pre-wrap;';
     body.appendChild(responsePane);
 
     let lastResponse: unknown = null;
@@ -167,7 +167,7 @@ export function createRestExploreFeature(options: RestExploreOptions = {}): Feat
     const copyBtn = doc.createElement('button');
     copyBtn.textContent = 'Copy response';
     copyBtn.style.cssText =
-      'padding: 6px 12px; border: 1px solid #d8dde6; background: #fff; border-radius: 4px; cursor: pointer; font-size: 12px; display: none;';
+      'padding: 6px 12px; border: 1px solid var(--sfdt-color-border); background: var(--sfdt-color-surface); border-radius: 4px; cursor: pointer; font-size: 12px; display: none;';
     footer.appendChild(copyBtn);
 
     let historyMenu: HTMLDivElement | null = null;
@@ -175,13 +175,13 @@ export function createRestExploreFeature(options: RestExploreOptions = {}): Feat
       const historyBtn = doc.createElement('button');
       historyBtn.textContent = '▸ History ▾';
       historyBtn.style.cssText =
-        'padding: 6px 10px; border: 1px solid #d8dde6; background: #fff; border-radius: 4px; cursor: pointer; font-size: 12px;';
+        'padding: 6px 10px; border: 1px solid var(--sfdt-color-border); background: var(--sfdt-color-surface); border-radius: 4px; cursor: pointer; font-size: 12px;';
       const histWrap = doc.createElement('div');
       histWrap.style.cssText = 'position: relative; margin-left: auto;';
       histWrap.appendChild(historyBtn);
       historyMenu = doc.createElement('div');
       historyMenu.style.cssText =
-        'display: none; position: absolute; top: 100%; right: 0; background: #fff; border: 1px solid #d8dde6; border-radius: 4px; min-width: 420px; max-height: 280px; overflow-y: auto; z-index: 100021; box-shadow: 0 2px 8px rgba(0,0,0,0.15);';
+        'display: none; position: absolute; top: 100%; right: 0; background: var(--sfdt-color-surface); border: 1px solid var(--sfdt-color-border); border-radius: 4px; min-width: 420px; max-height: 280px; overflow-y: auto; z-index: 100021; box-shadow: 0 2px 8px rgba(0,0,0,0.15);';
       histWrap.appendChild(historyMenu);
       historyBtn.addEventListener('click', async (e) => {
         e.stopPropagation();
@@ -201,7 +201,7 @@ export function createRestExploreFeature(options: RestExploreOptions = {}): Feat
       const clearBtn = doc.createElement('button');
       clearBtn.textContent = 'Clear history';
       clearBtn.style.cssText =
-        'padding: 6px 10px; border: 1px solid #d8dde6; background: #fff; border-radius: 4px; cursor: pointer; font-size: 12px;';
+        'padding: 6px 10px; border: 1px solid var(--sfdt-color-border); background: var(--sfdt-color-surface); border-radius: 4px; cursor: pointer; font-size: 12px;';
       clearBtn.addEventListener('click', async () => {
         await clearRestHistory();
         showToast('History cleared', { doc, kind: 'success' });
@@ -237,7 +237,7 @@ export function createRestExploreFeature(options: RestExploreOptions = {}): Feat
       const entries = await readRestHistory();
       if (entries.length === 0) {
         const empty = doc.createElement('div');
-        empty.style.cssText = 'padding: 10px; color: #80868d; font-size: 12px;';
+        empty.style.cssText = 'padding: 10px; color: var(--sfdt-color-text-icon); font-size: 12px;';
         empty.textContent = 'No requests yet.';
         historyMenu.appendChild(empty);
         return;
@@ -245,11 +245,11 @@ export function createRestExploreFeature(options: RestExploreOptions = {}): Feat
       for (const entry of entries) {
         const item = doc.createElement('div');
         item.style.cssText =
-          'padding: 8px 10px; cursor: pointer; border-bottom: 1px solid #f3f3f3; font-family: ui-monospace, monospace; font-size: 11px;';
+          'padding: 8px 10px; cursor: pointer; border-bottom: 1px solid var(--sfdt-color-bg); font-family: ui-monospace, monospace; font-size: 11px;';
         const badge = doc.createElement('span');
         badge.textContent = entry.method;
         badge.style.cssText =
-          'display: inline-block; min-width: 50px; padding: 1px 4px; border-radius: 3px; background: #16325c; color: #fff; font-weight: 600; margin-right: 6px; text-align: center;';
+          'display: inline-block; min-width: 50px; padding: 1px 4px; border-radius: 3px; background: var(--sfdt-color-brand-deep); color: var(--sfdt-color-surface); font-weight: 600; margin-right: 6px; text-align: center;';
         const text = doc.createElement('span');
         text.textContent = entry.path;
         item.appendChild(badge);

--- a/extension/features/saved-soql.ts
+++ b/extension/features/saved-soql.ts
@@ -72,18 +72,18 @@ export function createSavedSoqlFeature(options: SavedSoqlOptions = {}): Feature 
     function sectionTitle(text: string): HTMLDivElement {
       const t = doc.createElement('div');
       t.textContent = text;
-      t.style.cssText = 'font-weight: 600; font-size: 13px; color: #16325c;';
+      t.style.cssText = 'font-weight: 600; font-size: 13px; color: var(--sfdt-color-brand-deep);';
       return t;
     }
 
     function queryRow(q: string, apiMode: SavedQuery['api'], onDelete?: () => void): HTMLDivElement {
       const row = doc.createElement('div');
       row.style.cssText =
-        'display: flex; gap: 8px; align-items: center; padding: 6px 8px; border: 1px solid #eef1f4; border-radius: 4px;';
+        'display: flex; gap: 8px; align-items: center; padding: 6px 8px; border: 1px solid var(--sfdt-color-surface-shade-3); border-radius: 4px;';
       const badge = doc.createElement('span');
       badge.textContent = apiMode === 'tooling' ? 'Tooling' : 'REST';
       badge.style.cssText =
-        'min-width: 54px; text-align: center; font-size: 10px; padding: 2px 4px; border-radius: 3px; background: #16325c; color: #fff;';
+        'min-width: 54px; text-align: center; font-size: 10px; padding: 2px 4px; border-radius: 3px; background: var(--sfdt-color-brand-deep); color: var(--sfdt-color-surface);';
       const text = doc.createElement('span');
       text.textContent = q;
       text.style.cssText =
@@ -91,7 +91,7 @@ export function createSavedSoqlFeature(options: SavedSoqlOptions = {}): Feature 
       const loadBtn = doc.createElement('button');
       loadBtn.textContent = 'Load';
       loadBtn.style.cssText =
-        'padding: 4px 10px; background: #0070d2; color: #fff; border: 0; border-radius: 4px; cursor: pointer; font-size: 11px;';
+        'padding: 4px 10px; background: var(--sfdt-color-brand); color: var(--sfdt-color-surface); border: 0; border-radius: 4px; cursor: pointer; font-size: 11px;';
       loadBtn.addEventListener('click', () => void loadInRunner(q, apiMode));
       row.appendChild(badge);
       row.appendChild(text);
@@ -100,7 +100,7 @@ export function createSavedSoqlFeature(options: SavedSoqlOptions = {}): Feature 
         const delBtn = doc.createElement('button');
         delBtn.textContent = '🗑';
         delBtn.style.cssText =
-          'padding: 4px 8px; background: #fff; border: 1px solid #d8dde6; border-radius: 4px; cursor: pointer; font-size: 11px;';
+          'padding: 4px 8px; background: var(--sfdt-color-surface); border: 1px solid var(--sfdt-color-border); border-radius: 4px; cursor: pointer; font-size: 11px;';
         delBtn.addEventListener('click', onDelete);
         row.appendChild(delBtn);
       }
@@ -121,7 +121,7 @@ export function createSavedSoqlFeature(options: SavedSoqlOptions = {}): Feature 
       const saved = await readSavedQueries();
       if (saved.length === 0) {
         const empty = doc.createElement('div');
-        empty.style.cssText = 'color: #80868d; font-size: 12px;';
+        empty.style.cssText = 'color: var(--sfdt-color-text-icon); font-size: 12px;';
         empty.textContent = 'No bookmarks yet. Save queries from the SOQL Runner (★ Save).';
         savedList.appendChild(empty);
         return;
@@ -129,7 +129,7 @@ export function createSavedSoqlFeature(options: SavedSoqlOptions = {}): Feature 
       for (const item of saved) {
         const nameLabel = doc.createElement('div');
         nameLabel.textContent = item.name;
-        nameLabel.style.cssText = 'font-size: 12px; color: #54698d; margin-top: 2px;';
+        nameLabel.style.cssText = 'font-size: 12px; color: var(--sfdt-color-text-weak); margin-top: 2px;';
         savedList.appendChild(nameLabel);
         savedList.appendChild(
           queryRow(item.q, item.api, async () => {
@@ -154,7 +154,7 @@ export function createSavedSoqlFeature(options: SavedSoqlOptions = {}): Feature 
       const history = await readSoqlHistory();
       if (history.length === 0) {
         const empty = doc.createElement('div');
-        empty.style.cssText = 'color: #80868d; font-size: 12px;';
+        empty.style.cssText = 'color: var(--sfdt-color-text-icon); font-size: 12px;';
         empty.textContent = 'No recent queries.';
         histList.appendChild(empty);
       } else {

--- a/extension/features/scheduled-flow-explorer.ts
+++ b/extension/features/scheduled-flow-explorer.ts
@@ -128,7 +128,7 @@ function buildModal(doc: Document, result: DiscoveryResult, now: Date): HTMLDivE
   if (result.flows.length === 0) {
     const empty = doc.createElement('div');
     empty.textContent = 'No active Schedule-Triggered Flows in this org.';
-    empty.style.color = '#80868d';
+    empty.style.color = 'var(--sfdt-color-text-icon)';
     body.appendChild(empty);
   } else {
     const list = doc.createElement('div');
@@ -136,12 +136,12 @@ function buildModal(doc: Document, result: DiscoveryResult, now: Date): HTMLDivE
       const next = calculateNextRun(entry.parsedSchedule, entry.activationDate, now);
       const row = doc.createElement('div');
       row.style.cssText =
-        'padding: 10px; border: 1px solid #d8dde6; border-radius: 4px; margin-bottom: 8px;';
+        'padding: 10px; border: 1px solid var(--sfdt-color-border); border-radius: 4px; margin-bottom: 8px;';
       const title = doc.createElement('div');
       title.style.fontWeight = '600';
       title.textContent = entry.label;
       const meta = doc.createElement('div');
-      meta.style.cssText = 'color: #80868d; font-size: 12px; margin-top: 4px;';
+      meta.style.cssText = 'color: var(--sfdt-color-text-icon); font-size: 12px; margin-top: 4px;';
       meta.textContent = `${entry.parsedSchedule.frequency} · ${entry.parsedSchedule.targetObject ?? 'no target object'}`;
       const nextRun = doc.createElement('div');
       nextRun.style.cssText = 'margin-top: 4px; font-size: 13px;';
@@ -159,7 +159,7 @@ function buildModal(doc: Document, result: DiscoveryResult, now: Date): HTMLDivE
   if (result.errors.length > 0) {
     const errBox = doc.createElement('div');
     errBox.style.cssText =
-      'margin-top: 12px; padding: 10px; background: #fef2f1; border: 1px solid #c23934; border-radius: 4px; font-size: 12px;';
+      'margin-top: 12px; padding: 10px; background: var(--sfdt-color-error-bg); border: 1px solid var(--sfdt-color-error); border-radius: 4px; font-size: 12px;';
     errBox.textContent = `${result.errors.length} flow${result.errors.length === 1 ? '' : 's'} could not be loaded.`;
     body.appendChild(errBox);
   }
@@ -197,7 +197,7 @@ export function createScheduledFlowExplorerFeature(
 
       const loadingOverlay = doc.createElement('div');
       loadingOverlay.style.cssText =
-        'position: fixed; inset: 0; background: rgba(0,0,0,0.4); z-index: 100020; display: flex; align-items: center; justify-content: center; color: #fff; font-family: system-ui, sans-serif;';
+        'position: fixed; inset: 0; background: rgba(0,0,0,0.4); z-index: 100020; display: flex; align-items: center; justify-content: center; color: var(--sfdt-color-surface); font-family: system-ui, sans-serif;';
       loadingOverlay.textContent = 'Discovering scheduled flows…';
       doc.body.appendChild(loadingOverlay);
       try {

--- a/extension/features/show-api-names.ts
+++ b/extension/features/show-api-names.ts
@@ -210,7 +210,7 @@ function makeApiSpan(doc: Document, text: string): HTMLSpanElement {
   const span = doc.createElement('span');
   span.className = MARKER_CLASS;
   span.textContent = `(${text})`;
-  span.style.cssText = 'font-weight: normal; color: #a9a9a9; margin-left: 0.5rem;';
+  span.style.cssText = 'font-weight: normal; color: var(--sfdt-color-text-faint); margin-left: 0.5rem;';
   return span;
 }
 
@@ -432,7 +432,7 @@ export function createShowApiNamesFeature(options: ShowApiNamesOptions = {}): Fe
     body.appendChild(toggleLabel);
 
     const hint = doc.createElement('div');
-    hint.style.cssText = 'color: #54698d; font-size: 12px;';
+    hint.style.cssText = 'color: var(--sfdt-color-text-weak); font-size: 12px;';
     hint.textContent = ctx
       ? `Current record: ${ctx.sobjectName} · ${ctx.recordId}`
       : 'Open a Lightning record page to use the copy helpers.';
@@ -445,7 +445,7 @@ export function createShowApiNamesFeature(options: ShowApiNamesOptions = {}): Fe
       btn.textContent = label;
       btn.disabled = !ctx;
       btn.style.cssText =
-        'padding: 6px 12px; background: #0070d2; color: #fff; border: 0; border-radius: 4px; cursor: pointer; font-size: 13px;' +
+        'padding: 6px 12px; background: var(--sfdt-color-brand); color: var(--sfdt-color-surface); border: 0; border-radius: 4px; cursor: pointer; font-size: 13px;' +
         (ctx ? '' : ' opacity: 0.5; cursor: not-allowed;');
       btn.addEventListener('click', () => void onClick());
       buttonRow.appendChild(btn);

--- a/extension/features/soap-explore.ts
+++ b/extension/features/soap-explore.ts
@@ -121,14 +121,14 @@ export function createSoapExploreFeature(options: {
 
     // Working spinner lives at the top of the body (presentView's header is title + × only).
     const spinner = doc.createElement('div');
-    spinner.style.cssText = 'border: 2px solid #f3f3f3; border-top: 2px solid #0070d2; border-radius: 50%; width: 14px; height: 14px; animation: spin 1s linear infinite; display: none;';
+    spinner.style.cssText = 'border: 2px solid var(--sfdt-color-bg); border-top: 2px solid var(--sfdt-color-brand); border-radius: 50%; width: 14px; height: 14px; animation: spin 1s linear infinite; display: none;';
 
     const configRow = doc.createElement('div');
     configRow.style.cssText = 'display: flex; gap: 8px; align-items: center;';
     configRow.appendChild(spinner);
 
     const wsdlSelect = doc.createElement('select');
-    wsdlSelect.style.cssText = 'padding: 6px 8px; border: 1px solid #d8dde6; border-radius: 4px; font-size: 13px; outline: none;';
+    wsdlSelect.style.cssText = 'padding: 6px 8px; border: 1px solid var(--sfdt-color-border); border-radius: 4px; font-size: 13px; outline: none;';
     (['Partner', 'Metadata', 'Tooling', 'Enterprise', 'Apex'] as const).forEach(w => {
       const opt = doc.createElement('option');
       opt.value = w;
@@ -140,24 +140,24 @@ export function createSoapExploreFeature(options: {
     opInput.type = 'text';
     opInput.placeholder = 'Operation (e.g. getUserInfo)';
     opInput.value = 'getUserInfo';
-    opInput.style.cssText = 'flex: 1; padding: 6px 8px; border: 1px solid #d8dde6; border-radius: 4px; font-size: 13px; outline: none;';
+    opInput.style.cssText = 'flex: 1; padding: 6px 8px; border: 1px solid var(--sfdt-color-border); border-radius: 4px; font-size: 13px; outline: none;';
 
     const opSelect = doc.createElement('select');
-    opSelect.style.cssText = 'padding: 6px 8px; border: 1px solid #d8dde6; border-radius: 4px; font-size: 13px; outline: none;';
+    opSelect.style.cssText = 'padding: 6px 8px; border: 1px solid var(--sfdt-color-border); border-radius: 4px; font-size: 13px; outline: none;';
     configRow.appendChild(wsdlSelect);
     configRow.appendChild(opSelect);
     configRow.appendChild(opInput);
 
     const sendBtn = doc.createElement('button');
     sendBtn.textContent = 'Send';
-    sendBtn.style.cssText = 'padding: 6px 14px; background: #0070d2; color: #fff; border: 0; border-radius: 4px; cursor: pointer; font-size: 13px; font-weight: 600;';
+    sendBtn.style.cssText = 'padding: 6px 14px; background: var(--sfdt-color-brand); color: var(--sfdt-color-surface); border: 0; border-radius: 4px; cursor: pointer; font-size: 13px; font-weight: 600;';
     configRow.appendChild(sendBtn);
     body.appendChild(configRow);
 
     const payloadTextarea = doc.createElement('textarea');
     payloadTextarea.placeholder = 'JSON arguments';
     payloadTextarea.value = '{}';
-    payloadTextarea.style.cssText = 'width: 100%; min-height: 120px; font-family: monospace; font-size: 12px; padding: 8px; border: 1px solid #d8dde6; border-radius: 4px; resize: vertical; outline: none;';
+    payloadTextarea.style.cssText = 'width: 100%; min-height: 120px; font-family: monospace; font-size: 12px; padding: 8px; border: 1px solid var(--sfdt-color-border); border-radius: 4px; resize: vertical; outline: none;';
     body.appendChild(payloadTextarea);
 
     function syncOperations(): void {
@@ -207,15 +207,15 @@ export function createSoapExploreFeature(options: {
     syncOperations();
 
     const statusPanel = doc.createElement('div');
-    statusPanel.style.cssText = 'color: #54698d; font-size: 12px;';
+    statusPanel.style.cssText = 'color: var(--sfdt-color-text-weak); font-size: 12px;';
     body.appendChild(statusPanel);
 
     const errorPanel = doc.createElement('div');
-    errorPanel.style.cssText = 'display: none; border: 1px solid #c23934; background: #fef2f1; color: #c23934; padding: 8px 12px; border-radius: 4px; font-size: 13px; white-space: pre-wrap;';
+    errorPanel.style.cssText = 'display: none; border: 1px solid var(--sfdt-color-error); background: var(--sfdt-color-error-bg); color: var(--sfdt-color-error); padding: 8px 12px; border-radius: 4px; font-size: 13px; white-space: pre-wrap;';
     body.appendChild(errorPanel);
 
     const responsePane = doc.createElement('pre');
-    responsePane.style.cssText = 'margin: 0; padding: 10px; background: #fafaf9; border: 1px solid #d8dde6; border-radius: 4px; overflow: auto; max-height: 280px; font-family: monospace; font-size: 12px; display: none; white-space: pre-wrap;';
+    responsePane.style.cssText = 'margin: 0; padding: 10px; background: var(--sfdt-color-surface-alt); border: 1px solid var(--sfdt-color-border); border-radius: 4px; overflow: auto; max-height: 280px; font-family: monospace; font-size: 12px; display: none; white-space: pre-wrap;';
     body.appendChild(responsePane);
 
     let lastResponse: any = null;
@@ -224,19 +224,19 @@ export function createSoapExploreFeature(options: {
     footer.style.cssText = 'display: flex; gap: 8px; align-items: center;';
     const copyBtn = doc.createElement('button');
     copyBtn.textContent = 'Copy response';
-    copyBtn.style.cssText = 'padding: 6px 12px; border: 1px solid #d8dde6; background: #fff; border-radius: 4px; cursor: pointer; font-size: 12px; display: none;';
+    copyBtn.style.cssText = 'padding: 6px 12px; border: 1px solid var(--sfdt-color-border); background: var(--sfdt-color-surface); border-radius: 4px; cursor: pointer; font-size: 12px; display: none;';
     footer.appendChild(copyBtn);
 
     let historyMenu: HTMLDivElement | null = null;
     if (historyEnabled) {
       const historyBtn = doc.createElement('button');
       historyBtn.textContent = '▸ History ▾';
-      historyBtn.style.cssText = 'padding: 6px 10px; border: 1px solid #d8dde6; background: #fff; border-radius: 4px; cursor: pointer; font-size: 12px;';
+      historyBtn.style.cssText = 'padding: 6px 10px; border: 1px solid var(--sfdt-color-border); background: var(--sfdt-color-surface); border-radius: 4px; cursor: pointer; font-size: 12px;';
       const histWrap = doc.createElement('div');
       histWrap.style.cssText = 'position: relative; margin-left: auto;';
       histWrap.appendChild(historyBtn);
       historyMenu = doc.createElement('div');
-      historyMenu.style.cssText = 'display: none; position: absolute; top: 100%; right: 0; background: #fff; border: 1px solid #d8dde6; border-radius: 4px; min-width: 420px; max-height: 280px; overflow-y: auto; z-index: 100021; box-shadow: 0 2px 8px rgba(0,0,0,0.15);';
+      historyMenu.style.cssText = 'display: none; position: absolute; top: 100%; right: 0; background: var(--sfdt-color-surface); border: 1px solid var(--sfdt-color-border); border-radius: 4px; min-width: 420px; max-height: 280px; overflow-y: auto; z-index: 100021; box-shadow: 0 2px 8px rgba(0,0,0,0.15);';
       histWrap.appendChild(historyMenu);
       historyBtn.addEventListener('click', async (e) => {
         e.stopPropagation();
@@ -256,7 +256,7 @@ export function createSoapExploreFeature(options: {
       doc.addEventListener('click', docClickHandler);
       const clearBtn = doc.createElement('button');
       clearBtn.textContent = 'Clear history';
-      clearBtn.style.cssText = 'padding: 6px 10px; border: 1px solid #d8dde6; background: #fff; border-radius: 4px; cursor: pointer; font-size: 12px;';
+      clearBtn.style.cssText = 'padding: 6px 10px; border: 1px solid var(--sfdt-color-border); background: var(--sfdt-color-surface); border-radius: 4px; cursor: pointer; font-size: 12px;';
       clearBtn.addEventListener('click', async () => {
         await clearSoapHistory();
         showToast('History cleared', { doc, kind: 'success' });
@@ -295,17 +295,17 @@ export function createSoapExploreFeature(options: {
       const entries = await readSoapHistory();
       if (entries.length === 0) {
         const empty = doc.createElement('div');
-        empty.style.cssText = 'padding: 10px; color: #80868d; font-size: 12px;';
+        empty.style.cssText = 'padding: 10px; color: var(--sfdt-color-text-icon); font-size: 12px;';
         empty.textContent = 'No requests yet.';
         historyMenu.appendChild(empty);
         return;
       }
       entries.forEach(entry => {
         const item = doc.createElement('div');
-        item.style.cssText = 'padding: 8px 10px; cursor: pointer; border-bottom: 1px solid #f3f3f3; font-family: monospace; font-size: 11px;';
+        item.style.cssText = 'padding: 8px 10px; cursor: pointer; border-bottom: 1px solid var(--sfdt-color-bg); font-family: monospace; font-size: 11px;';
         const badge = doc.createElement('span');
         badge.textContent = entry.wsdl;
-        badge.style.cssText = 'display: inline-block; min-width: 60px; padding: 1px 4px; border-radius: 3px; background: #16325c; color: #fff; font-weight: 600; margin-right: 6px; text-align: center;';
+        badge.style.cssText = 'display: inline-block; min-width: 60px; padding: 1px 4px; border-radius: 3px; background: var(--sfdt-color-brand-deep); color: var(--sfdt-color-surface); font-weight: 600; margin-right: 6px; text-align: center;';
         const text = doc.createElement('span');
         text.textContent = entry.operation;
         item.appendChild(badge);

--- a/extension/features/soql-runner.ts
+++ b/extension/features/soql-runner.ts
@@ -443,14 +443,14 @@ export function createSoqlRunnerFeature(options: SoqlRunnerOptions = {}): Featur
     const setMode = (next: ApiMode): void => {
       mode = next;
       const isRest = next === 'rest';
-      restBtn.style.background = isRest ? '#0070d2' : '#fff';
-      restBtn.style.color = isRest ? '#fff' : '#16325c';
-      toolingBtn.style.background = isRest ? '#fff' : '#0070d2';
-      toolingBtn.style.color = isRest ? '#16325c' : '#fff';
+      restBtn.style.background = isRest ? 'var(--sfdt-color-brand)' : 'var(--sfdt-color-surface)';
+      restBtn.style.color = isRest ? 'var(--sfdt-color-surface)' : 'var(--sfdt-color-brand-deep)';
+      toolingBtn.style.background = isRest ? 'var(--sfdt-color-surface)' : 'var(--sfdt-color-brand)';
+      toolingBtn.style.color = isRest ? 'var(--sfdt-color-brand-deep)' : 'var(--sfdt-color-surface)';
       void runAutocomplete();
     };
     const togStyle =
-      'padding: 4px 12px; border: 1px solid #d8dde6; cursor: pointer; font-size: 12px;';
+      'padding: 4px 12px; border: 1px solid var(--sfdt-color-border); cursor: pointer; font-size: 12px;';
     restBtn.style.cssText = togStyle + ' border-radius: 4px 0 0 4px;';
     toolingBtn.style.cssText = togStyle + ' border-radius: 0 4px 4px 0;';
     restBtn.textContent = 'REST';
@@ -465,13 +465,13 @@ export function createSoqlRunnerFeature(options: SoqlRunnerOptions = {}): Featur
       const historyBtn = doc.createElement('button');
       historyBtn.textContent = '▸ History ▾';
       historyBtn.style.cssText =
-        'padding: 4px 10px; border: 1px solid #d8dde6; background: #fff; border-radius: 4px; cursor: pointer; font-size: 12px;';
+        'padding: 4px 10px; border: 1px solid var(--sfdt-color-border); background: var(--sfdt-color-surface); border-radius: 4px; cursor: pointer; font-size: 12px;';
       const histWrap = doc.createElement('div');
       histWrap.style.cssText = 'position: relative;';
       histWrap.appendChild(historyBtn);
       historyMenu = doc.createElement('div');
       historyMenu.style.cssText =
-        'display: none; position: absolute; top: 100%; left: 0; background: #fff; border: 1px solid #d8dde6; border-radius: 4px; min-width: 360px; max-width: 600px; max-height: 280px; overflow-y: auto; z-index: 100021; box-shadow: 0 2px 8px rgba(0,0,0,0.15);';
+        'display: none; position: absolute; top: 100%; left: 0; background: var(--sfdt-color-surface); border: 1px solid var(--sfdt-color-border); border-radius: 4px; min-width: 360px; max-width: 600px; max-height: 280px; overflow-y: auto; z-index: 100021; box-shadow: 0 2px 8px rgba(0,0,0,0.15);';
       histWrap.appendChild(historyMenu);
       historyBtn.addEventListener('click', async (e) => {
         e.stopPropagation();
@@ -495,13 +495,13 @@ export function createSoqlRunnerFeature(options: SoqlRunnerOptions = {}): Featur
     const savedQueriesBtn = doc.createElement('button');
     savedQueriesBtn.textContent = '★ Bookmarks ▾';
     savedQueriesBtn.style.cssText =
-      'padding: 4px 10px; border: 1px solid #d8dde6; background: #fff; border-radius: 4px; cursor: pointer; font-size: 12px;';
+      'padding: 4px 10px; border: 1px solid var(--sfdt-color-border); background: var(--sfdt-color-surface); border-radius: 4px; cursor: pointer; font-size: 12px;';
     const savedWrap = doc.createElement('div');
     savedWrap.style.cssText = 'position: relative;';
     savedWrap.appendChild(savedQueriesBtn);
     const savedQueriesMenu = doc.createElement('div');
     savedQueriesMenu.style.cssText =
-      'display: none; position: absolute; top: 100%; left: 0; background: #fff; border: 1px solid #d8dde6; border-radius: 4px; min-width: 360px; max-width: 600px; max-height: 280px; overflow-y: auto; z-index: 100021; box-shadow: 0 2px 8px rgba(0,0,0,0.15);';
+      'display: none; position: absolute; top: 100%; left: 0; background: var(--sfdt-color-surface); border: 1px solid var(--sfdt-color-border); border-radius: 4px; min-width: 360px; max-width: 600px; max-height: 280px; overflow-y: auto; z-index: 100021; box-shadow: 0 2px 8px rgba(0,0,0,0.15);';
     savedWrap.appendChild(savedQueriesMenu);
     savedQueriesBtn.addEventListener('click', async (e) => {
       e.stopPropagation();
@@ -524,7 +524,7 @@ export function createSoqlRunnerFeature(options: SoqlRunnerOptions = {}): Featur
     const textarea = doc.createElement('textarea');
     textarea.placeholder = 'SELECT Id, Name FROM Account LIMIT 10';
     textarea.style.cssText =
-      'width: 100%; min-height: 120px; font-family: ui-monospace, monospace; font-size: 13px; padding: 8px; border: 1px solid #d8dde6; border-bottom: 1px solid #e1e6eb; border-radius: 4px 4px 0 0; resize: vertical; margin-bottom: 0; outline: none; box-sizing: border-box;';
+      'width: 100%; min-height: 120px; font-family: ui-monospace, monospace; font-size: 13px; padding: 8px; border: 1px solid var(--sfdt-color-border); border-bottom: 1px solid var(--sfdt-color-surface-shade-6); border-radius: 4px 4px 0 0; resize: vertical; margin-bottom: 0; outline: none; box-sizing: border-box;';
     body.appendChild(textarea);
 
     // --- AUTOCOMPLETE UI SETUP ---
@@ -537,10 +537,10 @@ export function createSoqlRunnerFeature(options: SoqlRunnerOptions = {}): Featur
     const autocompleteBox = doc.createElement('div');
     autocompleteBox.className = 'sfdt-soql-autocomplete-box';
     autocompleteBox.style.cssText =
-      'border: 1px solid #d8dde6; border-top: none; border-radius: 0 0 4px 4px; background: #fafaf9; padding: 10px 12px; display: flex; flex-direction: column; gap: 8px; font-family: system-ui, sans-serif;';
+      'border: 1px solid var(--sfdt-color-border); border-top: none; border-radius: 0 0 4px 4px; background: var(--sfdt-color-surface-alt); padding: 10px 12px; display: flex; flex-direction: column; gap: 8px; font-family: system-ui, sans-serif;';
 
     const autocompleteHeader = doc.createElement('div');
-    autocompleteHeader.style.cssText = 'display: flex; justify-content: space-between; align-items: center; color: #54698d; font-size: 12px; font-weight: 600;';
+    autocompleteHeader.style.cssText = 'display: flex; justify-content: space-between; align-items: center; color: var(--sfdt-color-text-weak); font-size: 12px; font-weight: 600;';
     
     const autocompleteTitle = doc.createElement('span');
     autocompleteTitle.textContent = 'Enter query to see suggestions...';
@@ -548,7 +548,7 @@ export function createSoqlRunnerFeature(options: SoqlRunnerOptions = {}): Featur
 
     const toggleWrapBtn = doc.createElement('button');
     toggleWrapBtn.textContent = 'Expand ▾';
-    toggleWrapBtn.style.cssText = 'background: none; border: none; color: #0070d2; font-size: 11px; cursor: pointer; padding: 2px 6px; border-radius: 3px; font-family: inherit;';
+    toggleWrapBtn.style.cssText = 'background: none; border: none; color: var(--sfdt-color-brand); font-size: 11px; cursor: pointer; padding: 2px 6px; border-radius: 3px; font-family: inherit;';
     toggleWrapBtn.addEventListener('click', () => {
       expandAutocomplete = !expandAutocomplete;
       updateResultsWrap();
@@ -567,11 +567,11 @@ export function createSoqlRunnerFeature(options: SoqlRunnerOptions = {}): Featur
     const runBtn = doc.createElement('button');
     runBtn.textContent = '▶ Run';
     runBtn.style.cssText =
-      'padding: 6px 14px; background: #0070d2; color: #fff; border: 0; border-radius: 4px; cursor: pointer; font-size: 13px;';
+      'padding: 6px 14px; background: var(--sfdt-color-brand); color: var(--sfdt-color-surface); border: 0; border-radius: 4px; cursor: pointer; font-size: 13px;';
     const bookmarkBtn = doc.createElement('button');
     bookmarkBtn.textContent = '★ Save';
     bookmarkBtn.style.cssText =
-      'padding: 6px 12px; background: #fff; color: #0070d2; border: 1px solid #d8dde6; border-radius: 4px; cursor: pointer; font-size: 13px;';
+      'padding: 6px 12px; background: var(--sfdt-color-surface); color: var(--sfdt-color-brand); border: 1px solid var(--sfdt-color-border); border-radius: 4px; cursor: pointer; font-size: 13px;';
     bookmarkBtn.addEventListener('click', async () => {
       const q = textarea.value.trim();
       if (!q) {
@@ -585,7 +585,7 @@ export function createSoqlRunnerFeature(options: SoqlRunnerOptions = {}): Featur
       }
     });
     const status = doc.createElement('span');
-    status.style.cssText = 'color: #54698d; font-size: 12px;';
+    status.style.cssText = 'color: var(--sfdt-color-text-weak); font-size: 12px;';
     runRow.appendChild(runBtn);
     runRow.appendChild(bookmarkBtn);
     runRow.appendChild(status);
@@ -593,12 +593,12 @@ export function createSoqlRunnerFeature(options: SoqlRunnerOptions = {}): Featur
 
     const errorPanel = doc.createElement('div');
     errorPanel.style.cssText =
-      'display: none; border: 1px solid #c23934; background: #fef2f1; color: #c23934; padding: 8px 12px; border-radius: 4px; font-size: 13px; white-space: pre-wrap;';
+      'display: none; border: 1px solid var(--sfdt-color-error); background: var(--sfdt-color-error-bg); color: var(--sfdt-color-error); padding: 8px 12px; border-radius: 4px; font-size: 13px; white-space: pre-wrap;';
     body.appendChild(errorPanel);
 
     const resultsWrap = doc.createElement('div');
     resultsWrap.style.cssText =
-      'border: 1px solid #d8dde6; border-radius: 4px; overflow: auto; max-height: 360px; display: none;';
+      'border: 1px solid var(--sfdt-color-border); border-radius: 4px; overflow: auto; max-height: 360px; display: none;';
     body.appendChild(resultsWrap);
 
     const footer = doc.createElement('div');
@@ -606,19 +606,19 @@ export function createSoqlRunnerFeature(options: SoqlRunnerOptions = {}): Featur
     const loadMoreBtn = doc.createElement('button');
     loadMoreBtn.textContent = 'Load more';
     loadMoreBtn.style.cssText =
-      'padding: 6px 12px; border: 1px solid #d8dde6; background: #fff; border-radius: 4px; cursor: pointer; font-size: 12px; display: none;';
+      'padding: 6px 12px; border: 1px solid var(--sfdt-color-border); background: var(--sfdt-color-surface); border-radius: 4px; cursor: pointer; font-size: 12px; display: none;';
     const copyCsvBtn = doc.createElement('button');
     copyCsvBtn.textContent = 'Copy CSV';
     copyCsvBtn.style.cssText =
-      'padding: 6px 12px; border: 1px solid #d8dde6; background: #fff; border-radius: 4px; cursor: pointer; font-size: 12px; display: none;';
+      'padding: 6px 12px; border: 1px solid var(--sfdt-color-border); background: var(--sfdt-color-surface); border-radius: 4px; cursor: pointer; font-size: 12px; display: none;';
     const exportCsvBtn = doc.createElement('button');
     exportCsvBtn.textContent = 'Export CSV';
     exportCsvBtn.style.cssText =
-      'padding: 6px 12px; border: 1px solid #d8dde6; background: #fff; border-radius: 4px; cursor: pointer; font-size: 12px; display: none;';
+      'padding: 6px 12px; border: 1px solid var(--sfdt-color-border); background: var(--sfdt-color-surface); border-radius: 4px; cursor: pointer; font-size: 12px; display: none;';
     const langGraphBtn = doc.createElement('button');
     langGraphBtn.textContent = 'LangGraph Node';
     langGraphBtn.style.cssText =
-      'padding: 6px 12px; border: 1px solid #d8dde6; background: #fff; border-radius: 4px; cursor: pointer; font-size: 12px; display: none;';
+      'padding: 6px 12px; border: 1px solid var(--sfdt-color-border); background: var(--sfdt-color-surface); border-radius: 4px; cursor: pointer; font-size: 12px; display: none;';
     footer.appendChild(loadMoreBtn);
     footer.appendChild(copyCsvBtn);
     footer.appendChild(exportCsvBtn);
@@ -628,7 +628,7 @@ export function createSoqlRunnerFeature(options: SoqlRunnerOptions = {}): Featur
       const clearHistBtn = doc.createElement('button');
       clearHistBtn.textContent = 'Clear history';
       clearHistBtn.style.cssText =
-        'padding: 6px 12px; border: 1px solid #d8dde6; background: #fff; border-radius: 4px; cursor: pointer; font-size: 12px; margin-left: auto;';
+        'padding: 6px 12px; border: 1px solid var(--sfdt-color-border); background: var(--sfdt-color-surface); border-radius: 4px; cursor: pointer; font-size: 12px; margin-left: auto;';
       clearHistBtn.addEventListener('click', async () => {
         await clearSoqlHistory();
         showToast('Query history cleared', { doc, kind: 'success' });
@@ -671,7 +671,7 @@ export function createSoqlRunnerFeature(options: SoqlRunnerOptions = {}): Featur
       const menu = doc.createElement('div');
       menu.className = 'sfdt-soql-cell-menu';
       menu.style.cssText =
-        'position: absolute; background: #fff; border: 1px solid #d8dde6; border-radius: 4px; box-shadow: 0 2px 8px rgba(0,0,0,0.15); z-index: 100030; padding: 4px 0; font-family: system-ui, sans-serif; font-size: 12px;';
+        'position: absolute; background: var(--sfdt-color-surface); border: 1px solid var(--sfdt-color-border); border-radius: 4px; box-shadow: 0 2px 8px rgba(0,0,0,0.15); z-index: 100030; padding: 4px 0; font-family: system-ui, sans-serif; font-size: 12px;';
 
       const items = [
         {
@@ -703,9 +703,9 @@ export function createSoqlRunnerFeature(options: SoqlRunnerOptions = {}): Featur
       for (const item of items) {
         const itemEl = doc.createElement('div');
         itemEl.textContent = item.label;
-        itemEl.style.cssText = 'padding: 6px 12px; cursor: pointer; color: #16325c;';
-        itemEl.addEventListener('mouseenter', () => itemEl.style.background = '#f4f6f9');
-        itemEl.addEventListener('mouseleave', () => itemEl.style.background = '#fff');
+        itemEl.style.cssText = 'padding: 6px 12px; cursor: pointer; color: var(--sfdt-color-brand-deep);';
+        itemEl.addEventListener('mouseenter', () => itemEl.style.background = 'var(--sfdt-color-surface-shade)');
+        itemEl.addEventListener('mouseleave', () => itemEl.style.background = 'var(--sfdt-color-surface)');
         itemEl.addEventListener('click', () => {
           item.click();
           menu.remove();
@@ -733,7 +733,7 @@ export function createSoqlRunnerFeature(options: SoqlRunnerOptions = {}): Featur
       while (resultsWrap.firstChild) resultsWrap.removeChild(resultsWrap.firstChild);
       if (records.length === 0) {
         const empty = doc.createElement('div');
-        empty.style.cssText = 'padding: 12px; color: #80868d; font-size: 13px;';
+        empty.style.cssText = 'padding: 12px; color: var(--sfdt-color-text-icon); font-size: 13px;';
         empty.textContent = 'No rows.';
         resultsWrap.appendChild(empty);
         resultsWrap.style.display = 'block';
@@ -748,7 +748,7 @@ export function createSoqlRunnerFeature(options: SoqlRunnerOptions = {}): Featur
         const th = doc.createElement('th');
         th.textContent = c;
         th.style.cssText =
-          'text-align: left; padding: 6px 10px; border-bottom: 1px solid #d8dde6; background: #fafaf9; position: sticky; top: 0;';
+          'text-align: left; padding: 6px 10px; border-bottom: 1px solid var(--sfdt-color-border); background: var(--sfdt-color-surface-alt); position: sticky; top: 0;';
         headRow.appendChild(th);
       }
       thead.appendChild(headRow);
@@ -763,7 +763,7 @@ export function createSoqlRunnerFeature(options: SoqlRunnerOptions = {}): Featur
             const link = doc.createElement('a');
             link.href = '#';
             link.textContent = raw.length > 200 ? raw.slice(0, 200) + '…' : raw;
-            link.style.cssText = 'color: #0070d2; text-decoration: underline; cursor: pointer;';
+            link.style.cssText = 'color: var(--sfdt-color-brand); text-decoration: underline; cursor: pointer;';
             link.addEventListener('click', (e) => {
               e.preventDefault();
               showCellMenu(link, raw);
@@ -773,7 +773,7 @@ export function createSoqlRunnerFeature(options: SoqlRunnerOptions = {}): Featur
             td.textContent = raw.length > 200 ? raw.slice(0, 200) + '…' : raw;
           }
           td.title = raw;
-          td.style.cssText = 'padding: 6px 10px; border-bottom: 1px solid #f3f3f3; vertical-align: top;';
+          td.style.cssText = 'padding: 6px 10px; border-bottom: 1px solid var(--sfdt-color-bg); vertical-align: top;';
           tr.appendChild(td);
         }
         tbody.appendChild(tr);
@@ -795,7 +795,7 @@ export function createSoqlRunnerFeature(options: SoqlRunnerOptions = {}): Featur
       const entries = await readSoqlHistory();
       if (entries.length === 0) {
         const empty = doc.createElement('div');
-        empty.style.cssText = 'padding: 10px; color: #80868d; font-size: 12px;';
+        empty.style.cssText = 'padding: 10px; color: var(--sfdt-color-text-icon); font-size: 12px;';
         empty.textContent = 'No queries yet.';
         historyMenu.appendChild(empty);
         return;
@@ -803,13 +803,13 @@ export function createSoqlRunnerFeature(options: SoqlRunnerOptions = {}): Featur
       for (const entry of entries) {
         const item = doc.createElement('div');
         item.style.cssText =
-          'padding: 8px 10px; cursor: pointer; border-bottom: 1px solid #f3f3f3; font-family: ui-monospace, monospace; font-size: 11px;';
+          'padding: 8px 10px; cursor: pointer; border-bottom: 1px solid var(--sfdt-color-bg); font-family: ui-monospace, monospace; font-size: 11px;';
         const badge = doc.createElement('span');
         badge.textContent = entry.api === 'tooling' ? 'TOOL ' : 'REST ';
         badge.style.cssText =
           entry.api === 'tooling'
-            ? 'color: #b46600; font-weight: 600; margin-right: 6px;'
-            : 'color: #0070d2; font-weight: 600; margin-right: 6px;';
+            ? 'color: var(--sfdt-color-warning-text); font-weight: 600; margin-right: 6px;'
+            : 'color: var(--sfdt-color-brand); font-weight: 600; margin-right: 6px;';
         const text = doc.createElement('span');
         const trimmed = entry.q.length > 200 ? entry.q.slice(0, 200) + '…' : entry.q;
         text.textContent = trimmed;
@@ -830,7 +830,7 @@ export function createSoqlRunnerFeature(options: SoqlRunnerOptions = {}): Featur
       const entries = await readSavedQueries();
       if (entries.length === 0) {
         const empty = doc.createElement('div');
-        empty.style.cssText = 'padding: 10px; color: #80868d; font-size: 12px;';
+        empty.style.cssText = 'padding: 10px; color: var(--sfdt-color-text-icon); font-size: 12px;';
         empty.textContent = 'No bookmarked queries yet.';
         savedQueriesMenu.appendChild(empty);
         return;
@@ -838,7 +838,7 @@ export function createSoqlRunnerFeature(options: SoqlRunnerOptions = {}): Featur
       for (const entry of entries) {
         const item = doc.createElement('div');
         item.style.cssText =
-          'padding: 8px 10px; cursor: pointer; border-bottom: 1px solid #f3f3f3; font-family: ui-monospace, monospace; font-size: 11px; display: flex; justify-content: space-between; align-items: center;';
+          'padding: 8px 10px; cursor: pointer; border-bottom: 1px solid var(--sfdt-color-bg); font-family: ui-monospace, monospace; font-size: 11px; display: flex; justify-content: space-between; align-items: center;';
         
         const contentWrap = doc.createElement('div');
         contentWrap.style.cssText = 'display: flex; align-items: center; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;';
@@ -847,8 +847,8 @@ export function createSoqlRunnerFeature(options: SoqlRunnerOptions = {}): Featur
         badge.textContent = entry.api === 'tooling' ? 'TOOL ' : 'REST ';
         badge.style.cssText =
           entry.api === 'tooling'
-            ? 'color: #b46600; font-weight: 600; margin-right: 6px; flex-shrink: 0;'
-            : 'color: #0070d2; font-weight: 600; margin-right: 6px; flex-shrink: 0;';
+            ? 'color: var(--sfdt-color-warning-text); font-weight: 600; margin-right: 6px; flex-shrink: 0;'
+            : 'color: var(--sfdt-color-brand); font-weight: 600; margin-right: 6px; flex-shrink: 0;';
         
         const titleText = doc.createElement('strong');
         titleText.textContent = `${entry.name}: `;
@@ -865,7 +865,7 @@ export function createSoqlRunnerFeature(options: SoqlRunnerOptions = {}): Featur
 
         const deleteBtn = doc.createElement('button');
         deleteBtn.textContent = '×';
-        deleteBtn.style.cssText = 'background: none; border: none; color: #c23934; font-size: 16px; cursor: pointer; padding: 0 4px;';
+        deleteBtn.style.cssText = 'background: none; border: none; color: var(--sfdt-color-error); font-size: 16px; cursor: pointer; padding: 0 4px;';
         deleteBtn.addEventListener('click', async (e) => {
           e.stopPropagation();
           if (win.confirm(`Are you sure you want to delete bookmark "${entry.name}"?`)) {
@@ -1448,7 +1448,7 @@ export function createSoqlRunnerFeature(options: SoqlRunnerOptions = {}): Featur
 
       if (data.results.length === 0) {
         const none = doc.createElement('span');
-        none.style.cssText = 'color: #80868d; font-size: 12px; font-style: italic;';
+        none.style.cssText = 'color: var(--sfdt-color-text-icon); font-size: 12px; font-style: italic;';
         none.textContent = 'No suggestions available';
         autocompleteResults.appendChild(none);
         return;
@@ -1461,16 +1461,16 @@ export function createSoqlRunnerFeature(options: SoqlRunnerOptions = {}): Featur
         btn.textContent = `${icon} ${item.value}`;
         btn.title = item.title;
         btn.style.cssText =
-          'display: inline-flex; align-items: center; gap: 4px; padding: 4px 10px; border: 1px solid #d8dde6; border-radius: 14px; background: #fff; color: #0070d2; font-size: 12px; cursor: pointer; white-space: nowrap; transition: background 0.15s, border-color 0.15s, transform 0.1s; outline: none; margin: 2px 0; font-family: system-ui, sans-serif;';
+          'display: inline-flex; align-items: center; gap: 4px; padding: 4px 10px; border: 1px solid var(--sfdt-color-border); border-radius: 14px; background: var(--sfdt-color-surface); color: var(--sfdt-color-brand); font-size: 12px; cursor: pointer; white-space: nowrap; transition: background 0.15s, border-color 0.15s, transform 0.1s; outline: none; margin: 2px 0; font-family: system-ui, sans-serif;';
         
         btn.addEventListener('mouseenter', () => {
-          btn.style.background = '#f4f6f9';
-          btn.style.borderColor = '#0070d2';
+          btn.style.background = 'var(--sfdt-color-surface-shade)';
+          btn.style.borderColor = 'var(--sfdt-color-brand)';
           btn.style.transform = 'translateY(-1px)';
         });
         btn.addEventListener('mouseleave', () => {
-          btn.style.background = '#fff';
-          btn.style.borderColor = '#d8dde6';
+          btn.style.background = 'var(--sfdt-color-surface)';
+          btn.style.borderColor = 'var(--sfdt-color-border)';
           btn.style.transform = 'none';
         });
         

--- a/extension/features/subflow-graph.ts
+++ b/extension/features/subflow-graph.ts
@@ -138,13 +138,13 @@ export function buildSubflowGraphSvg(doc: Document, graph: SubflowGraph): SVGSVG
   svg.setAttribute('width', String(width));
   svg.setAttribute('height', String(height));
   svg.style.cssText =
-    'display: block; font-family: system-ui, sans-serif; background: #fff;';
+    'display: block; font-family: system-ui, sans-serif; background: var(--sfdt-color-surface);';
 
   const defs = doc.createElementNS(SVG_NS, 'defs');
   for (const [id, fill] of [
-    ['sfdt-arrow', '#54698d'],
-    ['sfdt-arrow-cycle', '#c23934'],
-    ['sfdt-arrow-missing', '#b46600'],
+    ['sfdt-arrow', 'var(--sfdt-color-text-weak)'],
+    ['sfdt-arrow-cycle', 'var(--sfdt-color-error)'],
+    ['sfdt-arrow-missing', 'var(--sfdt-color-warning-text)'],
   ] as const) {
     const marker = doc.createElementNS(SVG_NS, 'marker');
     marker.setAttribute('id', id);
@@ -156,7 +156,10 @@ export function buildSubflowGraphSvg(doc: Document, graph: SubflowGraph): SVGSVG
     marker.setAttribute('orient', 'auto-start-reverse');
     const path = doc.createElementNS(SVG_NS, 'path');
     path.setAttribute('d', 'M 0 0 L 10 5 L 0 10 z');
-    path.setAttribute('fill', fill);
+    // SVG paint via the CSS `fill` property (not the presentation attribute) so
+    // the `var(--sfdt-*)` token resolves; the custom property inherits from the
+    // injected :root block into the <marker> subtree.
+    path.style.fill = fill;
     marker.appendChild(path);
     defs.appendChild(marker);
   }
@@ -176,7 +179,7 @@ export function buildSubflowGraphSvg(doc: Document, graph: SubflowGraph): SVGSVG
         line.setAttribute('y1', String(sy));
         line.setAttribute('x2', String(sx + 30));
         line.setAttribute('y2', String(sy));
-        line.setAttribute('stroke', '#b46600');
+        line.style.stroke = 'var(--sfdt-color-warning-text)';
         line.setAttribute('stroke-width', '1.5');
         line.setAttribute('stroke-dasharray', '4 3');
         line.setAttribute('marker-end', 'url(#sfdt-arrow-missing)');
@@ -191,7 +194,7 @@ export function buildSubflowGraphSvg(doc: Document, graph: SubflowGraph): SVGSVG
       const path = doc.createElementNS(SVG_NS, 'path');
       path.setAttribute('d', `M ${sx} ${sy} C ${mx} ${sy}, ${mx} ${ty}, ${tx} ${ty}`);
       path.setAttribute('fill', 'none');
-      path.setAttribute('stroke', isCycle ? '#c23934' : '#54698d');
+      path.style.stroke = isCycle ? 'var(--sfdt-color-error)' : 'var(--sfdt-color-text-weak)';
       path.setAttribute('stroke-width', isCycle ? '2' : '1.5');
       if (edge.missing) path.setAttribute('stroke-dasharray', '4 3');
       path.setAttribute('marker-end', isCycle ? 'url(#sfdt-arrow-cycle)' : 'url(#sfdt-arrow)');
@@ -209,8 +212,8 @@ export function buildSubflowGraphSvg(doc: Document, graph: SubflowGraph): SVGSVG
     rect.setAttribute('height', String(lay.height));
     rect.setAttribute('rx', '4');
     rect.setAttribute('ry', '4');
-    rect.setAttribute('fill', inCycle ? '#fef2f1' : '#f4f6f9');
-    rect.setAttribute('stroke', inCycle ? '#c23934' : '#d8dde6');
+    rect.style.fill = inCycle ? 'var(--sfdt-color-error-bg)' : 'var(--sfdt-color-surface-shade)';
+    rect.style.stroke = inCycle ? 'var(--sfdt-color-error)' : 'var(--sfdt-color-border)';
     rect.setAttribute('stroke-width', '1.5');
     group.appendChild(rect);
 
@@ -219,7 +222,7 @@ export function buildSubflowGraphSvg(doc: Document, graph: SubflowGraph): SVGSVG
     text.setAttribute('y', String(lay.height / 2 + 4));
     text.setAttribute('text-anchor', 'middle');
     text.setAttribute('font-size', '12');
-    text.setAttribute('fill', inCycle ? '#c23934' : '#16325c');
+    text.style.fill = inCycle ? 'var(--sfdt-color-error)' : 'var(--sfdt-color-brand-deep)';
     const label = lay.node.label;
     text.textContent = label.length > MAX_LABEL_CHARS ? label.slice(0, MAX_LABEL_CHARS - 1) + '…' : label;
     const title = doc.createElementNS(SVG_NS, 'title');
@@ -242,11 +245,11 @@ export function buildSubflowGraphModal(doc: Document, graph: SubflowGraph): View
   // header is title + × only, so it sits at the top of the body now.
   const toggle = doc.createElement('div');
   toggle.style.cssText =
-    'display: inline-flex; border: 1px solid #d8dde6; border-radius: 4px; overflow: hidden; margin-bottom: 12px;';
+    'display: inline-flex; border: 1px solid var(--sfdt-color-border); border-radius: 4px; overflow: hidden; margin-bottom: 12px;';
   const graphBtn = doc.createElement('button');
   const listBtn = doc.createElement('button');
   const baseToggleStyle =
-    'padding: 4px 12px; border: 0; background: #fff; cursor: pointer; font-size: 12px;';
+    'padding: 4px 12px; border: 0; background: var(--sfdt-color-surface); cursor: pointer; font-size: 12px;';
   graphBtn.style.cssText = baseToggleStyle;
   listBtn.style.cssText = baseToggleStyle;
   graphBtn.textContent = 'Graph';
@@ -260,9 +263,9 @@ export function buildSubflowGraphModal(doc: Document, graph: SubflowGraph): View
   if (graph.cycles.length > 0) {
     const cycleBox = doc.createElement('div');
     cycleBox.style.cssText =
-      'border: 1px solid #c23934; border-radius: 4px; padding: 10px; margin-bottom: 12px; background: #fef2f1;';
+      'border: 1px solid var(--sfdt-color-error); border-radius: 4px; padding: 10px; margin-bottom: 12px; background: var(--sfdt-color-error-bg);';
     const cycleTitle = doc.createElement('div');
-    cycleTitle.style.cssText = 'font-weight: 600; color: #c23934; margin-bottom: 4px;';
+    cycleTitle.style.cssText = 'font-weight: 600; color: var(--sfdt-color-error); margin-bottom: 4px;';
     cycleTitle.textContent = `${graph.cycles.length} cycle${graph.cycles.length === 1 ? '' : 's'} detected`;
     cycleBox.appendChild(cycleTitle);
     for (const cycle of graph.cycles) {
@@ -276,7 +279,7 @@ export function buildSubflowGraphModal(doc: Document, graph: SubflowGraph): View
   }
 
   const graphPane = doc.createElement('div');
-  graphPane.style.cssText = 'border: 1px solid #d8dde6; border-radius: 4px; overflow: auto;';
+  graphPane.style.cssText = 'border: 1px solid var(--sfdt-color-border); border-radius: 4px; overflow: auto;';
   graphPane.appendChild(buildSubflowGraphSvg(doc, graph));
 
   const listPane = doc.createElement('div');
@@ -290,12 +293,12 @@ export function buildSubflowGraphModal(doc: Document, graph: SubflowGraph): View
   for (const node of flows) {
     const row = doc.createElement('div');
     row.style.cssText =
-      'border: 1px solid #d8dde6; border-radius: 4px; padding: 10px; margin-bottom: 6px;';
+      'border: 1px solid var(--sfdt-color-border); border-radius: 4px; padding: 10px; margin-bottom: 6px;';
     const title = doc.createElement('div');
     title.style.cssText = 'font-weight: 600;';
     title.textContent = node.label;
     const meta = doc.createElement('div');
-    meta.style.cssText = 'color: #80868d; font-size: 12px; margin-top: 2px;';
+    meta.style.cssText = 'color: var(--sfdt-color-text-icon); font-size: 12px; margin-top: 2px;';
     const depth = graph.maxDepth.get(node.id) ?? 0;
     meta.textContent = `depth ${depth} · calls ${node.outgoing.length} · called by ${node.incoming.length}`;
     row.appendChild(title);
@@ -306,7 +309,7 @@ export function buildSubflowGraphModal(doc: Document, graph: SubflowGraph): View
       if (chains.length > 0) {
         const chainBox = doc.createElement('div');
         chainBox.style.cssText =
-          'margin-top: 6px; font-family: monospace; font-size: 12px; color: #54698d;';
+          'margin-top: 6px; font-family: monospace; font-size: 12px; color: var(--sfdt-color-text-weak);';
         for (const chain of chains.slice(0, 5)) {
           const line = doc.createElement('div');
           line.textContent = chain.join(' → ');
@@ -314,7 +317,7 @@ export function buildSubflowGraphModal(doc: Document, graph: SubflowGraph): View
         }
         if (chains.length > 5) {
           const more = doc.createElement('div');
-          more.style.color = '#80868d';
+          more.style.color = 'var(--sfdt-color-text-icon)';
           more.textContent = `…and ${chains.length - 5} more chain${chains.length - 5 === 1 ? '' : 's'}`;
           chainBox.appendChild(more);
         }
@@ -330,13 +333,13 @@ export function buildSubflowGraphModal(doc: Document, graph: SubflowGraph): View
   if (graph.unresolvedReferences.length > 0) {
     const unresolvedBox = doc.createElement('div');
     unresolvedBox.style.cssText =
-      'border: 1px solid #fe9339; border-radius: 4px; padding: 10px; margin-top: 12px; background: #fff7eb;';
+      'border: 1px solid var(--sfdt-color-warning); border-radius: 4px; padding: 10px; margin-top: 12px; background: var(--sfdt-color-warning-bg-3);';
     const title = doc.createElement('div');
-    title.style.cssText = 'font-weight: 600; color: #b46600;';
+    title.style.cssText = 'font-weight: 600; color: var(--sfdt-color-warning-text);';
     title.textContent = `${graph.unresolvedReferences.length} reference${graph.unresolvedReferences.length === 1 ? '' : 's'} to flows we couldn't load`;
     unresolvedBox.appendChild(title);
     const list = doc.createElement('div');
-    list.style.cssText = 'font-size: 12px; color: #b46600;';
+    list.style.cssText = 'font-size: 12px; color: var(--sfdt-color-warning-text);';
     list.textContent = graph.unresolvedReferences.join(', ');
     unresolvedBox.appendChild(list);
     body.appendChild(unresolvedBox);
@@ -346,17 +349,17 @@ export function buildSubflowGraphModal(doc: Document, graph: SubflowGraph): View
     if (mode === 'graph') {
       graphPane.style.display = '';
       listPane.style.display = 'none';
-      graphBtn.style.background = '#16325c';
-      graphBtn.style.color = '#fff';
-      listBtn.style.background = '#fff';
-      listBtn.style.color = '#16325c';
+      graphBtn.style.background = 'var(--sfdt-color-brand-deep)';
+      graphBtn.style.color = 'var(--sfdt-color-surface)';
+      listBtn.style.background = 'var(--sfdt-color-surface)';
+      listBtn.style.color = 'var(--sfdt-color-brand-deep)';
     } else {
       graphPane.style.display = 'none';
       listPane.style.display = '';
-      listBtn.style.background = '#16325c';
-      listBtn.style.color = '#fff';
-      graphBtn.style.background = '#fff';
-      graphBtn.style.color = '#16325c';
+      listBtn.style.background = 'var(--sfdt-color-brand-deep)';
+      listBtn.style.color = 'var(--sfdt-color-surface)';
+      graphBtn.style.background = 'var(--sfdt-color-surface)';
+      graphBtn.style.color = 'var(--sfdt-color-brand-deep)';
     }
   };
   graphBtn.addEventListener('click', () => setView('graph'));
@@ -385,7 +388,7 @@ export function createSubflowGraphFeature(options: SubflowGraphFeatureOptions = 
     async onActivate() {
       const loading = doc.createElement('div');
       loading.style.cssText =
-        'position: fixed; inset: 0; background: rgba(0,0,0,0.4); z-index: 100020; display: flex; align-items: center; justify-content: center; color: #fff; font-family: system-ui, sans-serif;';
+        'position: fixed; inset: 0; background: rgba(0,0,0,0.4); z-index: 100020; display: flex; align-items: center; justify-content: center; color: var(--sfdt-color-surface); font-family: system-ui, sans-serif;';
       loading.textContent = 'Building subflow graph…';
       doc.body.appendChild(loading);
       try {

--- a/extension/features/trigger-conflicts.ts
+++ b/extension/features/trigger-conflicts.ts
@@ -116,13 +116,13 @@ export function buildConflictsModal(
 
   if (groups.length === 0) {
     const empty = doc.createElement('div');
-    empty.style.color = '#80868d';
+    empty.style.color = 'var(--sfdt-color-text-icon)';
     empty.textContent =
       'No record-triggered flows in this org share the same object + timing + event.';
     body.appendChild(empty);
   } else {
     const intro = doc.createElement('div');
-    intro.style.cssText = 'color: #54698d; font-size: 13px; margin-bottom: 12px;';
+    intro.style.cssText = 'color: var(--sfdt-color-text-weak); font-size: 13px; margin-bottom: 12px;';
     intro.textContent =
       'These groups of record-triggered flows fire on the same object + timing + event. The order in which they run is not guaranteed, so behaviour can vary save-to-save. Use Deactivate to silence a conflicting flow without deleting it; Activate restores the latest version.';
     body.appendChild(intro);
@@ -130,7 +130,7 @@ export function buildConflictsModal(
     for (const group of groups) {
       const groupBox = doc.createElement('div');
       groupBox.style.cssText =
-        'border: 1px solid #d8dde6; border-radius: 4px; padding: 10px; margin-bottom: 8px;';
+        'border: 1px solid var(--sfdt-color-border); border-radius: 4px; padding: 10px; margin-bottom: 8px;';
       const title = doc.createElement('div');
       title.style.cssText = 'font-weight: 600; margin-bottom: 6px;';
       title.textContent = `${group.objectApiName} · ${group.triggerTiming} · ${group.triggerEvent}`;
@@ -147,11 +147,11 @@ export function buildConflictsModal(
 
   const footer = doc.createElement('div');
   footer.style.cssText =
-    'padding: 12px 16px; border-top: 1px solid #d8dde6; display: flex; justify-content: flex-end; gap: 8px;';
+    'padding: 12px 16px; border-top: 1px solid var(--sfdt-color-border); display: flex; justify-content: flex-end; gap: 8px;';
   const closeFooter = doc.createElement('button');
   closeFooter.textContent = 'Close';
   closeFooter.style.cssText =
-    'padding: 6px 12px; border: 1px solid #d8dde6; background: #fff; border-radius: 4px; cursor: pointer;';
+    'padding: 6px 12px; border: 1px solid var(--sfdt-color-border); background: var(--sfdt-color-surface); border-radius: 4px; cursor: pointer;';
   footer.appendChild(closeFooter);
 
   const view = presentView({ title, body, footer, doc, width: '720px' });
@@ -167,7 +167,7 @@ function buildFlowRow(
 ): HTMLDivElement {
   const row = doc.createElement('div');
   row.style.cssText =
-    'display: flex; align-items: center; justify-content: space-between; gap: 8px; padding: 6px 0; border-top: 1px solid #f3f3f3;';
+    'display: flex; align-items: center; justify-content: space-between; gap: 8px; padding: 6px 0; border-top: 1px solid var(--sfdt-color-bg);';
 
   const left = doc.createElement('div');
   left.style.cssText = 'min-width: 0; flex: 1;';
@@ -183,7 +183,7 @@ function buildFlowRow(
   labelLine.appendChild(labelSpan);
   labelLine.appendChild(stateBadge);
   const criteria = doc.createElement('div');
-  criteria.style.cssText = 'color: #80868d; font-size: 12px; margin-top: 1px;';
+  criteria.style.cssText = 'color: var(--sfdt-color-text-icon); font-size: 12px; margin-top: 1px;';
   criteria.textContent = flow.entryCriteriaSummary ?? 'no entry criteria';
   left.appendChild(labelLine);
   left.appendChild(criteria);
@@ -193,22 +193,22 @@ function buildFlowRow(
   right.style.cssText = 'display: flex; gap: 4px; align-items: center;';
 
   const statusSpan = doc.createElement('span');
-  statusSpan.style.cssText = 'font-size: 11px; color: #80868d; min-width: 18px;';
+  statusSpan.style.cssText = 'font-size: 11px; color: var(--sfdt-color-text-icon); min-width: 18px;';
   right.appendChild(statusSpan);
 
   const activateBtn = doc.createElement('button');
   const deactivateBtn = doc.createElement('button');
 
   const baseBtnStyle =
-    'padding: 4px 10px; border: 1px solid #d8dde6; background: #fff; border-radius: 3px; font-size: 12px; cursor: pointer;';
+    'padding: 4px 10px; border: 1px solid var(--sfdt-color-border); background: var(--sfdt-color-surface); border-radius: 3px; font-size: 12px; cursor: pointer;';
   activateBtn.style.cssText = baseBtnStyle;
   deactivateBtn.style.cssText = baseBtnStyle;
 
   const latest = extra?.latestVersionNumber ?? null;
   activateBtn.textContent = latest ? `Activate v${latest}` : 'Activate';
   deactivateBtn.textContent = 'Deactivate';
-  deactivateBtn.style.color = '#c23934';
-  deactivateBtn.style.borderColor = '#f9d4d2';
+  deactivateBtn.style.color = 'var(--sfdt-color-error)';
+  deactivateBtn.style.borderColor = 'var(--sfdt-color-error-bg-5)';
 
   const refresh = () => {
     const active = extra?.active ?? true;
@@ -224,19 +224,19 @@ function buildFlowRow(
 
   const setPending = (label: string) => {
     statusSpan.textContent = label;
-    statusSpan.style.color = '#54698d';
+    statusSpan.style.color = 'var(--sfdt-color-text-weak)';
     activateBtn.disabled = true;
     deactivateBtn.disabled = true;
   };
   const setError = (msg: string) => {
     statusSpan.textContent = '✗';
-    statusSpan.style.color = '#c23934';
+    statusSpan.style.color = 'var(--sfdt-color-error)';
     statusSpan.title = msg;
     refresh();
   };
   const setOk = () => {
     statusSpan.textContent = '✓';
-    statusSpan.style.color = '#04844b';
+    statusSpan.style.color = 'var(--sfdt-color-success)';
     statusSpan.title = '';
     refresh();
   };
@@ -277,12 +277,12 @@ function buildFlowRow(
 function setBadgeState(badge: HTMLSpanElement, active: boolean): void {
   if (active) {
     badge.textContent = 'Active';
-    badge.style.background = '#ddf3e4';
-    badge.style.color = '#04844b';
+    badge.style.background = 'var(--sfdt-color-success-bg)';
+    badge.style.color = 'var(--sfdt-color-success)';
   } else {
     badge.textContent = 'Inactive';
-    badge.style.background = '#f3f3f3';
-    badge.style.color = '#80868d';
+    badge.style.background = 'var(--sfdt-color-bg)';
+    badge.style.color = 'var(--sfdt-color-text-icon)';
   }
 }
 
@@ -345,7 +345,7 @@ export function createTriggerConflictsFeature(
     async onActivate() {
       const loading = doc.createElement('div');
       loading.style.cssText =
-        'position: fixed; inset: 0; background: rgba(0,0,0,0.4); z-index: 100020; display: flex; align-items: center; justify-content: center; color: #fff; font-family: system-ui, sans-serif;';
+        'position: fixed; inset: 0; background: rgba(0,0,0,0.4); z-index: 100020; display: flex; align-items: center; justify-content: center; color: var(--sfdt-color-surface); font-family: system-ui, sans-serif;';
       loading.textContent = 'Scanning flows for trigger conflicts…';
       doc.body.appendChild(loading);
       try {

--- a/extension/lib/tokens.ts
+++ b/extension/lib/tokens.ts
@@ -1,0 +1,101 @@
+// Design tokens — the single source of truth for every colour value in the
+// extension UI. All three surfaces (content-script features on Salesforce
+// pages, the standalone Workspace app page, and the options page) reference
+// these as `var(--sfdt-color-*)` custom properties; the raw hex literals live
+// ONLY in this file. Consolidating them here is what lets a future dark theme
+// (P0-2) swap values in one place instead of hunting hard-coded colours across
+// forty-odd files.
+//
+// This file is the documented exception to the "no hard-coded colours" rule
+// (the extension's design-token grep gate points here). The only other place a
+// raw hex is allowed is the user-configurable highlight colour default in
+// features/canvas-search.ts, which is a runtime data value string-concatenated
+// with an alpha suffix (`${colour}80`) and therefore cannot be a CSS variable.
+
+/**
+ * Palette derived from the Salesforce Lightning Design System values the UI was
+ * already using. Each token maps 1:1 to exactly one former hex literal, so this
+ * refactor is provably pixel-for-pixel identical — a token always resolves to
+ * the single value it replaced.
+ */
+export const SFDT_TOKENS: Record<string, string> = {
+  // Brand blues
+  'color-brand': '#0070d2',
+  'color-brand-active': '#005fb2',
+  'color-brand-deep': '#16325c',
+  'color-info': '#1589ee',
+
+  // Text / neutrals
+  'color-text': '#3e3e3c',
+  'color-text-weak': '#54698d',
+  'color-text-muted': '#706e6b',
+  'color-text-icon': '#80868d',
+  'color-text-disabled': '#b0adab',
+  'color-text-faint': '#a9a9a9',
+
+  // Surfaces
+  'color-surface': '#fff',
+  'color-surface-alt': '#fafaf9',
+  'color-bg': '#f3f3f3',
+  'color-surface-shade': '#f4f6f9',
+  'color-surface-shade-2': '#f3f6f9',
+  'color-surface-shade-3': '#eef1f4',
+  'color-surface-shade-4': '#e9eef3',
+  'color-surface-shade-5': '#eef1f6',
+  'color-surface-shade-6': '#e1e6eb',
+
+  // Borders
+  'color-border': '#d8dde6',
+  'color-border-2': '#e0e0e0',
+  'color-border-3': '#d4d4d4',
+
+  // Error / red
+  'color-error': '#c23934',
+  'color-error-bg': '#fef2f1',
+  'color-error-bg-2': '#fdf3f2',
+  'color-error-bg-3': '#fef6f5',
+  'color-error-bg-4': '#fde2e0',
+  'color-error-bg-5': '#f9d4d2',
+  'color-error-border': '#f4c7c3',
+
+  // Success / green
+  'color-success': '#04844b',
+  'color-success-2': '#2e844a',
+  'color-success-bg': '#ddf3e4',
+  'color-success-bg-2': '#f4fbf7',
+
+  // Warning / amber
+  'color-warning': '#fe9339',
+  'color-warning-text': '#b46600',
+  'color-warning-text-2': '#6b5a1f',
+  'color-warning-border': '#f4d27a',
+  'color-warning-bg': '#fff8e5',
+  'color-warning-bg-2': '#fff8e1',
+  'color-warning-bg-3': '#fff7eb',
+  'color-warning-bg-4': '#fef8f3',
+  'color-warning-bg-5': '#fef4ec',
+  'color-warning-bg-6': '#fef1e1',
+
+  // Code / editor
+  'color-code-bg': '#1e1e1e',
+};
+
+const TOKENS_STYLE_ID = 'sfdt-design-tokens';
+
+/** The `:root { --sfdt-*: … }` block. The one place raw hex literals live. */
+export const SFDT_TOKENS_CSS = `:root {\n${Object.entries(SFDT_TOKENS)
+  .map(([name, value]) => `  --sfdt-${name}: ${value};`)
+  .join('\n')}\n}`;
+
+/**
+ * Idempotently inject the token custom properties into a document's head so
+ * every `var(--sfdt-*)` reference (inline styles on content-script elements,
+ * SVG fills, injected stylesheets) resolves. Safe to call repeatedly.
+ */
+export function ensureTokens(doc: Document = document): void {
+  if (doc.getElementById(TOKENS_STYLE_ID)) return;
+  const style = doc.createElement('style');
+  style.id = TOKENS_STYLE_ID;
+  style.textContent = SFDT_TOKENS_CSS;
+  (doc.head ?? doc.documentElement).appendChild(style);
+}

--- a/extension/test/api-version-audit.test.ts
+++ b/extension/test/api-version-audit.test.ts
@@ -113,7 +113,7 @@ describe('api-version-audit feature', () => {
     await feature.init?.();
     const pill = document.querySelector<HTMLElement>(`.${AUDIT_CLASS} span`);
     expect(pill?.textContent).toBe('API v67 · 2 behind');
-    expect(pill?.style.background).toBe('#fe9339'); // amber — components below floor
+    expect(pill?.style.background).toBe('var(--sfdt-color-warning)'); // amber — components below floor
   });
 
   it('renders a neutral pill when nothing is below the floor', async () => {
@@ -127,7 +127,7 @@ describe('api-version-audit feature', () => {
     await feature.init?.();
     const pill = document.querySelector<HTMLElement>(`.${AUDIT_CLASS} span`);
     expect(pill?.textContent).toBe('API v67');
-    expect(pill?.style.background).toBe('#706e6b'); // neutral grey
+    expect(pill?.style.background).toBe('var(--sfdt-color-text-muted)'); // neutral grey
   });
 
   it('still renders Apex/Trigger when the Flow query fails', async () => {

--- a/extension/test/org-release-badge.test.ts
+++ b/extension/test/org-release-badge.test.ts
@@ -101,7 +101,7 @@ describe('org-release-badge feature', () => {
     await feature.init?.();
     const pill = document.querySelector<HTMLElement>('.sfdt-org-release-badge span');
     expect(pill?.textContent).toBe("Winter '27 · Preview");
-    expect(pill?.style.background).toBe('#fe9339'); // amber preview colour
+    expect(pill?.style.background).toBe('var(--sfdt-color-warning)'); // amber preview colour
   });
 
   it('renders nothing when neither release nor org can be read', async () => {

--- a/extension/test/phase6.test.ts
+++ b/extension/test/phase6.test.ts
@@ -311,13 +311,13 @@ describe('extension/features/subflow-graph', () => {
     ]);
     const svg = buildSubflowGraphSvg(document, graph);
     const rects = Array.from(svg.querySelectorAll('rect'));
-    expect(rects.every((r) => r.getAttribute('stroke') === '#c23934')).toBe(true);
+    expect(rects.every((r) => r.style.stroke === 'var(--sfdt-color-error)')).toBe(true);
     // Filter to direct-child edge paths so marker arrowhead paths don't
     // pollute the count.
     const directChildPaths = Array.from(svg.children).filter(
       (n): n is SVGPathElement => n.tagName.toLowerCase() === 'path',
     );
-    const cycleEdges = directChildPaths.filter((p) => p.getAttribute('stroke') === '#c23934');
+    const cycleEdges = directChildPaths.filter((p) => p.style.stroke === 'var(--sfdt-color-error)');
     // A→B and B→A — both should be in the cycle and stroked red.
     expect(cycleEdges).toHaveLength(2);
   });

--- a/extension/test/toast.test.ts
+++ b/extension/test/toast.test.ts
@@ -34,9 +34,9 @@ describe('toast — showToast', () => {
     showToast('it broke', { kind: 'error' });
     const toasts = document.querySelectorAll<HTMLElement>('.sfdt-toast');
     expect(toasts[0]!.className).toContain('sfdt-toast--info');
-    expect(toasts[0]!.style.background).toBe('#0070d2');
+    expect(toasts[0]!.style.background).toBe('var(--sfdt-color-brand)');
     expect(toasts[1]!.className).toContain('sfdt-toast--error');
-    expect(toasts[1]!.style.background).toBe('#c23934');
+    expect(toasts[1]!.style.background).toBe('var(--sfdt-color-error)');
   });
 
   it('renders into a caller-provided document', () => {

--- a/extension/ui/health-modal.ts
+++ b/extension/ui/health-modal.ts
@@ -48,28 +48,28 @@ function clear(el: Element): void {
 function severityColour(severity: Severity): string {
   switch (severity) {
     case 'high':
-      return '#c23934';
+      return 'var(--sfdt-color-error)';
     case 'medium':
-      return '#fe9339';
+      return 'var(--sfdt-color-warning)';
     case 'low':
-      return '#1589ee';
+      return 'var(--sfdt-color-info)';
     case 'info':
-      return '#80868d';
+      return 'var(--sfdt-color-text-icon)';
   }
 }
 
 function ratingColour(rating: Rating): string {
   switch (rating) {
     case 'Excellent':
-      return '#04844b';
+      return 'var(--sfdt-color-success)';
     case 'Very Good':
-      return '#2e844a';
+      return 'var(--sfdt-color-success-2)';
     case 'Good':
-      return '#1589ee';
+      return 'var(--sfdt-color-info)';
     case 'Poor':
-      return '#fe9339';
+      return 'var(--sfdt-color-warning)';
     case 'Very Poor':
-      return '#c23934';
+      return 'var(--sfdt-color-error)';
   }
 }
 
@@ -91,7 +91,7 @@ export function mountHealthModal(options: MountHealthModalOptions = {}): HealthM
   const footer = doc.createElement('div');
   footer.className = 'sfdt-modal-footer sfdt-health-modal-footer';
   footer.style.cssText =
-    'padding: 12px 16px; border-top: 1px solid #d8dde6; display: flex; justify-content: flex-end; gap: 8px;';
+    'padding: 12px 16px; border-top: 1px solid var(--sfdt-color-border); display: flex; justify-content: flex-end; gap: 8px;';
 
   let view: ViewHandle | null = null;
 
@@ -127,7 +127,7 @@ export function mountHealthModal(options: MountHealthModalOptions = {}): HealthM
     title.textContent = 'Running Health Check';
     const sub = doc.createElement('div');
     sub.className = 'sfdt-health-loading-subtitle';
-    sub.style.cssText = 'color: #80868d; margin-top: 4px;';
+    sub.style.cssText = 'color: var(--sfdt-color-text-icon); margin-top: 4px;';
     sub.textContent = flowLabel;
     wrap.appendChild(title);
     wrap.appendChild(sub);
@@ -141,7 +141,7 @@ export function mountHealthModal(options: MountHealthModalOptions = {}): HealthM
     const wrap = styledDiv(doc, 'sfdt-health-error', 'padding: 16px;');
     const title = doc.createElement('div');
     title.className = 'sfdt-health-section-title';
-    title.style.cssText = 'font-size: 16px; font-weight: 600; color: #c23934;';
+    title.style.cssText = 'font-size: 16px; font-weight: 600; color: var(--sfdt-color-error);';
     title.textContent = 'Health Check Failed';
     const msg = doc.createElement('div');
     msg.className = 'sfdt-health-error-message';
@@ -157,7 +157,7 @@ export function mountHealthModal(options: MountHealthModalOptions = {}): HealthM
     const card = styledDiv(
       doc,
       'sfdt-health-card',
-      `border: 1px solid #d8dde6; border-radius: 4px; padding: 10px; text-align: center; min-width: 80px; background: #fafaf9;`,
+      `border: 1px solid var(--sfdt-color-border); border-radius: 4px; padding: 10px; text-align: center; min-width: 80px; background: var(--sfdt-color-surface-alt);`,
     );
     const lbl = doc.createElement('div');
     lbl.className = 'sfdt-health-card-label';
@@ -176,11 +176,11 @@ export function mountHealthModal(options: MountHealthModalOptions = {}): HealthM
     const card = styledDiv(
       doc,
       'sfdt-health-metric',
-      'border: 1px solid #d8dde6; border-radius: 4px; padding: 8px; text-align: center; min-width: 80px;',
+      'border: 1px solid var(--sfdt-color-border); border-radius: 4px; padding: 8px; text-align: center; min-width: 80px;',
     );
     const lbl = doc.createElement('div');
     lbl.className = 'sfdt-health-metric-label';
-    lbl.style.cssText = 'font-size: 11px; color: #80868d; font-weight: 500;';
+    lbl.style.cssText = 'font-size: 11px; color: var(--sfdt-color-text-icon); font-weight: 500;';
     lbl.textContent = label;
     const val = doc.createElement('div');
     val.className = 'sfdt-health-metric-value';
@@ -194,7 +194,7 @@ export function mountHealthModal(options: MountHealthModalOptions = {}): HealthM
   function buildFamilyDisclosure(family: IssueFamily): HTMLDetailsElement {
     const details = doc.createElement('details');
     details.className = 'sfdt-health-family';
-    details.style.cssText = 'border: 1px solid #d8dde6; border-radius: 4px; margin-bottom: 6px;';
+    details.style.cssText = 'border: 1px solid var(--sfdt-color-border); border-radius: 4px; margin-bottom: 6px;';
 
     const summary = doc.createElement('summary');
     summary.style.cssText =
@@ -202,7 +202,7 @@ export function mountHealthModal(options: MountHealthModalOptions = {}): HealthM
 
     const sevBadge = doc.createElement('span');
     sevBadge.className = `sfdt-health-family-severity sfdt-health-severity-${family.severity}`;
-    sevBadge.style.cssText = `display: inline-block; padding: 2px 6px; border-radius: 3px; font-size: 10px; font-weight: 700; color: #fff; background: ${severityColour(family.severity)};`;
+    sevBadge.style.cssText = `display: inline-block; padding: 2px 6px; border-radius: 3px; font-size: 10px; font-weight: 700; color: var(--sfdt-color-surface); background: ${severityColour(family.severity)};`;
     sevBadge.textContent = family.severity.toUpperCase();
 
     const titleSpan = doc.createElement('span');
@@ -212,7 +212,7 @@ export function mountHealthModal(options: MountHealthModalOptions = {}): HealthM
 
     const countSpan = doc.createElement('span');
     countSpan.className = 'sfdt-health-family-count';
-    countSpan.style.cssText = 'color: #80868d; font-size: 12px;';
+    countSpan.style.cssText = 'color: var(--sfdt-color-text-icon); font-size: 12px;';
     countSpan.textContent = `(${family.instanceCount})`;
 
     summary.appendChild(sevBadge);
@@ -225,7 +225,7 @@ export function mountHealthModal(options: MountHealthModalOptions = {}): HealthM
 
     const impact = doc.createElement('div');
     impact.className = 'sfdt-health-family-impact';
-    impact.style.cssText = 'color: #80868d; margin-bottom: 6px;';
+    impact.style.cssText = 'color: var(--sfdt-color-text-icon); margin-bottom: 6px;';
     impact.textContent = `Score impact: -${family.scoreImpact}`;
     familyBody.appendChild(impact);
 
@@ -263,7 +263,7 @@ export function mountHealthModal(options: MountHealthModalOptions = {}): HealthM
 
     const metaLine = doc.createElement('div');
     metaLine.className = 'sfdt-health-flow-meta';
-    metaLine.style.cssText = 'color: #80868d; font-size: 12px; display: flex; gap: 12px;';
+    metaLine.style.cssText = 'color: var(--sfdt-color-text-icon); font-size: 12px; display: flex; gap: 12px;';
     const flowTypeSpan = doc.createElement('span');
     flowTypeSpan.textContent = report.meta.flowType;
     metaLine.appendChild(flowTypeSpan);
@@ -286,7 +286,7 @@ export function mountHealthModal(options: MountHealthModalOptions = {}): HealthM
     scoreNum.textContent = String(report.summary.overallScore);
     const scoreRating = doc.createElement('div');
     scoreRating.className = 'sfdt-health-rating';
-    scoreRating.style.cssText = 'color: #54698d; font-weight: 600;';
+    scoreRating.style.cssText = 'color: var(--sfdt-color-text-weak); font-weight: 600;';
     scoreRating.textContent = report.summary.rating;
     scoreWrap.appendChild(scoreNum);
     scoreWrap.appendChild(scoreRating);
@@ -314,7 +314,7 @@ export function mountHealthModal(options: MountHealthModalOptions = {}): HealthM
     if (report.issueFamilies.length === 0) {
       const empty = doc.createElement('div');
       empty.className = 'sfdt-health-empty';
-      empty.style.cssText = 'color: #80868d; font-size: 13px;';
+      empty.style.cssText = 'color: var(--sfdt-color-text-icon); font-size: 13px;';
       empty.textContent = 'No issues detected — your flow is in excellent shape.';
       familiesSection.appendChild(empty);
     } else {
@@ -347,7 +347,7 @@ export function mountHealthModal(options: MountHealthModalOptions = {}): HealthM
     copyBtn.className = 'sfdt-health-btn';
     copyBtn.textContent = 'Copy JSON';
     copyBtn.style.cssText =
-      'padding: 6px 12px; border: 1px solid #d8dde6; background: #fff; border-radius: 4px; cursor: pointer;';
+      'padding: 6px 12px; border: 1px solid var(--sfdt-color-border); background: var(--sfdt-color-surface); border-radius: 4px; cursor: pointer;';
     copyBtn.addEventListener('click', () => {
       if (options.onCopyJson) {
         void options.onCopyJson(report.rawJson);

--- a/extension/ui/present-view.ts
+++ b/extension/ui/present-view.ts
@@ -56,7 +56,7 @@ export function presentView(opts: PresentOpts): ViewHandle {
 export function presentAsModal(opts: PresentOpts): ViewHandle {
   const doc = opts.doc ?? document;
   const card = doc.createElement('div');
-  card.style.cssText = `background: #fff; border-radius: 4px; width: ${opts.width ?? '860px'}; max-width: 95vw; max-height: 90vh; display: flex; flex-direction: column;`;
+  card.style.cssText = `background: var(--sfdt-color-surface); border-radius: 4px; width: ${opts.width ?? '860px'}; max-width: 95vw; max-height: 90vh; display: flex; flex-direction: column;`;
 
   let overlay: HTMLDivElement | null = doc.createElement('div');
   overlay.className = 'sfdt-view-overlay';
@@ -75,7 +75,7 @@ export function presentAsModal(opts: PresentOpts): ViewHandle {
 
   const header = doc.createElement('div');
   header.style.cssText =
-    'padding: 12px 16px; border-bottom: 1px solid #d8dde6; display: flex; justify-content: space-between; align-items: center; font-weight: 600;';
+    'padding: 12px 16px; border-bottom: 1px solid var(--sfdt-color-border); display: flex; justify-content: space-between; align-items: center; font-weight: 600;';
   const label = doc.createElement('span');
   label.textContent = opts.title;
   const closeBtn = doc.createElement('button');

--- a/extension/ui/side-button.ts
+++ b/extension/ui/side-button.ts
@@ -37,8 +37,8 @@ const BUTTON_STYLE = [
   'transform: translateY(-50%)',
   'width: 32px',
   'height: 48px',
-  'background: #0070d2',
-  'color: #fff',
+  'background: var(--sfdt-color-brand)',
+  'color: var(--sfdt-color-surface)',
   'border-radius: 4px 0 0 4px',
   'display: flex',
   'align-items: center',
@@ -54,8 +54,8 @@ const MENU_STYLE = [
   'top: 50%',
   'right: 40px',
   'transform: translateY(-50%)',
-  'background: #fff',
-  'border: 1px solid #d8dde6',
+  'background: var(--sfdt-color-surface)',
+  'border: 1px solid var(--sfdt-color-border)',
   'border-radius: 4px',
   'box-shadow: 0 2px 8px rgba(0,0,0,0.15)',
   'min-width: 240px',
@@ -117,14 +117,14 @@ export function mountSideButton(opts: {
   const header = doc.createElement('div');
   header.className = 'sfdt-menu-header';
   header.style.cssText =
-    'padding: 10px 14px; border-bottom: 1px solid #d8dde6; display: flex; justify-content: space-between; align-items: center;';
+    'padding: 10px 14px; border-bottom: 1px solid var(--sfdt-color-border); display: flex; justify-content: space-between; align-items: center;';
   const headerTitle = doc.createElement('span');
   headerTitle.className = 'sfdt-menu-title';
   headerTitle.style.fontWeight = '600';
   headerTitle.textContent = 'SFDT SF Helper';
   const headerClose = doc.createElement('span');
   headerClose.className = 'sfdt-menu-close';
-  headerClose.style.cssText = 'cursor: pointer; font-size: 18px; color: #80868d;';
+  headerClose.style.cssText = 'cursor: pointer; font-size: 18px; color: var(--sfdt-color-text-icon);';
   headerClose.textContent = '×';
   header.appendChild(headerTitle);
   header.appendChild(headerClose);
@@ -136,12 +136,12 @@ export function mountSideButton(opts: {
 
   const footer = doc.createElement('div');
   footer.className = 'sfdt-menu-footer';
-  footer.style.cssText = 'padding: 8px 14px; border-top: 1px solid #d8dde6;';
+  footer.style.cssText = 'padding: 8px 14px; border-top: 1px solid var(--sfdt-color-border);';
   const settingsLink = doc.createElement('a');
   settingsLink.href = '#';
   settingsLink.id = 'sfdt-settings-link';
   settingsLink.className = 'sfdt-menu-settings-link';
-  settingsLink.style.cssText = 'color: #0070d2; text-decoration: none; font-size: 12px;';
+  settingsLink.style.cssText = 'color: var(--sfdt-color-brand); text-decoration: none; font-size: 12px;';
   settingsLink.textContent = '⚙ Settings';
   footer.appendChild(settingsLink);
 
@@ -186,7 +186,7 @@ export function mountSideButton(opts: {
   function buildEmptyState(): HTMLDivElement {
     const empty = doc.createElement('div');
     empty.className = 'sfdt-menu-empty';
-    empty.style.cssText = 'padding: 16px; text-align: center; color: #80868d;';
+    empty.style.cssText = 'padding: 16px; text-align: center; color: var(--sfdt-color-text-icon);';
     empty.textContent = 'No tools available for this page.';
     return empty;
   }

--- a/extension/ui/toast.ts
+++ b/extension/ui/toast.ts
@@ -36,10 +36,10 @@ function ensureContainer(doc: Document): HTMLElement {
 }
 
 const KIND_BACKGROUND: Record<ToastKind, string> = {
-  info: '#0070d2',
-  success: '#04844b',
-  warning: '#fe9339',
-  error: '#c23934',
+  info: 'var(--sfdt-color-brand)',
+  success: 'var(--sfdt-color-success)',
+  warning: 'var(--sfdt-color-warning)',
+  error: 'var(--sfdt-color-error)',
 };
 
 // Returns a dismiss() so callers can close the toast early.
@@ -54,7 +54,7 @@ export function showToast(message: string, options: ToastOptions = {}): () => vo
   toast.setAttribute('role', 'status');
   toast.style.cssText = [
     'background: ' + KIND_BACKGROUND[kind],
-    'color: #fff',
+    'color: var(--sfdt-color-surface)',
     'padding: 10px 14px',
     'border-radius: 4px',
     'box-shadow: 0 2px 6px rgba(0,0,0,0.2)',


### PR DESCRIPTION
## Item: P0-1 · Design-token refactor (size M)

Extract every hard-coded colour from `extension/ui/*.ts`, the `STYLES` constants in `entrypoints/app/main.ts` + `entrypoints/options/main.ts`, and per-feature inline `cssText` into CSS custom properties (`--sfdt-color-*`) defined in one tokens module consumed by all three surfaces. **No visual change.**

## What changed

- **New `extension/lib/tokens.ts`** — the single source of truth. Holds all ~44 raw hex values as `--sfdt-color-*` custom properties, exports `SFDT_TOKENS_CSS` (the `:root { … }` block) and `ensureTokens(doc)` (idempotent injector).
- **~770 hex literals → `var(--sfdt-color-*)`** across 35 features + 4 `ui/` components. Each token maps **1:1** to exactly the hex it replaced.
- **Token injection wired into all three surfaces:**
  - content script (`content.ts`): `ensureTokens(document)` at boot injects the `:root` block into the host Salesforce page (namespaced, can't collide with SLDS).
  - app page (`app/main.ts`) + options page (`options/main.ts`): token block prepended to their injected stylesheet.
- **`subflow-graph.ts` SVG paints** moved from `setAttribute('fill'|'stroke', …)` to the CSS `style.fill`/`style.stroke` properties, where `var()` resolves (custom properties inherit from `:root` into the `<marker>`/SVG subtree).
- **4 mechanical test-assertion updates** (`toast`, `phase6`/subflow, `api-version-audit`, `org-release-badge`) — now expect the `var(--sfdt-*)` string instead of the raw hex. No logic changed.

## Acceptance criteria

1. **Single tokens source; all surfaces use `var(--sfdt-*)`.** ✅ The AC1 grep over the three UI dirs returns only the documented allowlist:
   ```
   $ grep -rE '#[0-9a-fA-F]{3,6}' extension/features extension/ui extension/entrypoints
   features/canvas-search.ts:  highlightColour: z.string().default('#FFD700'),
   features/canvas-search.ts:  let highlightColour = '#FFD700';
   ```
   The tokens source is `extension/lib/tokens.ts` (its correct architectural home alongside the other shared libs; `lib/` is outside the grep's dir scope, so the three UI dirs are 100% clean).
   **Documented allowlist (1 entry, 2 lines):** `canvasSearch.highlightColour`'s default `#FFD700` stays a literal — it is a **user-configurable runtime value** that is string-concatenated with an alpha suffix (`${colour}80`) in `injectDynamicStyles`, so it cannot be a CSS variable. (`lib/settings.ts` mirrors the same default; also outside the AC1 grep scope.)

2. **Screenshot parity — no visual change.** Proven mechanically: reversing every `var(--sfdt-color-*)` back to its token value yields **byte-identical files** vs. `HEAD` for all 35 bulk-tokenized files (35/35). The other 4 files only *add* the `:root` token definitions or change the SVG paint *mechanism* to the same resolved value. Live before/after screenshots (Workspace, options, side-button menu, one modal) are for the verifier to capture in a loaded unpacked build.

3. **Existing vitest suites pass** — only the 4 mechanical assertion updates above (each justified: the rendered value is now a `var(--sfdt-*)` string). Full suite green in isolation; the only red runs were timing flakes in the untouched `sfdt-bridge.test.ts` under heavy parallel machine load (passes 49/49 in isolation).

## Global Definition of Done

- **Registry/kill-switch/toggle:** N/A — pure refactor, no new feature. No manifest/registry/kill-switch/toggle change applies.
- **DOM discipline:** zero `innerHTML` introduced (only `createElement` + `textContent` + `style`/`setAttribute`).
- **No new runtime dependency.**
- **Vitest:** logic covered; 4 mechanical selector/value updates only.
- **A11y:** unchanged — no markup/roles/focus/keyboard paths touched.
- **Both themes:** light only until P0-2; this refactor is the P0-2 enabler.
- **CHANGELOG:** `[Unreleased] → Changed` entry added.
- **Docs MDX:** none — no user-facing change.
- **Telemetry no-egress test:** green (untouched).
- **SID/secrets:** untouched — no worker/bridge code changed.
- **Permission ledger:** none. No manifest permission added.

## Verification gates (from `extension/`)

- `npx vitest run` — 809 tests; green except timing flakes in untouched `sfdt-bridge.test.ts` under load (49/49 in isolation).
- `npx tsc --noEmit` — exit 0.
- `npx eslint .` — exit 0.
- `npx wxt build` — built OK; manifest version `0.7.0` == `package.json` `0.7.0`.

## Checkpoint summary

This is a no-behaviour refactor: every UI colour now flows through one file (`lib/tokens.ts`) as a `--sfdt-color-*` variable instead of being hard-coded in ~38 files. It renders identically today (each token equals the exact hex it replaced — proven by a byte-for-byte reverse check) and is the single prerequisite that makes a one-switch dark theme (P0-2) feasible. The only literal colour left in the UI dirs is the user's configurable search-highlight default, which technically can't be a CSS variable; it's documented as an allowlist entry.

https://claude.ai/code/session_01AYp5KQjiDPHnZfGba2tCY8