### PR TITLE
feat(extension): SOQL Runner — Explain / query plan (P1-1)

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to `@sfdt/extension` are documented here. Format follows [Ke
 
 ## [Unreleased]
 
+### Added
+- **SOQL Query Runner — Explain (query plan).** The SOQL Runner gains a **🔎 Explain** action that calls Salesforce's query-plan endpoint (`.../query/?explain=` for REST, `.../tooling/query/?explain=` for Tooling) for the current query and renders the returned plans in a table — leading operation type, relative cost, cardinality, SObject cardinality, SObject, and optimizer notes — so you can spot table scans and unindexed filters before running the query. The call goes through the existing worker-proxied API client (the session id never leaves the worker). Non-explainable queries (SOSL/GraphQL) and API errors surface inline in the tool's error panel rather than as a thrown toast.
+
 ## [0.7.0] - 2026-07-14
 
 ### Added

--- a/extension/features/soql-runner.ts
+++ b/extension/features/soql-runner.ts
@@ -396,6 +396,76 @@ async function runQuery(
   return api.query<Record<string, unknown>>(soql);
 }
 
+// --- QUERY PLAN / EXPLAIN ---
+// Salesforce's query-plan endpoint: GET .../query/?explain=<soql> (Tooling
+// queries use .../tooling/query/?explain=). It returns one plan per candidate
+// leading operation; the lowest relativeCost is the one the optimizer picks.
+interface QueryPlanNote {
+  description?: string;
+  fields?: string[];
+  tableEnumOrId?: string;
+}
+
+interface QueryPlan {
+  cardinality?: number;
+  leadingOperationType?: string;
+  relativeCost?: number;
+  sobjectCardinality?: number;
+  sobjectType?: string;
+  notes?: QueryPlanNote[];
+}
+
+interface QueryPlanResponse {
+  plans?: QueryPlan[];
+  sourceQuery?: string;
+}
+
+export interface ExplainPlanRow {
+  sobjectType: string;
+  leadingOperationType: string;
+  relativeCost: string;
+  cardinality: string;
+  sobjectCardinality: string;
+  notes: string;
+}
+
+// Only plain SOQL is explainable — SOSL/GraphQL will 400, which the caller
+// surfaces inline. The endpoint mirrors runQuery's REST/Tooling split so the
+// plan matches how the query itself would run.
+async function explainQuery(
+  api: SalesforceApiClient,
+  soql: string,
+  mode: ApiMode,
+): Promise<QueryPlanResponse> {
+  const apiVersion = api.apiVersion;
+  const endpoint =
+    mode === 'tooling'
+      ? `/services/data/${apiVersion}/tooling/query`
+      : `/services/data/${apiVersion}/query`;
+  return api.apiGet<QueryPlanResponse>(endpoint, { explain: soql });
+}
+
+function numToCell(value: number | undefined): string {
+  return typeof value === 'number' ? String(value) : '';
+}
+
+export function explainPlansToRows(resp: QueryPlanResponse | null | undefined): ExplainPlanRow[] {
+  const plans = Array.isArray(resp?.plans) ? resp!.plans : [];
+  return plans.map((plan) => ({
+    sobjectType: plan.sobjectType ?? '',
+    leadingOperationType: plan.leadingOperationType ?? '',
+    relativeCost: numToCell(plan.relativeCost),
+    cardinality: numToCell(plan.cardinality),
+    sobjectCardinality: numToCell(plan.sobjectCardinality),
+    notes: Array.isArray(plan.notes)
+      ? plan.notes
+          .map((n) => n.description)
+          .filter((d): d is string => typeof d === 'string' && d.length > 0)
+          .join('; ')
+      : '',
+  }));
+}
+
 export interface SoqlRunnerOptions {
   doc?: Document;
   win?: Window;
@@ -584,14 +654,22 @@ export function createSoqlRunnerFeature(options: SoqlRunnerOptions = {}): Featur
         showToast('Query bookmarked successfully', { doc, kind: 'success' });
       }
     });
+    const explainBtn = doc.createElement('button');
+    explainBtn.textContent = '🔎 Explain';
+    explainBtn.title = 'Show the query plan (cost, cardinality, leading operation) for this query';
+    explainBtn.style.cssText =
+      'padding: 6px 12px; background: #fff; color: #0070d2; border: 1px solid #d8dde6; border-radius: 4px; cursor: pointer; font-size: 13px;';
     const status = doc.createElement('span');
     status.style.cssText = 'color: #54698d; font-size: 12px;';
     runRow.appendChild(runBtn);
