### PR TITLE
feat(quality): remove legacy Code Analyzer v4 (A-1 / F-001)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+- **Legacy Code Analyzer v4 (`sf scanner run`) support** — Salesforce Code Analyzer v5 is now the only supported engine (F-001). The `quality --allow-legacy-analyzer` opt-in flag, the `quality.analyzer.allowLegacyV4` config key, the `SFDT_ANALYZER_ALLOW_LEGACY` env var, and the v4 fallback in `scripts/quality/code-analyzer.sh` are gone. On a machine without v5, the static scan is reported as `skipped` (never a fabricated clean result) with install guidance (`sf plugins install code-analyzer`); a lingering `quality` key in an existing `.sfdt/config.json` is ignored, not an error.
+
 ## [0.20.0] - 2026-07-28
 
 ### Security

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -20,7 +20,7 @@ Full detail in [CHANGELOG.md](CHANGELOG.md). Highlights only:
 - **v0.17.0** — `sfdt doctor`, `test --lwc`, `quality --output-file` (SARIF), Claude Code skill installs, skills audit + drift guard — **Shipped (stable)**
 - **v0.16.x** — dependency graph seed+expand, `dependencies --gaps`, run history (`sfdt history`), MCP mutating/test tools, native-host read-only kinds, skills pack export, Apache-2.0 relicense — **Shipped (stable)**
 - **`RunRelevantTests` smart-deploy opt-in** (`deployment.smart.useRelevantTests`) — depends on the Salesforce Spring '26 beta API — **Shipped (beta)**
-- **`quality --allow-legacy-analyzer`** — Code Analyzer v4 is opt-in legacy, non-authoritative; removed at 1.0 — **In develop** (see below)
+- **Legacy Code Analyzer v4 removed (F-001)** — v5 is the only supported engine; the `quality --allow-legacy-analyzer` opt-in and the v4 (`sf scanner run`) fallback are gone — **In develop (removal landed)**
 
 Items this revision reclassified from "planned" to shipped (they were stale here): unified logic tests (`sfdt test --logic`), Agentforce support (`sfdt agent-test` + GenAi metadata in smart-deploy deltas), Code Analyzer v5 in `sfdt quality`, the agent-skills pack (`skills export --target pack`), MCP mutating-tool expansion, the Chrome Web Store publish job, the org release badge, the Flow Scanner surface, and native-host read-only kinds. See the changelog for each.
 

--- a/docs/ENV-VARS.md
+++ b/docs/ENV-VARS.md
@@ -34,8 +34,7 @@
 | `SFDT_DEFAULT_BRANCH` | `config.defaultBranch` (default: `"main"`); a user-exported env value wins. Used by `deployment-assistant.sh` for PR base branch |
 | `SFDT_SMOKE_TESTS` | Per-invocation: comma-joined `config.smokeTests.testClasses`, set by `smoke.js` (a user-exported env value wins) |
 | `SFDT_ANALYZER_INCLUDE_FIXES` | Per-invocation: `"true"` from `quality --include-fixes`; `scripts/quality/code-analyzer.sh` adds `--include-fixes --include-suggestions` to the Code Analyzer v5 run |
-| `SFDT_ANALYZER_OUTPUT_FILE` | Per-invocation: from `quality --output-file <path>`; `scripts/quality/code-analyzer.sh` adds a second `--output-file` to the Code Analyzer v5 run (format inferred from the extension, e.g. `.sarif`); v4 logs a warning and skips |
-| `SFDT_ANALYZER_ALLOW_LEGACY` | Per-invocation: `"true"` from `quality --allow-legacy-analyzer` or config `quality.analyzer.allowLegacyV4`; permits the legacy Code Analyzer v4 (`sf scanner run`) when v5 is unavailable. Without it, a v4-only environment emits the `skipped` marker (v5 required — J-1 policy; skip is never rendered as a pass). v4 support is removed at 1.0 |
+| `SFDT_ANALYZER_OUTPUT_FILE` | Per-invocation: from `quality --output-file <path>`; `scripts/quality/code-analyzer.sh` adds a second `--output-file` to the Code Analyzer v5 run (format inferred from the extension, e.g. `.sarif`) |
 | `SFDT_TAG_RELEASE` / `SFDT_CREATE_PR` / `SFDT_NOTIFY_SLACK` | Per-invocation: `"true"` from `deploy --tag/--create-pr/--notify` (or the GUI Release Hub toggles); drive post-deploy tagging, PR creation, and notifications in `deployment-assistant.sh` |
 | `SFDT_PACKAGE_DIRS` | JSON array of all package paths from `config.packageDirectories`, e.g. `["force-app/main/default","force-app/feature-a"]` |
 | `SFDT_MANIFEST_LAYOUT` | `config.manifestLayout` (`"flat"` or `"subpath"`); default `"flat"` |

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -399,11 +399,11 @@ sfdt quality --generate-stubs --dry-run  # preview stubs without writing files
 | `--all` | Run both `quality/code-analyzer.sh` and `quality/test-analyzer.sh` |
 | `--fix-plan` | After analysis, send the output to AI for a prioritized, file-specific fix plan |
 | `--include-fixes` | Ask **Code Analyzer v5** for actionable fixes/suggestions in the scan output (`--include-fixes --include-suggestions`); the richer output feeds `--fix-plan` |
