### PR TITLE
docs: design and roadmap for visual manifest builder + sf-pi review

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -33,6 +33,7 @@ Sequenced from the [sf-pi integration review](docs/reviews/sf-pi-integration-rev
 - **`sfdt soql` command family** — schema search/describe, relationship discovery, query validation, query plans, bounded SOQL/SOSL execution with exports. Thin command + `soql-runner.js`, auto-surfaced to MCP/GUI/VS Code. Inspired by sf-pi's SF SOQL extension — **Planned**
 - **Apex observability** — trace flags, debug log retrieve/watch, Anonymous Apex execution; complements `sfdt test`. Inspired by sf-pi's SF Apex extension — **Planned**
 - **ApexGuru check in `sfdt quality`** — additive org-side analysis alongside Code Analyzer v5; license/edition-gated, so it degrades to `warn`/`skipped`, never `error`. Inspired by sf-pi's SF Code Analyzer extension — **Planned**
+- **Visual manifest builder (GUI · VS Code · Chrome)** — changeset-style checkbox builder: browse org inventory or local source by type, tick components, live package.xml / destructiveChanges.xml preview, save/deploy. One engine (`renderPackageXml` + `org-inventory.js`), GUI page inherited by VS Code via the dashboard iframe, Chrome via new read-only bridge kinds. Absorbs extension-plan items P5-4/P5-5 (pulled forward 2026-07-29). Mini-plan: [docs/design/visual-manifest-builder.md](docs/design/visual-manifest-builder.md) — **Planned**
 
 ## Research
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,6 +28,12 @@ Items this revision reclassified from "planned" to shipped (they were stale here
 
 ## Planned
 
+Sequenced from the [sf-pi integration review](docs/reviews/sf-pi-integration-review.md) (2026-07-29). All three re-implement capabilities natively — no dependency on sf-pi, which is pi-runtime-coupled. FEATURES.json entries are seeded when a phase for them opens; the active phase remains 1.0 stabilization (F-001 first).
+
+- **`sfdt soql` command family** — schema search/describe, relationship discovery, query validation, query plans, bounded SOQL/SOSL execution with exports. Thin command + `soql-runner.js`, auto-surfaced to MCP/GUI/VS Code. Inspired by sf-pi's SF SOQL extension — **Planned**
+- **Apex observability** — trace flags, debug log retrieve/watch, Anonymous Apex execution; complements `sfdt test`. Inspired by sf-pi's SF Apex extension — **Planned**
+- **ApexGuru check in `sfdt quality`** — additive org-side analysis alongside Code Analyzer v5; license/edition-gated, so it degrades to `warn`/`skipped`, never `error`. Inspired by sf-pi's SF Code Analyzer extension — **Planned**
+
 ## Research
 
 ## Blocked

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,6 +28,8 @@ Items this revision reclassified from "planned" to shipped (they were stale here
 
 ## Planned
 
+Cross-workstream dispatch and status (including Chrome-extension items tracked outside this repo) lives on the internal Notion board "SFDT Master Backlog — Agent Dispatch Board"; this file remains the source of truth for the CLI items below.
+
 Sequenced from the [sf-pi integration review](docs/reviews/sf-pi-integration-review.md) (2026-07-29). All three re-implement capabilities natively — no dependency on sf-pi, which is pi-runtime-coupled. FEATURES.json entries are seeded when a phase for them opens; the active phase remains 1.0 stabilization (F-001 first).
 
 - **`sfdt soql` command family** — schema search/describe, relationship discovery, query validation, query plans, bounded SOQL/SOSL execution with exports. Thin command + `soql-runner.js`, auto-surfaced to MCP/GUI/VS Code. Inspired by sf-pi's SF SOQL extension — **Planned**

--- a/docs/design/visual-manifest-builder.md
+++ b/docs/design/visual-manifest-builder.md
@@ -1,0 +1,139 @@
+# Mini-plan: Visual Manifest Builder (GUI · VS Code · Chrome)
+
+**Date:** 2026-07-29 · **Status:** Approved design, implementation not started
+**Satisfies:** Chrome Extension Execution Plan items P5-4 (package.xml builder) and P5-5
+(destructiveChanges.xml builder), pulled forward ahead of Phase 4 by decision 2026-07-29,
+with scope broadened to the GUI and VS Code. P5-4 is an "L — mini-plan first" item; this
+is that mini-plan.
+
+## Problem
+
+sfdt can build manifests from git diffs (`sfdt manifest`), from org-compare selections
+(GUI CompareTable), and by editing an existing file (GUI add/remove component) — but it has
+no changeset-style builder: browse metadata by type, tick checkboxes, watch a live
+package.xml preview, save/deploy. The Chrome extension's `metadata-retrieve.ts` proves the
+UX but is a 946-line island with its own XML writer, disconnected from the CLI engine.
+
+## Decisions (2026-07-29, recorded verbatim)
+
+1. **Sequencing:** all three surfaces now — P5-4/P5-5 pulled ahead of Chrome Phase 4.
+2. **Sources:** org inventory **and** local source tree. No git-delta pre-seed (that
+   remains `sfdt manifest` / smart-deploy's job).
+3. **VS Code:** inherits the GUI page through the existing dashboard iframe
+   (`DashboardController`). No native webview.
+4. **Modes:** additive (package.xml) and destructive (destructiveChanges.xml + empty
+   package.xml pair) ship together, one builder with a mode toggle.
+
+## Architecture: one engine, one UI, three transports
+
+```
+                    ┌───────────────────────────────┐
+                    │  Engine (existing, CLI-side)  │
+                    │  org-inventory.js  listMetadata│
+                    │  metadata-mapper.js renderPackageXml
+                    └──────┬──────────────┬─────────┘
+                           │              │
+              gui-server routes      bridge kinds (flow-core contract)
+                           │              │
+        ┌─────────────┐    │         ┌────┴─────────┐
+        │ GUI page    │◄───┘         │ Chrome ext.  │
+        │ (React)     │              │ metadata-    │
+        └─────┬───────┘              │ retrieve.ts  │
+              │ iframe                └──────────────┘
+        ┌─────┴───────┐               (offline fallback:
+        │ VS Code     │                SOAP listMetadata,
+        │ Dashboard   │                as today)
+        └─────────────┘
+```
+
+**Single-writer rule:** every surface renders XML through
+`renderPackageXml(metadata, apiVersion)` (`src/lib/metadata-mapper.js`). The Chrome
+extension's private `generatePackageXml()` is retired when the bridge is connected and
+kept only as the offline fallback (or replaced by a vendored pure function from
+flow-core — decided in PR-3).
+
+## Work plan (one PR per item, per repo convention)
+
+### PR-1 — Server engine + GUI builder page
+
+New/changed routes in `src/lib/gui-server/index.js`:
+
+| Route | Purpose |
+|---|---|
+| `GET /api/manifest/discover-org?org=&type=` | Org members for one type via `org-inventory.js#listMetadataMembers`; `GET …&types=1` variant lists types via `listMetadataTypes`. Serve from `logs/scan-latest.json` when fresh; `?refresh=1` re-fetches. |
+| `GET /api/manifest/discover` | Exists (local glob). Fix: `gui/src/api.js#discoverComponents` never passes the supported `package` param. |
+| `POST /api/manifest/render` | `{items:[{type,member}], mode:'additive'|'destructive', apiVersion}` → XML via `renderPackageXml`. Destructive returns the pair `{destructiveChangesXml, emptyPackageXml}`. (Generalises the existing `POST /api/compare/manifest`.) |
+| `POST /api/manifest/save` | Batch save (replaces the per-component round-trip loop in `Manifests.jsx:80`); writes to `config.manifestDir` with the `rl-…-package.xml` / `-destructiveChanges.xml` naming; refuses `deployed/`. |
+
+New GUI page `gui/src/pages/ManifestBuilder.jsx` (Release group in `gui/src/routes.js`):
+
+- Two-panel browser modeled on `Scan.jsx:161` (type list ↔ member grid) with the selection
+  model from `CompareTable.jsx` (per-row + per-type-header checkboxes, filters,
+  "N selected" bulk bar, select-all).
+- Source toggle **Org | Local** (org uses discover-org; local uses discover).
+- Mode toggle **Additive | Destructive** — destructive gets prominent warning styling and
+  the paired-file explanation (link to `SFDT_DESTRUCTIVE_TIMING` docs).
+- Live XML preview pane (pattern: `ManifestViewer` in `Manifests.jsx:159`) updating on
+  every tick; wildcard (`*`) when a whole type is ticked; copy/download/save.
+- Selections persist per org (localStorage keyed by org alias), clear-all.
+- Registration checklist: `GUI_ROUTES` entry + `ICONS`/`PAGES` in `gui/src/App.jsx`
+  (boot-time throw if missing) + `npm run generate:catalogs` + `npm run build:gui`.
+
+### PR-2 — VS Code inheritance
+
+- Fix the deep-link gap: `gui/src/App.jsx:117` initializes `useState('dashboard')` and
+  ignores `window.location.pathname`; read the path on boot so
+  `dashboardPageUrl(port, 'manifest-builder', …)` actually lands on the builder.
+- Add command `sfdt.manifestBuilder` opening `DashboardController` at the builder page;
+  contribute it next to the existing `sfdt.manifest` terminal command.
+- No new webview infra, honoring the "CLI-backed, no reimplemented logic" rule
+  (`docs/PATTERNS.md:20`).
+
+### PR-3 — Bridge kinds (flow-core contract + host mirror)
+
+- `packages/flow-core/src/bridge-contract.ts`: add read-only kinds
+  `manifest.discover` (type list / members for a type, backed by `org-inventory.js`) and
+  `manifest.render` (items+mode → XML via `renderPackageXml`). Minor protocol bump
+  1.2 → 1.3 (`negotiateProtocolVersion` warns, doesn't refuse).
+- Mount in `src/lib/bridge/routes.js` (HTTP) **and** mirror in `host/src/index.js` —
+  both kinds are read-only/pure, so they are native-host-eligible (the host's
+  "read-only fallback" policy holds; no write kind added).
+- Lockstep: flow-core version bump, contract types imported by extension + routes + host.
+
+### PR-4 — Chrome extension refactor (delivers P5-4 + P5-5 AC)
+
+- `extension/features/metadata-retrieve.ts`: when the bridge is connected, source the
+  type/member tree from `manifest.discover` and XML from `manifest.render`; offline
+  keeps today's worker-proxied SOAP `describeMetadata`/`listMetadata` path (P5-4's spec
+  already requires the offline mode).
+- Add the destructive mode toggle (P5-5) with warning styling and paired-file output.
+- Selections persist per org (`chrome.storage.local`), clear-all.
+- All Notion Global DoD items apply: feature-registry manifest, kill switch, no
+  `innerHTML`, tokens, Vitest, a11y checklist, CHANGELOG, docs-site MDX, no new
+  permissions (none needed — ledger untouched).
+- P5-6 (browsable picker in metadata-retrieve) becomes trivial afterward: the tree is
+  already this feature's UI.
+
+## Invariants this touches (from golden-principles/MEMORY_BANK)
+
+- JSON envelope stays stdout-only; the new routes/kinds return raw JSON like their peers.
+- `src/lib/command-policy.js:181` marks `manifest` as `supportsJson:false`, `surfaces.gui:false`
+  — revisit in PR-1 if the builder is surfaced through command policy at all (routes may
+  make this moot; do not flip casually).
+- `generated/*` catalogs regenerate after the GUI route addition; CI fails on drift.
+- No new config keys expected; if one appears, template + schema + consumer move together.
+- Beta/license-gated org behavior: `listMetadata` failures degrade to a visible error
+  state, never a fabricated empty tree.
+- One feature per session: PR-1 through PR-4 are separate sessions/PRs against `develop`.
+
+## Verification (end-to-end)
+
+1. PR-1: build a manifest from org + local sources in the GUI; `sf project deploy validate`
+   accepts the generated package.xml against a real org (manual, documented in PR).
+   Destructive pair validates with the documented pre/post timing flow.
+2. PR-2: `sfdt.manifestBuilder` in VS Code opens the panel directly on the builder page.
+3. PR-3: `npx vitest run` in flow-core + host contract tests; version negotiation
+   warns (not refuses) against a 1.2 client.
+4. PR-4: extension verification gates (`npx vitest run`, `tsc --noEmit`, `eslint`,
+   `wxt build`) + manual smoke with `sfdt ui` running; bridge-connected XML is
+   byte-identical to `renderPackageXml` output for the same selection.

--- a/docs/reviews/sf-pi-integration-review.md
+++ b/docs/reviews/sf-pi-integration-review.md
@@ -1,0 +1,68 @@
+# Review: `salesforce/sf-pi` — what (if anything) belongs in the sfdt CLI
+
+**Date:** 2026-07-29
+**Scope:** Evaluate https://github.com/salesforce/sf-pi for capabilities worth incorporating into `@sfdt/cli`, and record the "next phase" answer from the internal docs hub.
+
+## What sf-pi actually is
+
+`salesforce/sf-pi` is **not** a Salesforce CLI (`sf`) plugin and not a deployment tool. It is an
+Apache-2.0-licensed bundle of ~24 TypeScript extensions for the **pi coding agent** (pi.dev),
+requiring Node ≥ 22.19 and the pi runtime (≥ 0.82.0), maintained by a Salesforce Forward
+Deployed Engineer. Every extension is coupled to pi's extension API (slash commands, status
+bar, hooks, TUI), so **nothing can be vendored or depended on directly**.
+
+"Incorporation" therefore means **re-implementing selected capabilities natively** in sfdt's
+own architecture (thin command + runner, MCP auto-surfacing, JSON envelope). The Apache-2.0
+license permits studying and porting the approach with attribution; no code is copied.
+
+## Per-extension verdicts
+
+| sf-pi extension | Capability | Verdict for sfdt |
+|---|---|---|
+| **SF SOQL** | Schema search/describe, relationship discovery, query drafting/validation, query plans, bounded SOQL/SOSL execution, exports | **Incorporate — top pick.** Biggest genuine gap: sfdt has `scan`, `dependencies`, and `data` but no query/schema lifecycle at all. |
+| **SF Apex** | Trace flags, debug log retrieve/watch, Anonymous Apex, targeted tests | **Incorporate.** Complements the existing `test` runner; sfdt has no log/trace/anonymous-Apex surface. |
+| **SF Code Analyzer** (ApexGuru pass) | ApexGuru org-side analysis on top of Code Analyzer | **Incorporate (small).** Additive check inside `sfdt quality`; ApexGuru is license/edition-gated so it must degrade to `warn`/`skipped`, never `error` (existing policy for gated org checks). |
+| SF LWC | Project scan, component inspection, targeted Jest tests | Partial, later. Overlaps `versions`/`quality`/`test --lwc`; incremental value is low. |
+| SF Docs | Cited Salesforce documentation lookup | Skip for now. AI-adjacent nicety; could become a prompt-catalog helper later. |
+| SF Data Explorer | Interactive query TUI | Skip. The bounded-execution piece lands inside the SOQL toolkit instead; sfdt is non-interactive-first (CI). |
+| SF LSP, DevBar, Splash, tldraw, Herdr, Brain | Agent-runtime UX (status bar, splash, diagramming, workspace lanes, session kernel) | Skip. Pi-runtime concerns with no CLI analogue. |
+| SF Guardrail | File protection, dangerous-command gating | Skip. sfdt's equivalent already exists: MCP `confirmExecution` on mutating tools, read-only verifier, no-write agent-loop default. |
+| SF Skills | Skill-source management across Claude Code/Codex/Cursor | Skip. `sfdt skills` already covers export/install/audit. |
+| SF Slack, SF Browser, SF Data 360, SF Agent Script | Slack search, browser automation, Data Cloud tooling, `.agent` authoring | Skip. Out of scope for a generic SFDX deploy/quality CLI. Data 360 or Agent Script support would suit an out-of-tree `sfdt-plugin-*` package if ever needed. |
+
+## How the "incorporate" items would land
+
+All three follow seams the codebase already has:
+
+1. **Thin command + runner** — e.g. `src/commands/soql.js` delegating to `src/lib/soql-runner.js`
+   (golden principle #1), same for Apex observability.
+2. **Check-registry propagation** — an ApexGuru check added alongside Code Analyzer v5 in the
+   quality path surfaces automatically to CLI, MCP, GUI, and VS Code, the same way
+   `monitor-runner.js`'s `CHECKS` map works.
+3. **Graceful degradation** — the established "shell out to `sf` / org API, emit
+   `skipped`/`warn` when the plugin or license is absent, never fabricate a pass" pattern
+   (as with Code Analyzer v5 JIT install).
+
+Constraints to respect when these are built: config keys move template + schema + consumer in
+lockstep; JSON envelope on stdout only; no hand-edits to `generated/*`; one feature per session.
+
+These three items are now recorded in [ROADMAP.md](../../ROADMAP.md) under **Planned**.
+Per the FEATURES.json contract, FEATURES entries are seeded only when a phase for them opens —
+the active phase is still **1.0 stabilization**, whose single open item is **F-001** (remove
+legacy Code Analyzer v4 support). That lands first.
+
+## Next phase (from the internal docs hub)
+
+- **Repo level (`@sfdt/cli`):** finish **1.0 stabilization** — F-001, removing `sf scanner run`
+  v4 fallback and the `--allow-legacy-analyzer` opt-in. The forward queue in ROADMAP.md was
+  empty before this review seeded the Planned section.
+- **Product level:** **Studio by SFDT Phase 0 (validation) is complete** — 8/9 board items
+  Done, decision memo: *"GO for constrained MVP; include BYOM model option and
+  open-source/self-hosted sandbox runner."* The next phase to build is **Phase 1 — internal
+  alpha** (project model, structured spec, generation pipeline, 10–15 base components, Apex
+  mock registry, basic LDS adapters, scenario switcher, code editor, diagnostics, ZIP export,
+  internal telemetry). Studio Phase 1 is a separate application, not CLI work; CLI involvement
+  begins around Phase 2 (SFDT bridge prototype) and Phase 4 (CLI commands).
+- **Flag:** the Phase 0 board still shows the **competitive audit as Blocked** even though the
+  decision memo is Done/GO. Worth resolving on the board so the GO decision's evidence trail
+  is consistent.


### PR DESCRIPTION
## Summary

This PR adds two design documents and updates the roadmap to record decisions and planned work from 2026-07-29:

1. **Visual Manifest Builder mini-plan** — a changeset-style checkbox builder for package.xml / destructiveChanges.xml, spanning GUI, VS Code, and Chrome extension. Absorbs Chrome extension plan items P5-4 and P5-5, pulled forward ahead of Phase 4.
2. **sf-pi integration review** — evaluates the Salesforce pi-agent extension bundle for capabilities worth re-implementing natively in sfdt. Identifies three items for the planned roadmap: SOQL command family, Apex observability, and ApexGuru checks.
3. **ROADMAP.md update** — seeds the Planned section with the three sf-pi-inspired items and the visual manifest builder, with links to design docs and mini-plans.

## Key changes

- **`docs/design/visual-manifest-builder.md`** (new, 139 lines)
  - Problem statement: sfdt lacks a browsable, checkbox-driven manifest builder (org inventory + local source tree).
  - Architecture: one engine (`renderPackageXml` + `org-inventory.js`), one React GUI page, three transports (GUI routes, VS Code dashboard iframe, Chrome bridge kinds).
  - Work plan: four PRs (server engine + GUI, VS Code inheritance, bridge kinds, Chrome extension refactor), with invariants and end-to-end verification steps.
  - Decisions recorded verbatim: sequencing (all three surfaces now), sources (org + local, no git-delta pre-seed), VS Code (iframe inheritance, no native webview), modes (additive + destructive together).

- **`docs/reviews/sf-pi-integration-review.md`** (new, 68 lines)
  - Clarifies that sf-pi is a pi-runtime-coupled agent extension bundle, not a Salesforce CLI plugin — so "incorporation" means re-implementing capabilities natively, not vendoring.
  - Per-extension verdicts: **Incorporate** (SOQL, Apex observability, ApexGuru check); **Skip** (LWC, Docs, Data Explorer, LSP/DevBar/etc., Guardrail, Skills, Slack/Browser/Data 360/Agent Script).
  - Implementation approach: thin command + runner, check-registry propagation, graceful degradation (existing patterns).
  - Next phase from internal docs hub: finish 1.0 stabilization (F-001), then Studio Phase 1 (separate application).

- **`ROADMAP.md`** (modified)
  - Adds note that cross-workstream dispatch lives on internal Notion board; this file is CLI source of truth.
  - Seeds Planned section with four items:
    - `sfdt soql` command family (schema, relationships, validation, plans, bounded execution)
    - Apex observability (trace flags, debug logs, Anonymous Apex)
    - ApexGuru check in `sfdt quality` (license-gated, degrades to warn/skipped)
    - Visual manifest builder (with link to mini-plan)
  - All three sf-pi items note they are inspired by but not dependent on sf-pi.

## Notable implementation details

- The visual manifest builder design respects golden principle #1 (thin command + runner), #3 (config keys in lockstep), and #6 (JSON envelope on stdout only).
- The sf-pi review explicitly avoids any code copying (Apache-2.0 permits study + re-implementation with attribution) and confirms no new dependencies.
- Both documents are design/planning artifacts (no code changes); they record decisions and unblock implementation PRs that will follow.
- FEATURES.json entries are deferred until a phase for them opens; the active phase remains 1.0 stabilization (F-001 first).

https://claude.ai/code/session_01K5M1EzgoFw3N5qGPraYabZ