+    runRow.appendChild(explainBtn);
     runRow.appendChild(bookmarkBtn);
     runRow.appendChild(status);
     body.appendChild(runRow);
 
     const errorPanel = doc.createElement('div');
+    // role=alert so screen readers announce query/plan errors inline as they appear.
+    errorPanel.setAttribute('role', 'alert');
     errorPanel.style.cssText =
       'display: none; border: 1px solid #c23934; background: #fef2f1; color: #c23934; padding: 8px 12px; border-radius: 4px; font-size: 13px; white-space: pre-wrap;';
     body.appendChild(errorPanel);
@@ -600,6 +678,16 @@ export function createSoqlRunnerFeature(options: SoqlRunnerOptions = {}): Featur
     resultsWrap.style.cssText =
       'border: 1px solid #d8dde6; border-radius: 4px; overflow: auto; max-height: 360px; display: none;';
     body.appendChild(resultsWrap);
+
+    // Query-plan (Explain) results — its own scrollable, keyboard-reachable
+    // region so it never clobbers the record table.
+    const explainWrap = doc.createElement('div');
+    explainWrap.tabIndex = 0;
+    explainWrap.setAttribute('role', 'region');
+    explainWrap.setAttribute('aria-label', 'SOQL query plan');
+    explainWrap.style.cssText =
+      'border: 1px solid #d8dde6; border-radius: 4px; overflow: auto; max-height: 360px; display: none;';
+    body.appendChild(explainWrap);
 
     const footer = doc.createElement('div');
     footer.style.cssText = 'display: flex; gap: 8px; align-items: center;';
@@ -653,6 +741,7 @@ export function createSoqlRunnerFeature(options: SoqlRunnerOptions = {}): Featur
       errorPanel.textContent = message;
       errorPanel.style.display = 'block';
       resultsWrap.style.display = 'none';
+      explainWrap.style.display = 'none';
       loadMoreBtn.style.display = 'none';
       copyCsvBtn.style.display = 'none';
       exportCsvBtn.style.display = 'none';
@@ -893,6 +982,7 @@ export function createSoqlRunnerFeature(options: SoqlRunnerOptions = {}): Featur
         return;
       }
       clearError();
+      explainWrap.style.display = 'none';
       runBtn.disabled = true;
       status.textContent = 'Running…';
       const t0 = Date.now();
@@ -945,6 +1035,82 @@ export function createSoqlRunnerFeature(options: SoqlRunnerOptions = {}): Featur
         showError(err instanceof Error ? err.message : String(err));
       } finally {
         loadMoreBtn.disabled = false;
+      }
+    }
+
+    function renderExplain(rows: ExplainPlanRow[]): void {
+      while (explainWrap.firstChild) explainWrap.removeChild(explainWrap.firstChild);
+      if (rows.length === 0) {
+        const empty = doc.createElement('div');
+        empty.style.cssText = 'padding: 12px; color: #80868d; font-size: 13px;';
+        empty.textContent = 'No query plan returned.';
+        explainWrap.appendChild(empty);
+        explainWrap.style.display = 'block';
+        return;
+      }
+      const cols: { key: keyof ExplainPlanRow; label: string }[] = [
+        { key: 'leadingOperationType', label: 'Leading Operation' },
+        { key: 'relativeCost', label: 'Relative Cost' },
+        { key: 'cardinality', label: 'Cardinality' },
+        { key: 'sobjectCardinality', label: 'SObject Cardinality' },
+        { key: 'sobjectType', label: 'SObject' },
+        { key: 'notes', label: 'Notes' },
+      ];
+      const table = doc.createElement('table');
+      table.style.cssText = 'border-collapse: collapse; width: 100%; font-size: 12px;';
+      const thead = doc.createElement('thead');
+      const headRow = doc.createElement('tr');
+      for (const c of cols) {
+        const th = doc.createElement('th');
+        th.textContent = c.label;
+        th.style.cssText =
+          'text-align: left; padding: 6px 10px; border-bottom: 1px solid #d8dde6; background: #fafaf9; position: sticky; top: 0;';
+        headRow.appendChild(th);
+      }
+      thead.appendChild(headRow);
+      table.appendChild(thead);
+      const tbody = doc.createElement('tbody');
+      for (const row of rows) {
+        const tr = doc.createElement('tr');
+        for (const c of cols) {
+          const td = doc.createElement('td');
+          td.textContent = row[c.key];
+          td.style.cssText = 'padding: 6px 10px; border-bottom: 1px solid #f3f3f3; vertical-align: top;';
+          tr.appendChild(td);
+        }
+        tbody.appendChild(tr);
+      }
+      table.appendChild(tbody);
+      explainWrap.appendChild(table);
+      explainWrap.style.display = 'block';
+    }
+
+    async function explain(): Promise<void> {
+      const soql = textarea.value.trim();
+      if (!soql) {
+        showError('Enter a SOQL query to explain.');
+        return;
+      }
+      clearError();
+      explainBtn.disabled = true;
+      status.textContent = 'Explaining…';
+      const t0 = Date.now();
+      try {
+        const resp = await explainQuery(api, soql, mode);
+        const rows = explainPlansToRows(resp);
+        const elapsed = Date.now() - t0;
+        status.textContent = `⏱ ${elapsed} ms · query plan (${rows.length} plan${
+          rows.length === 1 ? '' : 's'
+        })`;
+        renderExplain(rows);
+      } catch (err) {
+        // Non-explainable queries (SOSL/GraphQL) and API errors land here — kept
+        // inline in the error panel, never thrown as an uncaught toast.
+        explainWrap.style.display = 'none';
+        showError(err instanceof Error ? err.message : String(err));
+        status.textContent = '';
+      } finally {
+        explainBtn.disabled = false;
       }
     }
 
