### PR TITLE
fix(smart-deploy): drop regex `d` flag so CodeQL can parse the file

### DIFF
--- a/src/lib/smart-deploy.js
+++ b/src/lib/smart-deploy.js
@@ -106,8 +106,22 @@ function isTestClassName(name) {
 
 /** `@IsTest` outside comments/strings — always test against sanitized source. */
 const IS_TEST_RE = /@IsTest\b/i;
-/** `@IsTest(...)` with the `d` flag so arg offsets can be sliced from the original source. */
-const IS_TEST_ARGS_RE = /@IsTest\s*\(([^)]*)\)/dgi;
+/** `@IsTest(...)` — pair with `annotationArgs` to slice args from the original source. */
+const IS_TEST_ARGS_RE = /@IsTest\s*\(([^)]*)\)/gi;
+
+/**
+ * Slice an `IS_TEST_ARGS_RE` group-1 span out of the *original* source, given a
+ * match against the sanitized text (`sanitizeApexSource` preserves offsets).
+ *
+ * ponytail: offsets are computed by hand instead of via the regex `d` flag —
+ * CodeQL's JavaScript extractor cannot parse `d` and silently skips the entire
+ * file, costing this module its security scan. Switch back to
+ * `match.indices[1]` once the extractor understands `d`.
+ */
+function annotationArgs(match, source) {
+  const start = match.index + match[0].indexOf('(') + 1;
+  return source.slice(start, start + match[1].length);
+}
 
 /**
  * Select test classes from `@IsTest` annotation metadata (Spring '26):
@@ -144,7 +158,7 @@ export function selectAnnotatedTests(deltaComponents, testClassSources) {
     const sanitized = sanitizeApexSource(source);
     if (!IS_TEST_RE.test(sanitized)) continue;
     for (const annotation of sanitized.matchAll(IS_TEST_ARGS_RE)) {
-      const args = source.slice(...annotation.indices[1]);
+      const args = annotationArgs(annotation, source);
       if (/\bcritical\s*=\s*true\b/i.test(args)) selected.add(className);
       for (const tf of args.matchAll(/testFor\s*=\s*(?:'([^']*)'|"([^"]*)")/gi)) {
         const value = tf[1] ?? tf[2] ?? '';
@@ -223,7 +237,7 @@ export function checkTestForHints(testClassSources) {
     total += 1;
     let hinted = false;
     for (const annotation of sanitized.matchAll(IS_TEST_ARGS_RE)) {
-      const args = source.slice(...annotation.indices[1]);
+      const args = annotationArgs(annotation, source);
       if (/\btestFor\s*=/i.test(args) || /\bcritical\s*=\s*true\b/i.test(args)) {
         hinted = true;
         break;


### PR DESCRIPTION
## Problem

CodeQL flags `src/lib/smart-deploy.js:110`:

> A parse error occurred: Invalid regular expression flag. Check the syntax of the file.

The ES2022 `d` (`hasIndices`) flag on `IS_TEST_ARGS_RE` isn't understood by CodeQL's JavaScript extractor. It aborts on the file and **silently skips the whole module** — `smart-deploy.js` has been getting zero CodeQL coverage.

The code itself is valid; Node has supported `d` since 16.4. This is an extractor gap, not a runtime bug.

## Fix

Drop `d` and compute the group-1 span by hand in a small `annotationArgs` helper:

```js
function annotationArgs(match, source) {
  const start = match.index + match[0].indexOf('(') + 1;
  return source.slice(start, start + match[1].length);
}
```

Behaviour is identical. Annotation *positions* still come from the sanitized text (`sanitizeApexSource` preserves offsets) and argument text is still sliced from the **original** source, so `testFor='...'` string literals survive sanitization.

A `ponytail:` comment on the helper records why the flag is gone and points back to `match.indices[1]` for whenever the extractor catches up.

## Testing

- `npm test` — 274 files, 4193 tests, all passing
- `npm run lint` — clean

No new tests: the existing suite already pins the offset arithmetic. Every `testFor` case depends on it, because the string literal is blanked in the sanitized copy — an off-by-one would fail to parse the target and drop the selection. `handles method-level annotations` covers non-zero, multi-line offsets.

## Note

Targeting `main` directly as requested. `develop` carries the same line and will need this too — cherry-pick or back-merge after this lands, otherwise the next promotion re-introduces the `d` flag.