### PR TITLE
fix(ci): run integration smoke nightly + on-demand, not per develop push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
     branches: [main, develop]
   schedule:
     - cron: '0 2 * * *'    # 2am UTC nightly
+  workflow_dispatch: {}    # manual on-demand integration smoke
 
 jobs:
   test:
@@ -63,11 +64,16 @@ jobs:
 
   # Gate: skip the live integration smoke gracefully when the DevHub auth
   # secret isn't configured, so the job is a no-op (not a failure) until a
-  # maintainer adds SFDX_AUTH_URL + SF_DEVHUB_USERNAME. Never runs on
-  # pull_request (secrets are not exposed to fork PRs and must not run there).
+  # maintainer adds SFDX_AUTH_URL + SF_DEVHUB_USERNAME.
+  #
+  # Runs on the nightly schedule and manual dispatch ONLY — never per push.
+  # Creating a scratch org on every develop push exhausts the Dev Hub's daily
+  # scratch-org allocation; a once-nightly smoke (plus on-demand) is enough.
+  # (schedule/workflow_dispatch never carry a pull_request context, so fork PRs
+  # still never see the secrets.)
   integration-gate:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/develop' && github.event_name != 'pull_request'
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     permissions:
       contents: read
     outputs:


### PR DESCRIPTION
## Problem

The `integration` job creates a fresh scratch org on **every push to `develop`**. High push volume exhausts the Dev Hub's daily scratch-org allocation, causing integration to fail once the limit is hit.

The nightly `schedule` cron was also effectively dead for this job: scheduled runs execute against the default branch (`main`), so the old `github.ref == 'refs/heads/develop'` gate could never be true on a scheduled run.

## Change

Gate the integration smoke on `schedule` + `workflow_dispatch` only — never per push:

- Add `workflow_dispatch` trigger for on-demand runs.
- `integration-gate` now runs on `github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'`.

Scratch-org creation drops from once-per-push to once-nightly (plus manual). Nothing downstream gates on this smoke (`publish-beta` needs only `[test, gui-build]`), and `test`/`gui-build` still run on every push.

## Notes

- Fork PRs still never see the secrets (schedule/workflow_dispatch carry no `pull_request` context).
- The nightly run only begins firing once this is on `main`, since scheduled runs use the default branch's workflow file.
- Selective cherry-pick to `main` ahead of the normal develop→main promotion; the same commit is already on `develop`.