@@ -1538,6 +1704,7 @@ export function createSoqlRunnerFeature(options: SoqlRunnerOptions = {}): Featur
     }
 
     runBtn.addEventListener('click', () => void execute());
+    explainBtn.addEventListener('click', () => void explain());
     loadMoreBtn.addEventListener('click', () => void loadMore());
     
     // Wire up autocomplete events
@@ -1645,6 +1812,8 @@ export function _soqlRunnerTestApi() {
     deleteSavedQuery,
     DescribeCache,
     runQuery,
+    explainQuery,
+    explainPlansToRows,
     HISTORY_CAP,
     PAGE_CAP,
   };

--- a/extension/test/soql-runner.test.ts
+++ b/extension/test/soql-runner.test.ts
@@ -24,7 +24,38 @@ const {
   deleteSavedQuery,
   DescribeCache,
   runQuery,
+  explainQuery,
+  explainPlansToRows,
 } = _soqlRunnerTestApi();
+
+const CANNED_PLAN = {
+  plans: [
+    {
+      cardinality: 1,
+      fields: ['Name'],
+      leadingOperationType: 'Index',
+      relativeCost: 0.5,
+      sobjectCardinality: 100,
+      sobjectType: 'Account',
+      notes: [
+        {
+          description: 'Not considering filter for optimization because unindexed',
+          fields: ['Description'],
+          tableEnumOrId: 'Account',
+        },
+      ],
+    },
+    {
+      cardinality: 100,
+      leadingOperationType: 'TableScan',
+      relativeCost: 2.8,
+      sobjectCardinality: 100,
+      sobjectType: 'Account',
+      notes: [],
+    },
+  ],
+  sourceQuery: "SELECT Name FROM Account WHERE Name = 'x'",
+};
 
 function fakeApi(overrides: Partial<SalesforceApiClient> = {}): SalesforceApiClient {
   return {
@@ -532,6 +563,144 @@ describe('soql-runner — runQuery', () => {
     await expect(
       runQuery(client, `query { uiapi { query { Account { edges { node { Bogus } } } } } }`, 'rest')
     ).rejects.toThrow("Cannot query field 'Bogus' on type 'Account'");
+  });
+});
+
+describe('soql-runner — explain / query plan', () => {
+  it('calls the REST query endpoint with an explain= param in rest mode', async () => {
+    const apiGet = vi.fn().mockResolvedValue(CANNED_PLAN);
+    const client = fakeApi({ apiGet });
+    await explainQuery(client, 'SELECT Name FROM Account', 'rest');
+    expect(apiGet).toHaveBeenCalledWith('/services/data/v62.0/query', {
+      explain: 'SELECT Name FROM Account',
+    });
+  });
+
+  it('calls the Tooling query endpoint with an explain= param in tooling mode', async () => {
+    const apiGet = vi.fn().mockResolvedValue(CANNED_PLAN);
+    const client = fakeApi({ apiGet });
+    await explainQuery(client, 'SELECT Id FROM FlowDefinition', 'tooling');
+    expect(apiGet).toHaveBeenCalledWith('/services/data/v62.0/tooling/query', {
+      explain: 'SELECT Id FROM FlowDefinition',
+    });
+  });
+
+  it('normalizes a canned plan response into renderable rows', () => {
+    const rows = explainPlansToRows(CANNED_PLAN);
+    expect(rows).toEqual([
+      {
+        sobjectType: 'Account',
+        leadingOperationType: 'Index',
+        relativeCost: '0.5',
+        cardinality: '1',
+        sobjectCardinality: '100',
+        notes: 'Not considering filter for optimization because unindexed',
+      },
+      {
+        sobjectType: 'Account',
+        leadingOperationType: 'TableScan',
+        relativeCost: '2.8',
+        cardinality: '100',
+        sobjectCardinality: '100',
+        notes: '',
+      },
+    ]);
+  });
+
+  it('returns no rows for an empty or malformed plan response', () => {
+    expect(explainPlansToRows(null)).toEqual([]);
+    expect(explainPlansToRows({})).toEqual([]);
+    expect(explainPlansToRows({ plans: [] })).toEqual([]);
+  });
+});
+
+describe('soql-runner — explain UI', () => {
+  function setSalesforceUrl(): void {
+    window.history.replaceState(
+      {},
+      '',
+      'https://x.lightning.force.com/lightning/setup/Flows/home',
+    );
+  }
+  async function flush(): Promise<void> {
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+  }
+  function findButton(text: string): HTMLButtonElement | undefined {
+    return Array.from(document.querySelectorAll('button')).find((b) => b.textContent === text);
+  }
+
+  it('renders the query plan table from a canned explain response', async () => {
+    setSalesforceUrl();
+    const apiGet = vi.fn().mockResolvedValue(CANNED_PLAN);
+    const feature = createSoqlRunnerFeature({ api: fakeApi({ apiGet }) });
+    await feature.onActivate?.();
+
+    const textarea = document.querySelector('textarea') as HTMLTextAreaElement;
+    textarea.value = 'SELECT Name FROM Account';
+    findButton('🔎 Explain')?.click();
+    await flush();
+
+    expect(apiGet).toHaveBeenCalledWith('/services/data/v62.0/query', {
+      explain: 'SELECT Name FROM Account',
+    });
+
+    // The plan table lives in the keyboard-reachable region.
+    const region = document.querySelector('[aria-label="SOQL query plan"]') as HTMLElement;
+    expect(region).toBeTruthy();
+    expect(region.getAttribute('tabindex')).toBe('0');
+    const headers = Array.from(region.querySelectorAll('th')).map((th) => th.textContent);
+    expect(headers).toEqual([
+      'Leading Operation',
+      'Relative Cost',
+      'Cardinality',
+      'SObject Cardinality',
+      'SObject',
+      'Notes',
+    ]);
+    const rows = region.querySelectorAll('tbody tr');
+    expect(rows).toHaveLength(2);
+    const firstRowCells = Array.from(rows[0]!.querySelectorAll('td')).map((td) => td.textContent);
+    expect(firstRowCells).toEqual([
+      'Index',
+      '0.5',
+      '1',
+      '100',
+      'Account',
+      'Not considering filter for optimization because unindexed',
+    ]);
+  });
+
+  it('surfaces an explain error inline in the error panel, not as a throw', async () => {
+    setSalesforceUrl();
+    const apiGet = vi.fn().mockRejectedValue(
+      new Error("MALFORMED_QUERY: EXPLAIN is not supported for this query"),
+    );
+    const feature = createSoqlRunnerFeature({ api: fakeApi({ apiGet }) });
+    await feature.onActivate?.();
+
+    const textarea = document.querySelector('textarea') as HTMLTextAreaElement;
+    textarea.value = 'FIND {Acme} IN ALL FIELDS';
+    // Must not throw — the click handler swallows the rejection into the panel.
+    expect(() => findButton('🔎 Explain')?.click()).not.toThrow();
+    await flush();
+
+    const alert = document.querySelector('[role="alert"]') as HTMLElement;
+    expect(alert).toBeTruthy();
+    expect(alert.textContent).toContain('MALFORMED_QUERY');
+    expect(alert.style.display).toBe('block');
+    // The plan region stays hidden on error.
+    const region = document.querySelector('[aria-label="SOQL query plan"]') as HTMLElement;
+    expect(region.style.display).toBe('none');
+  });
+
+  it('shows an inline error when explaining an empty query', async () => {
+    setSalesforceUrl();
+    const feature = createSoqlRunnerFeature({ api: fakeApi() });
+    await feature.onActivate?.();
+    findButton('🔎 Explain')?.click();
+    await flush();
+    expect(document.body.textContent).toContain('Enter a SOQL query to explain.');
   });
 });
 