-| `--output-file <path>` | Also write the Code Analyzer v5 results to a file; the format follows the extension (e.g. `.sarif` for GitHub code-scanning upload). Requires v5 — v4 logs a warning and skips |
+| `--output-file <path>` | Also write the Code Analyzer v5 results to a file; the format follows the extension (e.g. `.sarif` for GitHub code-scanning upload) |
 | `--generate-stubs` | Generate `@IsTest` stub classes for Apex classes that have no test class |
 | `--dry-run` | Preview `--generate-stubs` output without writing any files |
 
-**Code Analyzer engine:** `sfdt quality` runs **Salesforce Code Analyzer v5** (`sf code-analyzer run`, a just-in-time plugin that auto-installs on a modern `sf` CLI). It falls back to the retired v4 (`sf scanner run`) if only that is present, and otherwise reports the scan as **SKIPPED** (never a fabricated clean result). Install manually with `sf plugins install code-analyzer` if needed.
+**Code Analyzer engine:** `sfdt quality` runs **Salesforce Code Analyzer v5** (`sf code-analyzer run`, a just-in-time plugin that auto-installs on a modern `sf` CLI) — the only supported engine. If v5 is unavailable the scan is reported as **SKIPPED** (never a fabricated clean result). Install manually with `sf plugins install code-analyzer` if needed. Legacy Code Analyzer v4 support (and its `--allow-legacy-analyzer` opt-in) was removed at 1.0.
 
 **AI fix plan:** The fix plan groups issues by severity (critical, high, medium, low) and provides file locations, descriptions, and concrete code suggestions. It focuses on Salesforce-specific concerns: governor limits, CRUD/FLS enforcement, bulk-safe patterns, and test coverage gaps.
 

