### PR TITLE
feat(extension): default API-name pattern to camelCase

### DIFF
--- a/extension/features/api-name-generator.ts
+++ b/extension/features/api-name-generator.ts
@@ -12,7 +12,7 @@ import { presentView, type ViewHandle } from '../ui/present-view.js';
 import { z } from 'zod';
 
 const API_NAME_GENERATOR_SETTINGS_SCHEMA = z.object({
-  namingPattern: z.enum(['Snake_Case', 'PascalCase', 'camelCase']).default('Snake_Case'),
+  namingPattern: z.enum(['Snake_Case', 'PascalCase', 'camelCase']).default('camelCase'),
 });
 
 registerSettingsShape('api-name-generator', API_NAME_GENERATOR_SETTINGS_SCHEMA);

--- a/extension/lib/settings.ts
+++ b/extension/lib/settings.ts
@@ -34,7 +34,7 @@ export const SettingsSchema = z.object({
   // @deprecated — superseded by registerSettingsShape('api-name-generator', …).
   apiNameGenerator: z
     .object({
-      namingPattern: z.enum(['Snake_Case', 'PascalCase', 'camelCase']).default('Snake_Case'),
+      namingPattern: z.enum(['Snake_Case', 'PascalCase', 'camelCase']).default('camelCase'),
     })
     .default({}),
 

--- a/extension/test/feature-smoke.test.ts
+++ b/extension/test/feature-smoke.test.ts
@@ -230,6 +230,8 @@ describe('extension/features — smoke', () => {
 
     labelInput!.value = 'Active Accounts';
     typeSelect!.value = 'Get Records';
+    // Pin the pattern so this smoke check is independent of the default.
+    patternSelect!.value = 'Snake_Case';
     labelInput!.dispatchEvent(new Event('input', { bubbles: true }));
     expect(preview?.textContent).toBe('Get_Active_Accounts');
   });

--- a/extension/test/settings.test.ts
+++ b/extension/test/settings.test.ts
@@ -23,7 +23,7 @@ describe('extension/lib/settings', () => {
     expect(isFeatureEnabled(s, 'scheduled-flow-explorer')).toBe(true);
     expect(isFeatureEnabled(s, 'setup-tabs')).toBe(true);
     expect(s.canvasSearch.shortcut).toBe('Ctrl+Shift+F');
-    expect(s.apiNameGenerator.namingPattern).toBe('Snake_Case');
+    expect(s.apiNameGenerator.namingPattern).toBe('camelCase');
     expect(s.bridge.preferredTransport).toBe('auto');
     expect(s.bridge.localhostPort).toBe(7654);
   });


### PR DESCRIPTION
Per request: make **camelCase** the out-of-the-box default for the API-name generator (was `Snake_Case`). Users can still switch patterns in the generator; this only changes the unset default.

Changed the default in both places it's declared (kept in sync):
- `features/api-name-generator.ts` (feature settings shape)
- `lib/settings.ts` (legacy mirror)

Tests updated: `settings.test.ts` (default assertion) and `feature-smoke.test.ts` (now pins the pattern explicitly, so it no longer couples to the default).

## Gates
`tsc` ✅  `eslint` ✅  `vitest` ✅ (1191)  `wxt build` ✅

Note: Salesforce's own auto-generated API names are underscore-style, so camelCase is a deliberate house preference, not the platform convention.

https://claude.ai/code/session_01QGMnA8uxYqC3LwCfE5uupV