### PR TITLE
harness(H-014): version-locked mirror sync in release pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -387,7 +387,8 @@ jobs:
         # continue-on-error for the same reason as the tap: a downstream
         # distribution sync must never fail an already-published release.
         # The export only wipes skills/ in the target, so that repo's README and
-        # LICENSE (which are hand-written, not generated) survive each sync.
+        # LICENSE (hand-written, not generated) survive each sync — except the
+        # README's "Synced from" footer, which the export bumps from package.json.
         if: steps.version.outputs.changed == 'true'
         continue-on-error: true
         env:
@@ -402,7 +403,8 @@ jobs:
           git clone --depth 1 "https://x-access-token:${SKILLS_PACK_TOKEN}@github.com/scoobydrew83/sfdt-skills.git" skills-pack
           node bin/sfdt.js skills export --target pack --out skills-pack
           cd skills-pack
-          sed -i -E "s#(Synced from \`@sfdt/cli\` v)[0-9]+\.[0-9]+\.[0-9]+#\1${VERSION}#" README.md
+          # The export bumps the README "Synced from" footer from package.json —
+          # no out-of-band sed needed, so a manual sync stays in step too.
           # manifest.json carries a generatedAt timestamp that changes on every
           # export, so diff the real content instead — otherwise a self-healing
           # re-run of an already-published version pushes a timestamp-only commit.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -45,6 +45,7 @@ so a previously failed publish **self-heals** on the next push to `main`. The `p
 4. Creates the GitHub Release (`--generate-notes`).
 5. Bumps the Homebrew tap (`scoobydrew83/homebrew-sfdt`, `Formula/sfdt.rb` url + sha256). Needs the `HOMEBREW_TAP_TOKEN` fine-grained PAT and runs `continue-on-error` — a failure is a yellow step, not a red run. Check it; bump the tap manually if it skipped. The tap repo is the single source of truth for the formula.
 6. The downstream `docker` job calls the reusable `docker-publish.yml` via `workflow_call` in the **same run** (a `GITHUB_TOKEN`-created Release doesn't fire downstream workflows), pushing `ghcr.io/scoobydrew83/sfdt:X.Y.Z` + `:latest`. Re-publish a version on demand via `workflow_dispatch` with the version input.
+7. Syncs the standalone skills pack repo (`scoobydrew83/sfdt-skills`, backs `npx skills add`) by running `sfdt skills export --target pack`, which regenerates `skills/` + `manifest.json` **and bumps the README "Synced from `@sfdt/cli` vX.Y.Z" footer from `package.json`** so it can't drift (harness H-014). Needs the `SKILLS_PACK_TOKEN` fine-grained PAT and runs `continue-on-error` — a downstream distribution sync must never fail a published release. To sync by hand, run `sfdt skills export --target pack --out ../sfdt-skills` (the footer bump is in the command, not the CI job).
 
 A prerelease version (`X.Y.Z-*`) on `main` **fails the job** by design — prereleases publish from `develop`.
 

--- a/src/commands/skills.js
+++ b/src/commands/skills.js
@@ -106,12 +106,31 @@ async function exportPack(parsedSkills, outOption) {
   const manifestPath = path.join(outDir, 'manifest.json');
   await fs.writeJson(manifestPath, manifest, { spaces: 2 });
 
+  // The mirror repo (scoobydrew83/sfdt-skills) carries a hand-written README whose
+  // footer records which CLI version it was synced from. Own that one line here,
+  // derived from package.json, so *every* sync path — CI and the documented manual
+  // `sfdt skills export --target pack` command — bumps it in lockstep and it can
+  // never drift out of step with the shipped version (harness H-014).
+  const readmePath = path.join(outDir, 'README.md');
+  let readmeSynced = false;
+  if (await fs.pathExists(readmePath)) {
+    const { version } = await fs.readJson(path.resolve(SKILLS_DIR, '..', 'package.json'));
+    const readme = await fs.readFile(readmePath, 'utf-8');
+    const footerRe = /Synced from `@sfdt\/cli` v\d+\.\d+\.\d+\./;
+    const updated = readme.replace(footerRe, `Synced from \`@sfdt/cli\` v${version}.`);
+    if (updated !== readme) {
+      await fs.writeFile(readmePath, updated, 'utf-8');
+      readmeSynced = true;
+    }
+  }
+
   const cwd = process.cwd();
   return {
     skillsCount: manifestSkills.length,
     outDir: path.relative(cwd, outDir) || '.',
     manifest: path.relative(cwd, manifestPath),
     skills: manifestSkills.map((s) => s.name),
+    readmeSynced,
   };
 }
 

--- a/test/commands/skills.test.js
+++ b/test/commands/skills.test.js
@@ -258,6 +258,29 @@ describe('skills export --target pack', () => {
     expect(manifest.skills.map((s) => s.name)).toEqual(['sf-deploy', 'sfdt-cli']);
   });
 
+  it('bumps the mirror README "Synced from" footer from package.json', async () => {
+    // The pack repo's README footer must track the shipped CLI version — the
+    // export owns it so every sync (CI or manual) stays in step (harness H-014).
+    fs.readFile.mockImplementation(async (file) => {
+      if (String(file).endsWith('README.md')) {
+        return '# SFDT Agent Skills\n\nSynced from `@sfdt/cli` v0.0.0.\n';
+      }
+      return `---\nname: sf-deploy\ndescription: Deploy metadata\n---\nbody`;
+    });
+
+    await createProgram().parseAsync([
+      'node', 'sfdt', 'skills', 'export', '--target', 'pack', '--out', 'out-pack',
+    ]);
+
+    const readmeWrite = fs.writeFile.mock.calls.find(([f]) => String(f).endsWith('README.md'));
+    expect(readmeWrite, 'README.md should be rewritten').toBeTruthy();
+    const written = readmeWrite[1];
+    expect(written).not.toContain('v0.0.0.');
+    // Footer now carries the real package.json version — asserted structurally so
+    // the test doesn't need bumping on every release.
+    expect(written).toMatch(/Synced from `@sfdt\/cli` v\d+\.\d+\.\d+\./);
+  });
+
   it('emits pack results as JSON', async () => {
     const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
 


### PR DESCRIPTION
## What

The `sfdt-skills` mirror README footer (`Synced from \`@sfdt/cli\` vX.Y.Z`) could drift out of step with the shipped version. Root cause: the footer was patched by a `sed` living **only** in `ci.yml`, so the README's own documented manual sync (`sfdt skills export --target pack`) never updated it.

## Fix

- **`src/commands/skills.js`** — `exportPack` now bumps the README footer from `package.json` itself, so *every* sync path (CI **and** manual) stays version-locked.
- **`.github/workflows/ci.yml`** — dropped the now-redundant `sed`.
- **`RELEASING.md`** — documented the pack sync as publish-job step 7.
- **`test/commands/skills.test.js`** — added a footer-bump test (structural version match; no per-release maintenance).

## Verify

`node ../skills/check-harness.mjs --repos ..` → **H-014 PASS** (`mirror says v0.18.1 vs cli v0.18.1`).

The mirror update itself ships in the paired scoobydrew83/sfdt-skills PR.