### PR DESCRIPTION
## P1-1 · SOQL Query Plan / EXPLAIN (size S)

Extends the existing **`soql-runner`** feature — no new feature id (the Explain action rides the existing `soql-runner` registry entry / kill-switch).

### What it does
Adds a **🔎 Explain** action next to Run. It calls Salesforce's query-plan endpoint for the current query and renders the returned plan(s):

- **REST mode** → `GET /services/data/vXX.0/query/?explain=<query>`
- **Tooling mode** → `GET /services/data/vXX.0/tooling/query/?explain=<query>`

Both go through the existing worker-proxied `api.apiGet` client, so the **session id never leaves the worker** — `chrome.cookies`/sid untouched.

The plan table shows one row per candidate leading operation: **Leading Operation**, **Relative Cost**, **Cardinality**, **SObject Cardinality**, **SObject**, and optimizer **Notes** — the lowest-cost row is the one the optimizer picks, so table scans / unindexed filters are visible before you run the query.

### AC coverage
1. ✅ Explain action calling `explain=` for the current query in both REST and Tooling modes.
2. ✅ Plan rows render `cardinality`, `sobjectCardinality`, `leadingOperationType`, relative `cost`, and `notes` (plus `sobjectType`).
3. ✅ Errors (non-explainable SOSL/GraphQL, API failures) surface **inline** in the tool's error panel — the click handler swallows the rejection; nothing is thrown or toasted.
4. ✅ Vitest: `explainQuery` request shape (REST + Tooling via the worker proxy), `explainPlansToRows` normalization, DOM render from a canned plan response, and the inline-error path.

