### PR TITLE
chore(features): F-001 passes=true (verifier)

### DIFF
--- a/FEATURES.json
+++ b/FEATURES.json
@@ -13,8 +13,8 @@
         "grep -rq 'sf scanner run' scripts/quality/ returns nothing",
         "grep -rq 'allow-legacy-analyzer\\|allowLegacyV4\\|SFDT_ANALYZER_ALLOW_LEGACY' src/ scripts/ returns nothing"
       ],
-      "passes": false,
-      "evidence": null
+      "passes": true,
+      "evidence": "2026-07-29, develop@c03aa30 (PR #287): step-1 grep -r 'sf scanner run' scripts/quality/ → empty (exit 1); step-2 grep -r 'allow-legacy-analyzer|allowLegacyV4|SFDT_ANALYZER_ALLOW_LEGACY' src/ scripts/ → empty (exit 1); npm test 4193 passed / check:all-contracts pass. Reviewer additionally proved via instrumented stub that sf scanner run is never invoked (PR #287 review)."
     }
   ]
 }


### PR DESCRIPTION
Verifier flip for FEATURES.json item F-001 after A-1 (remove legacy Code Analyzer v4) merged to `develop` as squash commit c03aa30 (PR #287).

## Evidence (recorded in FEATURES.json)

2026-07-29, develop@c03aa30 (PR #287): step-1 grep -r 'sf scanner run' scripts/quality/ → empty (exit 1); step-2 grep -r 'allow-legacy-analyzer|allowLegacyV4|SFDT_ANALYZER_ALLOW_LEGACY' src/ scripts/ → empty (exit 1); npm test 4193 passed / check:all-contracts pass. Reviewer additionally proved via instrumented stub that sf scanner run is never invoked (PR #287 review).

## Rerun results (this branch, develop@c03aa30)

- `grep -rq 'sf scanner run' scripts/quality/` → no matches, exit 1 (pass)
- `grep -rq 'allow-legacy-analyzer\|allowLegacyV4\|SFDT_ANALYZER_ALLOW_LEGACY' src/ scripts/` → no matches, exit 1 (pass)
- `npm test` → 274 files / 4193 tests passed
- `npm run check:all-contracts` → all checks pass, both before and after the FEATURES.json edit; `tools/check-features-edits.mjs` reports "FEATURES.json OK (1 entries, structure + edit-scope checked)"

Change scope: FEATURES.json only — `passes` and `evidence` fields of F-001, per golden principles #9/#11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TqRspW9JrYxVX7k4N5nyft)_