### PR TITLE
chore: release CLI v0.21.0 + extension v0.10.0 + VS Code v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.0] - 2026-07-30
+
+> **The bridge contract changed — `PROTOCOL_VERSION` moves `1.2` → `1.3`.** The two additive
+> `manifest.discover` / `manifest.render` request kinds (B-3) are a **minor** protocol bump, so a
+> `1.2` client is warned about the minor mismatch and keeps working — it is never refused, and no
+> kind was removed or renamed. `PROTOCOL_VERSION` lives in
+> `packages/flow-core/src/bridge-contract.ts`; `@sfdt/flow-core` ships at **0.10.0** in this
+> release (bumped `0.9.7 → 0.10.0` with the contract change, consumer ranges moved to `^0.10.0` in
+> lockstep). The client that speaks `1.3` is `@sfdt/extension` **0.10.0**, which needs this CLI
+> (>= 0.21.0) for its bridge path and falls back to its offline SOAP path against an older one.
+>
+> **Breaking for anyone opted into the legacy analyzer (see Removed).** `quality
+> --allow-legacy-analyzer`, the `quality.analyzer.allowLegacyV4` config key, and
+> `SFDT_ANALYZER_ALLOW_LEGACY` are **gone** — passing the flag is now an unknown-option error, and
+> the env var is ignored. A lingering `quality.analyzer.allowLegacyV4` key in an existing
+> `.sfdt/config.json` is ignored rather than a hard error, so no config edit is required to
+> upgrade. Salesforce Code Analyzer **v5 is the only supported engine**; on a machine without v5
+> the static scan reports `skipped` with install guidance, never a fabricated clean result.
+> Shipped as a minor bump under this project's pre-1.0 (`0.x`) versioning, where the minor slot
+> carries breaking changes.
+
 ### Added
 - **Chrome extension: Metadata Retrieve & Deploy rides the manifest bridge kinds (B-4, delivers extension-plan P5-4/P5-5).** The extension's metadata browser now sources its type/member tree from `manifest.discover` and all manifest XML from `manifest.render` whenever a bridge is connected — the single-writer rule holds end to end (only `renderPackageXml` produces XML on the bridge path; the extension's private SOAP writer survives strictly as the offline fallback). It also gains the Additive | Destructive mode toggle (paired `destructiveChanges.xml` + empty `package.xml` output with warning styling) and per-org selection persistence with clear-all. Details in `extension/CHANGELOG.md`; no new extension permissions.
 - **SOQL Console — the `sfdt soql` family as a dashboard page (D-4).** A new GUI page (deep-linkable at `/soql`) surfaces the query/schema lifecycle: search sObjects and browse fields/relationships (describe with picklists, reference targets, parent/child relationships), validate a query (local checks plus the org `LIMIT 0` round-trip — an unreachable org degrades to a local-only verdict, never a fabricated pass), fetch query plans (REST explain; the query is never executed), and run SOQL/SOSL with the configured row bound. Seven thin `/api/soql/*` routes wrap the existing `src/lib/soql-runner.js` — the single engine shared with the CLI, MCP, and VS Code, so bounds (`soql.defaultLimit` clamped to `soql.maxLimit`), bound/truncated metadata, and error messages are identical across surfaces; the routes never accept an output path and never write files. Results export client-side as raw JSON (the `writeExport` shape) or the runner's own `toCsv` shaping returned by the server (dot-path parent columns) — no second export format. Errors surface the real sf/org message, never an empty result. No new config keys, no new dependencies.

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to `@sfdt/extension` are documented here. Format follows [Ke
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-07-30
+
+> **Minimum `@sfdt/cli`: 0.21.0** — the bridge path added below speaks the `manifest.discover` /
+> `manifest.render` request kinds and wire protocol **1.3**, both of which ship in `@sfdt/cli`
+> 0.21.0 (`@sfdt/flow-core` 0.10.0). Against an older CLI the probe simply fails and the tool
+> reports "sfdt bridge unavailable — using the Salesforce SOAP API directly", so Metadata Retrieve
+> & Deploy stays fully functional on its offline SOAP path; nothing breaks, the CLI-rendered
+> manifest just isn't available. CLI 0.21.0 publishes to npm with this release, so it is on npm
+> before this version clears Web Store review. No new manifest permissions in this version.
+
 ### Fixed
 - **Restoring a member-level selection no longer truncates that metadata type's tree.** `restoreSelections()` seeds the persisted member into the type's children, but the member-fetch guard in `toggleExpand()` tested *emptiness* (`childXmlNames.length === 0`) rather than *completeness* — so after reopening the tool, a type with a restored member showed **only** that member, forever: collapsing and re-expanding never re-fetched, and there is no refresh affordance, so the only way to see the type's other members was to drop the saved selection. Load state is now tracked explicitly (`membersLoaded`, set only by a successful bridge/SOAP member fetch), so a node whose children came from storage — or from an imported `package.xml`, which had the same defect — still fetches its real member list on expand, while a genuinely loaded node does not re-fetch. The restored ticks survive that fetch: they are merged onto the fetched list, and a selected member the org no longer returns is **kept** (with a log line naming it) rather than silently dropped, since not losing the user's selection is the entire point of persistence. A restored type is also left **collapsed** rather than expanded, so a one-member list is never *presented* as the type's complete membership and the first expand does the real fetch — no hidden collapse-then-expand needed; the type row carries a **partial tick** (`indeterminate`, labelled "some members selected") so the restored selection is still plainly visible while collapsed. Fixed on both the bridge and offline SOAP paths. Wildcard restores were never affected (they set the type's own tick and never touch the child list).
 - **A `manifest.discover` reply missing its `members` array is treated as a failure, not an empty metadata type.** The bridge branch coerced a non-array payload to `[]` *and* marked the node loaded, so a malformed `ok: true` response produced a fabricated empty tree that then never re-fetched — precisely the failure the "never a fabricated empty tree" invariant exists to prevent. Such a response now surfaces as an error, collapses the node, and leaves it re-fetchable with its seeded children and ticks intact. (The offline SOAP path has no equivalent hole: `apiSoap` throws on every transport error and SOAP fault, so a falsy `listMetadata` result genuinely means the type has zero members — that is now documented in place.)

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sfdt/extension",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "Chrome MV3 extension for Salesforce Flow Builder and other Salesforce tools. WXT + TypeScript.",
   "license": "Apache-2.0",
   "private": true,

