### PR TITLE
fix(extension): smoke-test UX fixes — dark-mode buttons, side-panel scroll, demote API-version pill

### DIFF
--- a/extension/test/shadow-host.test.ts
+++ b/extension/test/shadow-host.test.ts
@@ -42,6 +42,16 @@ describe('ui/shadow-host', () => {
     expect(h.root.querySelectorAll('style')).toHaveLength(0);
   });
 
+  it('forces <button> to inherit the themed colour (no dark-on-dark buttons)', () => {
+    // A native <button> ignores the parent `color` (UA `buttontext`), so any
+    // button with a themed background but no explicit colour would be invisible
+    // in dark mode. The reset must make buttons inherit the wrapper colour.
+    const h = getShadowHost(document);
+    const sheet = h.root.adoptedStyleSheets[0]!;
+    const css = [...sheet.cssRules].map((r) => r.cssText).join('\n');
+    expect(css).toMatch(/\.sfdt-shadow-content button\s*\{[^}]*color:\s*inherit/);
+  });
+
   it('is idempotent — repeated calls return the same root+mount', () => {
     const a = getShadowHost(document);
     const b = getShadowHost(document);

--- a/extension/ui/shadow-host.ts
+++ b/extension/ui/shadow-host.ts
@@ -21,12 +21,22 @@ const CONTENT_CLASS = 'sfdt-shadow-content';
 // otherwise inherit inward) and re-establishes our own baseline. `all`
 // excludes custom properties by spec, so `var(--sfdt-*)` still inherits from the
 // host :root — dark mode keeps working. display is restored (initial => inline).
+// A native <button> does NOT inherit `color` — it uses the UA `buttontext`
+// system colour (dark) regardless of its parent, so any button that sets a
+// themed `background` (e.g. --sfdt-color-surface) but omits `color` renders
+// dark-on-dark in dark mode. Force buttons to inherit the wrapper's themed
+// colour; buttons that set their own inline `color` (primary/brand/error) still
+// win (inline style > adopted stylesheet). Scoped to <button> only — <select>/
+// <textarea> may rely on the UA field background, so leave them untouched.
 const BASE_CSS = `.${CONTENT_CLASS} {
   all: initial;
   display: block;
   color: var(--sfdt-color-text);
   font-family: system-ui, -apple-system, sans-serif;
   font-size: 13px;
+}
+.${CONTENT_CLASS} button {
+  color: inherit;
 }`;
 
 export interface ShadowHost {

--- a/extension/ui/workspace-host.ts
+++ b/extension/ui/workspace-host.ts
@@ -78,6 +78,8 @@ export function orgOriginFor(orgHost: string): string {
 export const HOST_STYLES = `
   *, *::before, *::after { box-sizing: border-box; }
   body { margin: 0; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif; color: var(--sfdt-color-text-strong); background: var(--sfdt-color-bg); }
+  /* A native <button> ignores inherited colour (UA buttontext), so tool buttons that set a themed background but no colour go dark-on-dark in dark mode. Make them inherit; more-specific rules (#sfdt-topbar button) and inline colours still win. */
+  button { color: inherit; }
   #sfdt-topbar { display: flex; align-items: center; gap: 12px; padding: 10px 16px; background: var(--sfdt-color-brand-deep); color: var(--sfdt-color-on-accent); }
   #sfdt-topbar .title { font-weight: 600; font-size: 15px; }
   #sfdt-topbar .org { margin-left: auto; font-size: 12px; opacity: 0.85; font-family: ui-monospace, monospace; }


### PR DESCRIPTION
Fixes found during Phase 2/3 smoke testing (4 commits).

## 1. Dark-on-dark buttons in dark mode
Native `<button>` ignores inherited `color` (UA `buttontext`), so neutral buttons that set a themed `background` but no `color` rendered invisible in dark mode. Base `button { color: inherit }` rule added to the **shadow host** (overlays) and **Workspace/side-panel host**; the **popup** secondary buttons (which used a dark *fill* token as text) switched to `--sfdt-color-brand-text` / `--sfdt-color-on-accent`. Colored buttons set their color inline so they're unaffected.

## 2. Side panel horizontal scroll
The topbar (long org URL + release badge + Switch org) forced the panel wider than ~360px, adding an h-scrollbar that clipped the tool list. Topbar now `flex-wrap`s with `min-width:0`, the org wraps, `body` guards `overflow-x`, and the sidebar shrinks under a narrow breakpoint.

## 3. Demote API-version audit to a menu
The always-on `API v67 · N behind` pill in the Setup tab strip was too prominent. Removed; the audit is now launched on demand from the ⚡ menu / command palette and opens as a Workspace tab or page modal (via `present-view`), like every other tool. Feature manifest (id/name/contexts) unchanged → catalogs unaffected.

## Gates
`tsc` ✅  `eslint` ✅  `wxt build` ✅  `vitest` ✅ (1191)  `check:catalogs` ✅  feature-manifests parity ✅

https://claude.ai/code/session_01QGMnA8uxYqC3LwCfE5uupV