--- a/generated/commands.json
+++ b/generated/commands.json
@@ -538,13 +538,6 @@
           "description": "Also write the Code Analyzer v5 results to a file; the format follows the extension (e.g. .sarif for code-scanning upload)"
         },
         {
-          "flags": "--allow-legacy-analyzer",
-          "name": "allowLegacyAnalyzer",
-          "required": false,
-          "default": null,
-          "description": "Permit the legacy Code Analyzer v4 (sf scanner run) when v5 is unavailable — results are non-authoritative (also: config quality.analyzer.allowLegacyV4)"
-        },
-        {
           "flags": "--dry-run",
           "name": "dryRun",
           "required": false,

--- a/scripts/quality/code-analyzer.sh
+++ b/scripts/quality/code-analyzer.sh
@@ -145,17 +145,15 @@ else
 fi
 
 # Emit structured JSON to stdout for GUI result parsing.
-# Try sf scanner (Salesforce Code Analyzer) if installed. When it is NOT
-# installed (or the run fails), never fabricate a clean scan result — emit an
-# unmistakably labelled skipped marker (status "skipped" + reason) so that no
-# downstream consumer can mistake the absence of a scan for a passing one.
-# "result": [] plus "_sfdt_unavailable" are kept for existing consumers
-# (gui-server parseQualityLines); "status"/"reason" are additive.
-# Prefer Salesforce Code Analyzer v5 (`sf code-analyzer run`, a just-in-time
-# plugin on a modern sf CLI). Fall back to the retired v4 (`sf scanner run`)
-# when only that is present, and otherwise emit the skipped marker — never
-# fabricate a clean scan. Set SFDT_ANALYZER_INCLUDE_FIXES=true to request
-# actionable fixes/suggestions in the output (v5 only).
+# Salesforce Code Analyzer v5 (`sf code-analyzer run`, a just-in-time plugin on
+# a modern sf CLI) is the ONLY supported engine — legacy v4 support was removed
+# at 1.0. When v5 is NOT available (or the run fails), never fabricate a clean
+# scan result — emit an unmistakably labelled skipped marker (status "skipped"
+# + reason) so that no downstream consumer can mistake the absence of a scan
+# for a passing one. "result": [] plus "_sfdt_unavailable" are kept for
+# existing consumers (gui-server parseQualityLines); "status"/"reason" are
+# additive. Set SFDT_ANALYZER_INCLUDE_FIXES=true to request actionable
+# fixes/suggestions in the output.
 _INCLUDE_FIXES=()
 if [[ "${SFDT_ANALYZER_INCLUDE_FIXES:-}" == "true" ]]; then
     _INCLUDE_FIXES=(--include-fixes --include-suggestions)
@@ -163,17 +161,10 @@ fi
 
 # SFDT_ANALYZER_OUTPUT_FILE: also write the results to this file; v5 infers the
 # format from the extension (e.g. .sarif) and --output-file is repeatable, so
-# the stdout-JSON contract below is unaffected. v5 only — v4 emits one format
-# per run and is not worth a second scan.
+# the stdout-JSON contract below is unaffected.
 _EXTRA_OUT=()
 if [[ -n "${SFDT_ANALYZER_OUTPUT_FILE:-}" ]]; then
     _EXTRA_OUT=(--output-file "$SFDT_ANALYZER_OUTPUT_FILE")
-fi
-
-_SCANNER_V4=""
-if command -v sf &>/dev/null; then
-    _SCANNER_V4=$(sf plugins --json 2>/dev/null | \
-        jq -r '.[] | select(.name == "@salesforce/sfdx-scanner") | .name' 2>/dev/null || true)
 fi
 
 if command -v sf &>/dev/null && sf code-analyzer --help &>/dev/null; then
@@ -193,25 +184,6 @@ if command -v sf &>/dev/null && sf code-analyzer --help &>/dev/null; then
         printf '{"status":"skipped","reason":"sf code-analyzer run failed","result":[],"_sfdt_unavailable":"sf code-analyzer run failed — no violation data available for this run"}\n'
     fi
     rm -f "$_ANALYZER_TMP"
-elif [[ -n "$_SCANNER_V4" && "${SFDT_ANALYZER_ALLOW_LEGACY:-}" == "true" ]]; then
-    # Legacy v4 runs only on explicit opt-in (quality --allow-legacy-analyzer or
-    # config quality.analyzer.allowLegacyV4). Its results are NON-AUTHORITATIVE:
-    # rule coverage and severities differ from v5, and SARIF/fixes/suggestions
-    # are unavailable. v4 support is removed at 1.0.
-    log_warning "Running LEGACY Salesforce Code Analyzer v4 (sf scanner run) — results are non-authoritative; upgrade to v5 (sf plugins install code-analyzer)."
-    if [[ -n "${SFDT_ANALYZER_OUTPUT_FILE:-}" ]]; then
-        log_warning "SFDT_ANALYZER_OUTPUT_FILE requires Code Analyzer v5 — no extra output file written."
-    fi
-    sf scanner run \
-        --format json \
-        --target "$FORCE_APP_DIR" \
-        --engine pmd,eslint \
-        2>/dev/null || \
-        printf '{"status":"skipped","reason":"sf scanner run failed","result":[],"_sfdt_unavailable":"sf scanner run failed — no violation data available for this run"}\n'
-elif [[ -n "$_SCANNER_V4" ]]; then
-    log_warning "Code Analyzer v5 not available; legacy v4 detected but NOT run (v5 is required for authoritative scans)."
-    log_warning "Install v5 with:  sf plugins install code-analyzer   — or rerun with --allow-legacy-analyzer to accept a non-authoritative v4 scan."
-    printf '{"status":"skipped","reason":"v5 required; legacy v4 present but not enabled","result":[],"_sfdt_unavailable":"Code Analyzer v5 not installed. Legacy v4 was detected but is opt-in only (--allow-legacy-analyzer, non-authoritative). Install v5: sf plugins install code-analyzer"}\n'
 else
     log_warning "Salesforce Code Analyzer not available — static violation analysis SKIPPED (not run)."
     log_warning "It auto-installs with a modern sf CLI, or run:  sf plugins install code-analyzer"

--- a/src/commands/quality.js
+++ b/src/commands/quality.js
@@ -166,7 +166,6 @@ export function registerQualityCommand(program) {
     .option('--generate-stubs', 'Generate @IsTest stub classes for untested Apex classes')
     .option('--include-fixes', 'Ask Code Analyzer v5 for actionable fixes/suggestions in the scan output (feeds the AI fix plan)')
     .option('--output-file <path>', 'Also write the Code Analyzer v5 results to a file; the format follows the extension (e.g. .sarif for code-scanning upload)')
-    .option('--allow-legacy-analyzer', 'Permit the legacy Code Analyzer v4 (sf scanner run) when v5 is unavailable — results are non-authoritative (also: config quality.analyzer.allowLegacyV4)')
     .option('--dry-run', 'Preview --generate-stubs output without writing files')
     .option('--agent', 'Non-interactive agent mode (do not block waiting on the AI fix-plan session)')
     .option('--api67', "Run only the API v67 (Summer '26) user-mode readiness scan of local Apex sources")
@@ -189,15 +188,11 @@ export function registerQualityCommand(program) {
 
         let qualityOutput = '';
 
-        // --include-fixes/--output-file/--allow-legacy-analyzer only affect the
-        // Code Analyzer run (test-analyzer ignores them); the shell script reads
-        // the SFDT_ vars. Legacy v4 is opt-in via flag or config (J-1 policy).
-        const allowLegacy =
-          options.allowLegacyAnalyzer || config.quality?.analyzer?.allowLegacyV4 === true;
+        // --include-fixes/--output-file only affect the Code Analyzer run
+        // (test-analyzer ignores them); the shell script reads the SFDT_ vars.
         const analyzerEnv = {
           ...(options.includeFixes ? { SFDT_ANALYZER_INCLUDE_FIXES: 'true' } : {}),
           ...(options.outputFile ? { SFDT_ANALYZER_OUTPUT_FILE: options.outputFile } : {}),
-          ...(allowLegacy ? { SFDT_ANALYZER_ALLOW_LEGACY: 'true' } : {}),
         };
 
         const runAnalyzer = async (scriptPath, label, extraEnv = {}) => {

--- a/src/lib/config-schema.json
+++ b/src/lib/config-schema.json
@@ -204,19 +204,6 @@
         "soapLoginLookbackDays": { "type": "integer", "minimum": 1 }
       }
     },
-    "quality": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "analyzer": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "allowLegacyV4": { "type": "boolean" }
-          }
-        }
-      }
-    },
     "monitoring": {
       "type": "object",
       "additionalProperties": false,

--- a/src/templates/sfdt.config.json
+++ b/src/templates/sfdt.config.json
@@ -97,11 +97,6 @@
     "connectedAppFlagPermissive": true,
     "soapLoginLookbackDays": 30
   },