--- a/generated/catalog-version.json
+++ b/generated/catalog-version.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
-  "cliVersion": "0.20.0",
-  "extensionVersion": "0.9.1",
-  "vscodeVersion": "0.5.2",
+  "cliVersion": "0.21.0",
+  "extensionVersion": "0.10.0",
+  "vscodeVersion": "0.6.0",
   "flowCoreVersion": "0.10.0",
   "bridgeProtocol": "1.3"
 }

--- a/generated/packages.json
+++ b/generated/packages.json
@@ -3,7 +3,7 @@
     {
       "path": "package.json",
       "name": "@sfdt/cli",
-      "version": "0.20.0",
+      "version": "0.21.0",
       "license": "Apache-2.0",
       "private": false,
       "engines": {
@@ -13,7 +13,7 @@
     {
       "path": "extension/package.json",
       "name": "@sfdt/extension",
-      "version": "0.9.1",
+      "version": "0.10.0",
       "license": "Apache-2.0",
       "private": true,
       "engines": null
@@ -37,7 +37,7 @@
     {
       "path": "vscode/package.json",
       "name": "sfdt-devtools",
-      "version": "0.5.2",
+      "version": "0.6.0",
       "license": "Apache-2.0",
       "private": true,
       "engines": {
@@ -55,7 +55,7 @@
     {
       "path": "packages/plugin/package.json",
       "name": "@sfdt/plugin",
-      "version": "0.20.0",
+      "version": "0.21.0",
       "license": "Apache-2.0",
       "private": false,
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sfdt/cli",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sfdt/cli",
-      "version": "0.20.0",
+      "version": "0.21.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [
@@ -55,7 +55,7 @@
     },
     "extension": {
       "name": "@sfdt/extension",
-      "version": "0.9.1",
+      "version": "0.10.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -17002,7 +17002,7 @@
     },
     "packages/plugin": {
       "name": "@sfdt/plugin",
-      "version": "0.20.0",
+      "version": "0.21.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@oclif/core": "^4.13.0",
@@ -17035,7 +17035,7 @@
     },
     "vscode": {
       "name": "sfdt-devtools",
-      "version": "0.5.2",
+      "version": "0.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@sfdt/flow-core": "^0.10.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sfdt/cli",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "Salesforce DevTools — Production-grade CLI for Salesforce DX deployment, testing, quality analysis, and release management",
   "type": "module",
   "bin": {

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sfdt/plugin",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "Salesforce CLI (sf) plugin for SFDT — exposes the @sfdt/cli commands as `sf sfdt <command>`. Thin wrapper; reimplements no logic.",
   "license": "Apache-2.0",
   "repository": {

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to the **SFDT for Salesforce** VS Code extension (`sfdt.sfdt
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-07-30
+
 ### Added
 
 - **`SFDT: Open Manifest Builder`** — opens the embedded dashboard deep-linked

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "sfdt-devtools",
   "displayName": "SFDT for Salesforce",
   "description": "A full command center for the sfdt CLI in VS Code: a grouped Commands tree for every sfdt command, a live Status panel (org, branch, versions), the Org Health view, an org picker, the embedded dashboard, and per-org window theming.",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "publisher": "sfdt",


### PR DESCRIPTION
Step 1 of `RELEASING.md` §3 — lands the version bump + CHANGELOG + lockfile sync on `develop`. **This is not the promote PR**; the `develop → main` promote is Drew's to run (steps reproduced at the bottom, verbatim from §3/§4).

## Versions

| Workspace | From | To | Bump | §5 reasoning |
|---|---|---|---|---|
| `@sfdt/cli` (root) | 0.20.0 | **0.21.0** | minor | Two new command families (`sfdt soql`, `sfdt apex`), the ApexGuru `quality` pass, the manifest-builder GUI page, and the bridge manifest kinds. Also **breaking** for anyone opted into the legacy analyzer (below) — shipped as a minor because `0.x` is where this project carries breaking changes, and `vscode/CHANGELOG.md` already committed to `>= 0.21` on the develop branch. |
| `@sfdt/plugin` | 0.20.0 | **0.21.0** | lockstep | **Corrected from your recommendation.** You asked me to bump it only if its content changed — it did not (`git diff 70397c2..HEAD -- packages/plugin/` is empty). But `RELEASING.md` §1 is explicit: `@sfdt/plugin` "Bumps with the CLI's release commit", and the v0.20.0 release commit (46bf370) did exactly that, annotated "(lockstep with the CLI)". It is also not really unchanged in effect: its oclif commands are code-generated from `createCli()` at build time, and `npm run build:plugin` now emits **106** command files covering the new `soql`/`apex` trees. Bumped to 0.21.0. |
| `@sfdt/flow-core` | 0.10.0 | **0.10.0** | none | Already bumped `0.9.7 → 0.10.0` in B-3 (#295) and unreleased, so the release commit's bump already exists — ships as-is, per your instruction and §5 ("flow-core / host: nothing to do"). **Consumer ranges verified consistent:** `^0.10.0` in all five consumers — root `package.json`, `extension/`, `gui/`, `host/`, `vscode/`. |
| `@sfdt/extension` | 0.9.1 | **0.10.0** | minor | Agreed. B-4 (#297) rewires Metadata Retrieve & Deploy onto the bridge manifest kinds and adds the Additive/Destructive toggle + per-org selection persistence; #298 fixes two defects in it. Filed under `Changed`/`Fixed` rather than `Added`, but it is a feature-scale change, so minor. |
| `sfdt-devtools` (`/vscode`) | 0.5.2 | **0.6.0** | minor | Agreed. B-2 (#294) contributes a **new command** (`sfdt.manifestBuilder`), so 0.5.3 would understate it. |
| `@sfdt/host` | 0.11.0 | **0.11.0** | none | **Checked, not bumped.** Content *did* change this cycle (B-3 added ~99 lines to `host/src/index.js` mirroring both manifest kinds, plus 108 lines of tests) and #295 moved its flow-core range to `^0.10.0`. But §1 is explicit: "`@sfdt/host` has no independent release — it ships inside `@sfdt/cli`." It is `private: true`, never published, and its version last moved in an unrelated docs commit — it is not maintained in lockstep. Leaving it at 0.11.0. |
| `@sfdt/gui` | 0.1.0 | **0.1.0** | none | Private, bundled into the CLI tarball at `prepack`, no independent version discipline. Untouched. |

### Called out prominently in the CHANGELOG

Two notes were added under the root `## [0.21.0]` heading, per §2:

- **Bridge contract changed — `PROTOCOL_VERSION` 1.2 → 1.3.** Additive minor (two new kinds, nothing removed or renamed), so a 1.2 client is warned about the minor mismatch and keeps working. Because it is a *minor* bump, the §5/§6 "never ship a breaking protocol change before the extension clears Web Store review" constraint **does not bind this release**. The extension's 0.10.0 entry now carries the **minimum `@sfdt/cli` version (0.21.0)** that §5 requires, plus the verified fallback behaviour: against an older CLI the `manifest.discover` probe returns `ok: false` and `initDataSource()` logs "sfdt bridge unavailable — using the Salesforce SOAP API directly", so the tool stays fully functional offline. Nothing breaks while the extension sits in review.
- **A-1's removal is breaking.** `quality --allow-legacy-analyzer`, `quality.analyzer.allowLegacyV4`, and `SFDT_ANALYZER_ALLOW_LEGACY` are gone; the flag is now an unknown-option error and the env var is ignored. A lingering config key is ignored rather than a hard error, so no config edit is needed to upgrade. Code Analyzer v5 is the only supported engine; without v5 the static scan reports `skipped`, never a fabricated clean result.

## The 13 shipped items, by surface

**Quality / analysis**
- **A-1 / F-001** — remove legacy Code Analyzer v4 (`sf scanner run`) support (#287), verifier flip (#291)
- **D-3** — ApexGuru org-side check in `sfdt quality`, license-gated and additive (#292)

**CLI commands**
- **D-1** — the `sfdt soql` family: schema search/describe/relationships, validation, plans, bounded execution (#290)
- **D-2** — `sfdt apex`: trace flags, debug log retrieve/watch, Anonymous Apex (#288)

**GUI (`sfdt ui`)**
- **B-1** — manifest builder page + server routes (#289)
- **D-4** — SOQL query console page + `/api/soql/*` routes (#296)

**VS Code**
- **B-2** — `SFDT: Open Manifest Builder` command + dashboard deep-link fix (#294)

**Bridge / flow-core**
- **B-3** — `manifest.discover` + `manifest.render` kinds, `PROTOCOL_VERSION` 1.2 → 1.3, flow-core 0.9.7 → 0.10.0 (#295)

**Chrome extension**
- **B-4** — metadata-retrieve over the bridge manifest kinds (#297)
- **B-5** — member-restore truncation + redundant-render fixes (#298)

**Docs**
- Visual manifest builder design + sf-pi review (#286)
- GUI SOQL console roadmap (#293)

## Gates (§2) — run on this branch, after the bumps

| Gate | Result |
|---|---|
| `npm test` (CLI + flow-core + host root suite) | **284 files / 4486 tests passed**, 0 failed |
| `npm run lint` (`src/ bin/ tools/`) | clean, exit 0 |
| `npm run test:all` — `test:flow-core` | **20 files / 371 tests passed** |
| `npm run test:all` — `test:extension` | **84 files / 1232 tests passed** |
| `npm run test:all` — `test:host` | **2 files / 42 tests passed** |
| `npm run test:all` — `test:vscode` | **17 files / 239 tests passed** |
| `npm run test:all` — `test:plugin` | **2 files / 11 tests passed** |
| **`test:all` total** | **409 files / 6381 tests passed, 0 failed** |
| API-version registry (`test/lib/api-version-registry.test.js`) | **4/4 passed** — the registry is *not* behind the current Salesforce GA, so no human curation is needed this cycle |
| `npm run check:all-contracts` | clean — catalogs up to date (11 files), license policy OK (7 manifests / 2 license files / 18 prose files), Node policy OK (`>=22.15.0` everywhere), auth docs OK (53 files), FEATURES.json OK (1 entry), package-internal paths OK (117 files) |
| `npm run build:gui` | OK — 690.19 kB JS / 45.46 kB CSS |
| `npm run build:ext` | OK — 1.2 MB total; built `manifest.json` version reads **0.10.0**, so the `package:ext` staleness guard passes |
| `npm run build:plugin` | OK — generated **106** oclif command files, `tsc` clean |
| `npm run lint -w vscode` / `build:vscode` / `package:vscode` (§5) | all clean — packaged `sfdt-devtools-0.6.0.vsix`, 12 files / 135.12 KB |
| `npm install --package-lock-only` (§2 lockfile sync) | committed; diff is **5 version lines only**, no dependency churn |
| `npm run generate:catalogs` (§2 — run last, after the bumps) | regenerated and committed: `catalog-version.json` (cli 0.21.0, ext 0.10.0, vscode 0.6.0, flow-core 0.10.0, bridge 1.3) + `packages.json`. `check:catalogs` re-verified clean afterwards. Nothing under `generated/` was hand-edited. |

Also spot-checked as part of §5's extension doc-staleness sweep: `extension/wxt.config.ts`, `extension/PRIVACY.md`, and `extension/README.md` are **unchanged since the v0.20.0 promote**, and the built manifest's permissions (`storage`, `clipboardWrite`, `cookies`, `contextMenus`, `sidePanel` + the existing host list) are identical — so B-4's "no new permissions" claim holds and PRIVACY.md is not stale. No hardcoded `0.20.0` / `0.9.1` / `0.5.2` strings remain in `README.md`, `docs/`, `skills/`, or `.github/`. The `sfdt-skills` README "Synced from" footer is bumped by `sfdt skills export --target pack` inside CI (§1 step 7), not by hand.

## Outstanding human-run gates (§2)

§2 lists four user-invoked skills. **None of them are available in this session** — they are not in my skill list and are not in this repo's `skills/` directory (which holds the ten Salesforce agent skills the CLI exports, not the release rituals; those live in the separate `skills` harness repo). I did not run them and have not simulated them. They remain **outstanding and must be run by a human on this branch before the promote**:

- [ ] **`/pre-release-cli-test`** — smoke `--help` for every registered command, derived from the Commander tree. Especially relevant this cycle: `soql` and `apex` add 14 new subcommands, and `quality` lost a flag.
- [ ] **`/pre-release-security`** — required, since far more than docs/tests changed. Note the v0.20.0 precedent: this gate is what found the `config.plugins[]` path-execution vulnerability.
- [ ] **`/pre-release-ui-test`** — required, `gui/` changed (10 files: the manifest builder and SOQL console pages plus the `App.jsx` deep-link fix).
- [ ] **`/validate-npm-paths`** — the mechanical half is already green here (`npm run check:package-paths`, 117 files scanned, clean, part of `check:all-contracts`), but the skill's judgement pass has not been run.

One §2 item is **N/A**: `@modelcontextprotocol/sdk` is unchanged at `~1.29.0`, so no `sf mcp start` / `sfdt mcp start` manual smoke is required.

## sfdt-site: 9 held docs PRs (#33–#41) — verified merge order

Reported for §4, **not acted on**. I verified the two anchor dependencies you gave me against the actual diffs, and one of them does not hold.

**#36 → #41 is real. ✅** #36 (D-1) adds `## \`sfdt soql\`` to `content/cli/commands/metadata.mdx`, which is what generates the `#sfdt-soql` anchor. #41 (D-4) links to `/cli/commands/metadata#sfdt-soql` from its new SOQL Console section. Merging #41 first ships a dead anchor. **#36 must land with or before #41.**

**#35 → #40 is *not* real — correcting you. ❌** #40's diff contains **no** `cli/dashboard#manifest-builder` link. It touches only `content/chrome-extension/features.mdx` and `content/chrome-extension/workspace.mdx`, and the only links it adds point at `/chrome-extension/bridge` — a page that already exists on `master`, so nothing can 404. #40's PR *body* asserts the dependency, but the code doesn't back it. #40's real (and merely cosmetic) dependency is on **#39** (B-3), which refreshes that bridge page's kind list and protocol version to 1.3; without #39 the link still resolves, the target page is just stale. **#40 can merge in any order.**

**#35 → #41 *is* real, for a different reason than you were given. ⚠️** Both edit `content/cli/dashboard.mdx` in overlapping hunks (both insert a `GuiPageTable` details row and a new `##` section right after the same "Data appears automatically…" paragraph) and both add the identical `manifest-builder` row to `data/upstream/gui-pages.json` — #41 already carries #35's catalog row. So **#35 before #41**, or #41 needs a rebase. Same net ordering you asked for, different mechanism.

**Bigger issue: the catalog files conflict across five PRs.** #33, #34, #35, #36, and #41 all rewrite `data/upstream/summary.json` *from the same base values* to different intermediate targets (e.g. `topLevelCommands` 44→45 in both #34 and #36; `gui.pages` 25→26 in #35 vs 25→27 in #41). They cannot all merge cleanly in any order. Prose conflicts cluster the same way:

| File | PRs touching it |
|---|---|
| `content/cli/commands/testing-quality.mdx` | #33, #34, #37 |
| `content/cli/mcp.mdx` | #34, #36, #37 |
| `content/cli/configuration.mdx` | #33, #36 |
| `content/cli/dashboard.mdx` | #35, #41 |
| `data/upstream/commands.json` | #33, #34, #36 |
| `data/upstream/summary.json` | #34, #35, #36, #41 |
| *(isolated — no overlap)* | #38, #39, #40 |

The clean path is the one §4 step 2b already prescribes: merge the **prose** changes in dependency order (#33, #34, #37, #36, #35, #41, then the isolated #38/#39/#40), then do **one authoritative catalog sync from the released `main` ref** — `node scripts/sync-upstream-catalogs.mjs` followed by `--check` — which supersedes every hand-carried `data/upstream/*` diff. Worth noting that **#41's `summary.json` already matches the full release state exactly** (46 top-level commands / 23 JSON-capable / 17 mutating, 27 GUI pages, 31 VS Code commands / 119 catalog entries, 39 MCP tools / 12 confirm-gated, bridge 1.3 / 13 kinds / 10 native-host kinds) — byte-identical to the catalogs regenerated in this PR — so if you merge #41 last its catalogs are already correct.

## Promote steps (Drew)

Reproducing `RELEASING.md` §3 and §4. Releases promote `develop` to `main` **wholesale** — CLI, flow-core, plugin, extension, VS Code together. Never cut a side release branch and never cherry-pick a subset; both re-drift the branches.

1. Land this PR on `develop` (normal PR — you are here).
2. Open the promote PR `develop → main`. Merge it as a **merge commit — NEVER squash**. Squashing rewrites the commits, so `develop` and `main` permanently disagree and every later PR shows CONFLICTING.
3. Fast-forward `develop` back onto `main` so both sit at the same commit:

   ```bash
   git checkout develop && git pull
   git merge --ff-only origin/main && git push
   ```

4. Verify:

   ```bash
   git rev-list --left-right --count main...develop   # must print: 0	0
   ```

   **The release is not done until that check reads `0	0`.** In v0.17.0 the promote step was skipped after the develop-side work merged; `main` sat 134 commits behind for a day while the "released" code existed only on `develop`, and reconciling it afterwards took a drift-repair merge. Treat the 0/0 check as a release gate, not housekeeping.

Then §4 — docs site (sfdt.dev). Cloudflare **Workers Builds auto-deploys `master`**, so merging to `master` *is* deploying:

- [ ] Run `/sync-docs-site` — version references, install commands, changelog highlights, staleness pass over commands/flags/config keys/MCP tools.
- [ ] Its **Step 2b catalog sync**: regenerate `generated/` catalogs **from the released ref (never `develop`)**, then in sfdt-site run `node scripts/sync-upstream-catalogs.mjs` and `--check` to confirm clean. Site counts render from these files, never by hand.
- [ ] Merge the **HELD draft docs PRs** for features shipping in this release — #33–#41 above; releasing is what un-holds them. Drafts are held so the site never documents unreleased behavior.
- [ ] Verify the deploy landed: check the Workers Builds run for `master` and spot-check a changed page on https://sfdt.dev/.

Publishing itself is CI's job (§1) — do **not** run `npm publish`. On merge to `main`, `ci.yml` tags `v0.21.0`, force-moves the floating `v0` tag, and publishes **`@sfdt/flow-core` → `@sfdt/cli` → `@sfdt/plugin`** in that order; `extension.yml` tags `ext-v0.10.0` and uploads to the Chrome Web Store; `vscode-release.yml` tags `vscode-v0.6.0` and publishes to the Marketplace + Open VSX. Then §7: `/post-release`, verify every distribution channel, and re-confirm the `0	0` check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01TqRspW9JrYxVX7k4N5nyft)_