### PR TITLE
ci(H-013): put harness-improver.yml on main so it is dispatchable

### DIFF
--- a/.github/workflows/harness-improver.yml
+++ b/.github/workflows/harness-improver.yml
@@ -1,0 +1,153 @@
+name: Harness Improver
+
+# Weekly meta-agent (Conductor Method phase: meta). Mines persisted verdict /
+# escalation / agent-fix telemetry for recurring failure categories and converts
+# each into exactly one encoded fix — a lint rule, a doc/skill edit, or a human
+# escalation. It opens PRs; it never merges. Self-improving is not self-approving.
+#
+# The agent definition is NOT vendored here — it lives in the skills repo
+# (harness-improver.md) so the three flywheel agents stay distributed from one
+# place. This workflow only supplies the schedule, the sandbox, and the
+# least-privilege allowlist.
+
+on:
+  schedule:
+    # Mondays 11:00 UTC. Deliberately clear of the other Monday jobs:
+    # codeql.yml (08:00) and scheduled-audit.yml (09:00).
+    - cron: '0 11 * * 1'
+  workflow_dispatch:
+
+# Only one improver at a time — two concurrent runs would mine the same rows
+# and open duplicate PRs against the same category.
+concurrency:
+  group: harness-improver
+  cancel-in-progress: false
+
+jobs:
+  improve:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # pushes harness/<category-slug> branches
+      pull-requests: write # opens the PRs (never merges — see allowlist below)
+      issues: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          # Full history: the improver clusters failures partly by git log /
+          # file area, and a depth-1 checkout would hide that signal.
+          fetch-depth: 0
+
+      - name: Checkout agent definitions
+        uses: actions/checkout@v7
+        with:
+          repository: scoobydrew83/skills
+          path: .harness-skills
+          fetch-depth: 1
+
+      - name: Verify the agent definition is present
+        run: |
+          DEF=.harness-skills/harness-improver.md
+          if [ ! -f "$DEF" ]; then
+            echo "::error::$DEF not found in scoobydrew83/skills."
+            echo "The harness-improver agent definition has not been published to the skills repo yet (H-011)."
+            echo "This job runs the definition rather than a vendored copy, so it cannot proceed without it."
+            exit 1
+          fi
+          echo "Using agent definition: $DEF"
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install and link the CLI
+        run: |
+          npm ci
+          npm link # puts `sfdt` on PATH so the agent runs the documented commands
+
+      # Telemetry: `sfdt history` reads logs/history.db, which is gitignored and
+      # written only on the machine that runs the conductor loop — it never
+      # reaches CI. tools/record-verdict.mjs therefore mirrors every row into the
+      # tracked .harness/telemetry.jsonl, which arrives with the checkout. That
+      # file is the improver's source here; `sfdt history` is the local one.
+      - name: Report telemetry depth
+        run: |
+          if [ -s .harness/telemetry.jsonl ]; then
+            echo "telemetry rows: $(wc -l < .harness/telemetry.jsonl)"
+          else
+            echo "::notice::.harness/telemetry.jsonl is empty or absent — the improver will report 'no signal'."
+          fi
+
+      - name: Write a minimal CLI config
+        run: |
+          # `sfdt history` / `sfdt notify` both require a .sfdt/ config dir. This
+          # repo has none (it's the CLI itself, not a Salesforce project), so
+          # write an ephemeral one — and exclude it locally so the improver's own
+          # `git add` can never sweep it into a PR.
+          #
+          # One generic webhook channel, no `events` filter, so every event the
+          # improver emits reaches it. n8n owns routing from there; it keys off
+          # the payload's `kind` field (e.g. `harness-escalation`). The secret is
+          # referenced by env-var NAME — sfdt never stores the URL in config.
+          mkdir -p .sfdt
+          cat > .sfdt/config.json <<'JSON'
+          {
+            "projectName": "sfdt harness",
+            "defaultOrg": "none",
+            "features": { "notifications": true },
+            "notifications": {
+              "enabled": true,
+              "channels": [
+                { "type": "webhook", "name": "n8n", "webhookUrlEnv": "HARNESS_WEBHOOK_URL", "severityThreshold": "warn" }
+              ]
+            }
+          }
+          JSON
+          echo '.sfdt/' >> .git/info/exclude
+          echo '.harness-skills/' >> .git/info/exclude
+
+      - name: Run harness-improver
+        uses: anthropics/claude-code-action@v1
+        env:
+          HARNESS_WEBHOOK_URL: ${{ secrets.HARNESS_WEBHOOK_URL }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # PRs opened with GITHUB_TOKEN do not trigger other workflows, so
+          # claude-code-review.yml would never grade the improver's own PRs —
+          # and self-improving is not self-approving. Set HARNESS_PR_TOKEN to a
+          # GitHub App installation token (or a PAT with repo scope) to close
+          # that loop; without it the fallback still works, the PRs just need
+          # review re-requested by hand.
+          github_token: ${{ secrets.HARNESS_PR_TOKEN || secrets.GITHUB_TOKEN }}
+          # Least-privilege, on the same pattern as claude-code-review.yml:
+          # enumerated subcommands, never `Bash(gh pr:*)` or `Bash(git:*)`.
+          # Deliberately absent, and deliberately NOT to be added:
+          #   gh pr merge / gh pr review  — the improver is a builder, never a
+          #                                 merger; gates and humans merge.
+          #   gh api                      — a write-capable escape hatch around
+          #                                 every restriction above it.
+          #   gh issue create             — findings ship as PRs, not issues.
+          # `git push` is unqualified because branch names are computed per
+          # finding; branch protection on the default branch is what stops a
+          # push there, not this list.
+          claude_args: >-
+            --allowedTools 'Read,Glob,Grep,Edit,Write,Bash(sfdt history:*),Bash(sfdt notify:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git branch:*),Bash(git switch:*),Bash(git checkout:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(gh pr create:*),Bash(gh pr list:*),Bash(gh pr view:*),Bash(npm run check:*),Bash(npm run generate:catalogs),Bash(npm test:*),Bash(node tools/:*)'
+          prompt: |
+            Read `.harness-skills/harness-improver.md` and follow its procedure exactly — it is your agent definition, including your hard bounds.
+
+            Repository: ${{ github.repository }} (default branch: ${{ github.event.repository.default_branch }}). You are running unattended on a schedule.
+
+            Binding constraints for this run:
+            - **Telemetry source.** `sfdt history` reads a machine-local db that does not exist on this runner, so mine `.harness/telemetry.jsonl` instead — one JSON row per line, same shape the db returns (`type`, `timestamp`, `status`, `summary`). Filter it to `type` of `verdict`, `escalation`, and `agent-fix`, then cluster by category (criterion text, file area, skill name, error signature).
+            - A category qualifies only at **>=3 occurrences**. Ignore singletons.
+            - Open **at most 3 PRs**, one per finding, branch `harness/<category-slug>`, smallest possible diff.
+            - Every PR body MUST cite the motivating rows — timestamp and phase for each — under a "Motivating history" heading. A PR that cannot cite >=3 rows must not be opened.
+            - Escalations go through `sfdt notify harness-escalation --message '<category>: <what needs a human decision>'`. That reaches the generic webhook channel as `kind: harness-escalation`; n8n owns routing from there.
+            - Never edit `generated/*` by hand — run `npm run generate:catalogs` if catalogs must change.
+            - Never touch FEATURES.json, `.harness/telemetry.jsonl`, or another agent's open branch. Telemetry is evidence — you read it, you never rewrite it.
+            - Do not merge, approve, or close anything.
+
+            If there are no qualifying categories (including an empty or absent telemetry file), stop and report a one-line "no signal" note. A quiet week is a PASS, not a failure to find work.


### PR DESCRIPTION
## Why

`workflow_dispatch` is only registered for workflows present on the **default branch**. `harness-improver.yml` currently exists only on `develop` (945dde1), so dispatching it fails:

```
$ gh workflow run harness-improver.yml --ref develop
HTTP 404: workflow harness-improver.yml not found on the default branch
```

This blocks H-013 — the drill that demonstrates one full self-improvement cycle end to end.

## What

Lands **only** `.github/workflows/harness-improver.yml` on `main`, byte-identical to the copy on `develop`. No other file from develop comes with it.

Once merged, `gh workflow run harness-improver.yml --ref develop` resolves and the run checks out `develop` — so it uses develop's workflow body and mines develop's `.harness/telemetry.jsonl`.

## Call out before merging

The `schedule:` trigger (Mondays 11:00 UTC) goes live with this merge. A scheduled run on `main` finds no `.harness/telemetry.jsonl` — that file lives on `develop` — and the workflow already handles that case: the "Report telemetry depth" step emits a notice and the improver reports "no signal" and exits. Harmless, but it is a real weekly job starting now.

Requires `CLAUDE_CODE_OAUTH_TOKEN` (present). `HARNESS_WEBHOOK_URL` is **not** set, so an ESCALATE finding's `sfdt notify` call would fail; `HARNESS_PR_TOKEN` is not set either, so the improver's PRs will not auto-trigger `claude-code-review.yml` and need review re-requested by hand.