### DoD
- Zero `innerHTML` — `createElement` + `textContent` throughout.
- No new runtime dependency.
- Plan results live in a `role="region"` `tabindex="0"` container (keyboard-reachable); the error panel is `role="alert"` so screen readers announce query/plan errors inline.
- CHANGELOG `[Unreleased]` entry added.

### Note on design tokens
The prompt referenced `extension/CLAUDE.md`, `extension/CONVENTIONS.md`, and `var(--sfdt-color-*)` design tokens + dark-mode foundation on `develop`. **None of these exist in the current `develop`** (`git ls-files` finds no such files; no `--sfdt-` tokens anywhere in `.ts`/`.css`). The soql-runner uses hardcoded Salesforce colors (`#0070d2`, `#fafaf9`, `#c23934`, …) throughout, so the new Explain UI matches that existing convention for visual consistency. If/when a token system lands, this UI should be migrated alongside the rest of the feature.

### Gates (from `extension/`)
- `npx vitest run` → 816 passed (54 files); soql-runner 68 passed
- `npx tsc --noEmit` → exit 0
- `npx eslint .` → exit 0
- `npx wxt build` → built, manifest version **0.7.0** (matches `package.json`)

### Docs-site MDX (follow-up for phase-gate docs sweep)
Update the Chrome-extension SOQL Runner page in `sfdt-site/content/` (e.g. `content/extension/soql-runner.mdx` or equivalent): add an **"Explain / query plan"** subsection describing the 🔎 Explain button, that it works in REST and Tooling modes, the columns shown (leading operation, relative cost, cardinality, sobject cardinality, notes), how to read relative cost (lowest wins; >1.0 ≈ selective-index threshold), and that non-explainable queries (SOSL/GraphQL) report inline.

https://claude.ai/code/session_01AYp5KQjiDPHnZfGba2tCY8