### PR TITLE
build(extension): packaging version-match guard (P0-7)

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to `@sfdt/extension` are documented here. Format follows [Ke
 
 ## [Unreleased]
 
+### Added
+- **Packaging version-match guard** (`scripts/check-version-match.ts`) — the `package:ext` step now fails if `extension/package.json`'s version differs from the built manifest (`.output/chrome-mv3/manifest.json`), naming both versions and the file, so a stale build artifact can't be zipped and shipped. Runs in the Extension CI packaging job; documented in the new `extension/RELEASING.md`.
+
 ## [0.7.0] - 2026-07-14
 
 ### Added

--- a/extension/RELEASING.md
+++ b/extension/RELEASING.md
@@ -1,0 +1,46 @@
+# Releasing `@sfdt/extension`
+
+The Chrome extension is built and packaged with [WXT](https://wxt.dev). Releases
+are cut from `main` by the **Extension CI** workflow (`.github/workflows/extension.yml`).
+
+## Version source of truth
+
+`extension/package.json` `version` is the single source of truth. WXT copies it
+into the built manifest (`.output/chrome-mv3/manifest.json`) at build time, so the
+two must always agree.
+
+## Cut a release
+
+1. Bump `version` in `extension/package.json`.
+2. Move the `## [Unreleased]` notes in `extension/CHANGELOG.md` under a new
+   `## [x.y.z] - <date>` heading.
+3. Merge to `main`. The `release` job in `extension.yml` detects the version bump,
+   tags `ext-vx.y.z`, creates a GitHub Release with the Chrome zip, and publishes
+   to the Chrome Web Store.
+
+Prerelease versions (containing `-`) are rejected by the release job.
+
+## Packaging (local + CI)
+
+```bash
+npm run package:ext   # build flow-core + extension, verify version match, then zip
+```
+
+`package:ext` runs three steps in order: `build:ext`, the **version-match guard**,
+then `wxt zip`. CI runs the same command in the `build` job.
+
+### Version-match guard (P0-7)
+
+`extension/scripts/check-version-match.ts` runs between build and zip. It compares
+`extension/package.json`'s version against the built manifest
+(`.output/chrome-mv3/manifest.json`) and **exits non-zero** if they differ, naming
+both versions and the manifest path. This prevents shipping a stale zip whose
+manifest lags the source version (the 0.5.0-vs-0.6.0 drift class).
+
+Run it standalone against the current build:
+
+```bash
+node extension/scripts/check-version-match.ts
+```
+
+The comparison core is unit-tested in `extension/test/version-match.test.ts`.

--- a/extension/scripts/check-version-match.ts
+++ b/extension/scripts/check-version-match.ts
@@ -1,0 +1,86 @@
+/**
+ * Packaging guard (execution-plan item P0-7).
+ *
+ * Fails the package step when `extension/package.json`'s version does not equal
+ * the version in the freshly built manifest (`.output/chrome-mv3/manifest.json`).
+ * This is the "stale build artifact" guard from the competitive-analysis §5.7
+ * anti-patterns: without it a stale `.output/` (source at 0.6.0, manifest still
+ * 0.5.0) could be zipped and shipped.
+ *
+ * Core (`checkVersionMatch`) throws on mismatch or a missing/invalid file so it
+ * is unit-testable; the CLI wrapper at the bottom turns a throw into a non-zero
+ * exit. Package-internal paths are resolved from `import.meta.url`, never the
+ * cwd, so it works regardless of where `node` is invoked from.
+ */
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+
+/** `extension/package.json` — the source of truth for the version. */
+export const PKG_PATH = resolve(scriptDir, '..', 'package.json');
+/** The built MV3 manifest WXT emits into `.output/`. */
+export const MANIFEST_PATH = resolve(scriptDir, '..', '.output', 'chrome-mv3', 'manifest.json');
+
+function readVersion(filePath: string, label: string): string {
+  let raw: string;
+  try {
+    raw = readFileSync(filePath, 'utf8');
+  } catch {
+    throw new Error(`${label} not found at ${filePath} (build the extension before packaging).`);
+  }
+  let json: { version?: unknown };
+  try {
+    json = JSON.parse(raw) as { version?: unknown };
+  } catch (err) {
+    throw new Error(`${label} at ${filePath} is not valid JSON: ${(err as Error).message}`);
+  }
+  if (typeof json.version !== 'string' || json.version.length === 0) {
+    throw new Error(`${label} at ${filePath} has no "version" string.`);
+  }
+  return json.version;
+}
+
+export interface CheckOptions {
+  pkgPath?: string;
+  manifestPath?: string;
+}
+
+/**
+ * Throws if the built manifest version differs from package.json, or if either
+ * file is missing/unreadable. Returns the agreed version on success.
+ */
+export function checkVersionMatch(opts: CheckOptions = {}): { version: string } {
+  const pkgPath = opts.pkgPath ?? PKG_PATH;
+  const manifestPath = opts.manifestPath ?? MANIFEST_PATH;
+
+  const pkgVersion = readVersion(pkgPath, 'package.json');
+  const manifestVersion = readVersion(manifestPath, 'built manifest');
+
+  if (pkgVersion !== manifestVersion) {
+    throw new Error(
+      `Version mismatch: extension/package.json is ${pkgVersion} but the built manifest ` +
+        `(${manifestPath}) is ${manifestVersion}. Rebuild the extension before packaging so ` +
+        `the zip cannot ship a stale version.`,
+    );
+  }
+  return { version: pkgVersion };
+}
+
+// --- Thin CLI wrapper ------------------------------------------------------
+// Only runs the guard when executed directly (node scripts/check-version-match.ts),
+// never when imported by the test.
+const invokedDirectly =
+  typeof process.argv[1] === 'string' &&
+  resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (invokedDirectly) {
+  try {
+    const { version } = checkVersionMatch();
+    console.log(`✓ version match: package.json and built manifest are both ${version}`);
+  } catch (err) {
+    console.error(`✗ ${(err as Error).message}`);
+    process.exit(1);
+  }
+}

--- a/extension/test/version-match.test.ts
+++ b/extension/test/version-match.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { checkVersionMatch } from '../scripts/check-version-match.js';
+
+// The guard reads two JSON files and compares their `version`. Tests exercise
+// the core against temp files so no real build is required.
+describe('check-version-match (P0-7 packaging guard)', () => {
+  let dir: string;
+  let pkgPath: string;
+  let manifestPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'sfdt-vmatch-'));
+    pkgPath = join(dir, 'package.json');
+    manifestPath = join(dir, 'manifest.json');
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('passes and returns the version when both match', () => {
+    writeFileSync(pkgPath, JSON.stringify({ version: '0.7.0' }));
+    writeFileSync(manifestPath, JSON.stringify({ version: '0.7.0' }));
+    expect(checkVersionMatch({ pkgPath, manifestPath })).toEqual({ version: '0.7.0' });
+  });
+
+  it('throws naming both versions and the manifest file on mismatch', () => {
+    writeFileSync(pkgPath, JSON.stringify({ version: '0.6.0' }));
+    writeFileSync(manifestPath, JSON.stringify({ version: '0.5.0' }));
+    expect(() => checkVersionMatch({ pkgPath, manifestPath })).toThrow(
+      /0\.6\.0.*0\.5\.0|0\.5\.0.*0\.6\.0/,
+    );
+    // The manifest path is named so the failure is actionable.
+    expect(() => checkVersionMatch({ pkgPath, manifestPath })).toThrow(manifestPath);
+  });
+
+  it('throws a clear error when the built manifest is missing', () => {
+    writeFileSync(pkgPath, JSON.stringify({ version: '0.7.0' }));
+    // manifestPath intentionally not written
+    expect(() => checkVersionMatch({ pkgPath, manifestPath })).toThrow(/built manifest not found/);
+  });
+
+  it('throws a clear error when package.json is missing', () => {
+    writeFileSync(manifestPath, JSON.stringify({ version: '0.7.0' }));
+    expect(() => checkVersionMatch({ pkgPath, manifestPath })).toThrow(/package\.json not found/);
+  });
+
+  it('throws when the manifest has no version string', () => {
+    writeFileSync(pkgPath, JSON.stringify({ version: '0.7.0' }));
+    writeFileSync(manifestPath, JSON.stringify({ name: 'no version here' }));
+    expect(() => checkVersionMatch({ pkgPath, manifestPath })).toThrow(/no "version" string/);
+  });
+
+  it('throws on invalid JSON', () => {
+    writeFileSync(pkgPath, JSON.stringify({ version: '0.7.0' }));
+    writeFileSync(manifestPath, '{ not valid json');
+    expect(() => checkVersionMatch({ pkgPath, manifestPath })).toThrow(/not valid JSON/);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "build:ext": "npm run build:flow-core && npm run build -w @sfdt/extension",
     "build:vscode": "npm run build:flow-core && npm run build -w vscode",
     "build:plugin": "npm run build -w @sfdt/plugin",
-    "package:ext": "npm run build:ext && npm run zip -w @sfdt/extension",
+    "package:ext": "npm run build:ext && node extension/scripts/check-version-match.ts && npm run zip -w @sfdt/extension",
     "package:vscode": "npm run package -w vscode",
     "test:flow-core": "npm run test -w @sfdt/flow-core",
     "test:extension": "npm run test -w @sfdt/extension",


### PR DESCRIPTION
## What & why (P0-7 · Packaging version-match check)

Adds a guard to the extension package step that **fails if `extension/package.json`'s version differs from the built manifest** (`.output/chrome-mv3/manifest.json`). This is the stale-build-artifact anti-pattern from the competitive-analysis §5.7 (our own `.output/` manifest at 0.5.0 while source was 0.6.0) — the guard makes it impossible to zip and ship a stale version.

## Changes
- `extension/scripts/check-version-match.ts` — importable core `checkVersionMatch()` (throws on mismatch or missing/invalid file, naming both versions + the manifest path) with a thin CLI wrapper that exits non-zero on throw. Package-internal paths resolved via `import.meta.url` (cwd-independent). Node built-ins only.
- `package.json` — `package:ext` now runs the guard between `build:ext` and `wxt zip`, so the Extension CI `build` job (`npm run package:ext`) catches drift.
- `extension/test/version-match.test.ts` — vitest covering match / mismatch / missing-manifest / missing-pkg / no-version / invalid-JSON.
- `extension/RELEASING.md` — new; documents the release flow and the guard.
- `extension/CHANGELOG.md` — `[Unreleased]` entry.

## Acceptance criteria
1. **Tamper → non-zero:** tampering the built manifest version makes the guard exit 1 with a message naming both versions and the file (proven below). ✅
2. **CI + docs:** runs in the Extension CI packaging job via `package:ext`; documented in `extension/RELEASING.md`. ✅

## Evidence
```
$ node scripts/check-version-match.ts        # matched
✓ version match: package.json and built manifest are both 0.7.0   (exit 0)

$ # tamper .output manifest version -> 0.5.0
$ node scripts/check-version-match.ts
✗ Version mismatch: extension/package.json is 0.7.0 but the built manifest (.../manifest.json) is 0.5.0. Rebuild the extension before packaging so the zip cannot ship a stale version.   (exit 1)
```
Gates from `extension/`: `npx vitest run` → 55 files / 815 tests pass · `npx tsc --noEmit` → exit 0 · `npx eslint .` → exit 0 · `npx wxt build` → built manifest 0.7.0 == package.json 0.7.0.

## Global DoD
- Feature-registry/kill-switch/opt-in: **N/A** — packaging guard, not a user feature.
- Zero `innerHTML` / DOM discipline: **N/A** — no UI added.
- No new runtime dependency: **MET** — Node built-ins only (`fs`, `path`, `url`, `process`).
- Vitest coverage: **MET** — 6 cases (match, mismatch, missing files, no-version, invalid JSON).
- A11y / both themes: **N/A**.
- CHANGELOG `[Unreleased]`: **MET**.
- Docs-site MDX: **N/A** — dev/release tooling; `RELEASING.md` is the doc.
- Telemetry no-egress test: **untouched** (still green in full run).
- SID-in-worker invariant: **N/A** — no API code touched.
- Permission ledger: **none** — no manifest permission changed.
- Diff scoped to this item: packaging/CI/test/docs only; no feature/UI/token code touched.

## Checkpoint summary
A build-time guard that refuses to package the extension if the version stamped in the built manifest doesn't match `package.json`. It runs automatically as part of `npm run package:ext` (local and CI) and can be run standalone with `node extension/scripts/check-version-match.ts`. It changes nothing users see — it only stops a bad zip from being produced.

https://claude.ai/code/session_01AYp5KQjiDPHnZfGba2tCY8