-  "quality": {
-    "analyzer": {
-      "allowLegacyV4": false
-    }
-  },
   "monitoring": {
     "backupDir": "monitoring-backup",
     "limitWarnThreshold": 0.75,


### PR DESCRIPTION
## What was removed (F-001)

Legacy Code Analyzer v4 (`sf scanner run`) support is gone — **Salesforce Code Analyzer v5 is the only supported engine**:

- **`scripts/quality/code-analyzer.sh`** — the v4 detection (`_SCANNER_V4`), the opt-in v4 run branch, and the "v4 detected but not enabled" branch are removed. Without v5 the scan emits the labelled `skipped` marker (never a fabricated clean result) with install guidance.
- **`src/commands/quality.js`** — the `--allow-legacy-analyzer` flag and the `SFDT_ANALYZER_ALLOW_LEGACY` env plumbing are removed.
- **Config key removed in lockstep (golden principle #3):** `quality.analyzer.allowLegacyV4` dropped from the template (`src/templates/sfdt.config.json`), the schema (`src/lib/config-schema.json`), and its only consumer (`quality.js`). The schema's top-level `additionalProperties: true` means a lingering `quality` key in an existing `.sfdt/config.json` is ignored, not an error.
- **Docs:** `docs/ENV-VARS.md` (env-var row removed; `buildScriptEnv()` never carried this per-invocation var), `docs/USAGE.md`, `ROADMAP.md` line 23 (removal recorded as landed), `CHANGELOG.md` (Unreleased → Removed).
- **`generated/commands.json`** regenerated via `npm run generate:catalogs` (not hand-edited).

## Acceptance greps (both empty)

```
$ grep -r 'sf scanner run' scripts/quality/
(no output, exit 1)

$ grep -r 'allow-legacy-analyzer\|allowLegacyV4\|SFDT_ANALYZER_ALLOW_LEGACY' src/ scripts/
(no output, exit 1)
```

## Tests

- `npm test` — 274 files, **4193 tests passed**, 0 failed
- `npm run check:all-contracts` — **pass**
- `bash -n scripts/quality/code-analyzer.sh` — clean

Notes: no tests exercised the v4 path directly, so none needed removal. `test/lib/gui-server-parsers.test.js` keeps fixtures with historical v4 skip-marker strings — they pin that old on-disk snapshots still parse (snapshots stay raw, principle #6). FEATURES.json untouched (verifier-only).

## Docs-site companion

sfdt-site companion PR: scoobydrew83/sfdt-site#33 (branch `docs/a-1-remove-analyzer-v4`) — removes the flag/config rows, updates the engine callout, re-syncs `data/upstream/commands.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TqRspW9JrYxVX7k4N5nyft)_