### PR TITLE
fix(apex): write --output debug logs 0600, not world-readable

### DIFF
--- a/src/lib/apex-runner.js
+++ b/src/lib/apex-runner.js
@@ -275,7 +275,9 @@ export async function getLog(orgAlias, logId, { outputFile } = {}) {
   // plugin-apex has returned both [{ log }] and { log } shapes across versions.
   const body = Array.isArray(result) ? (result[0]?.log ?? '') : (result?.log ?? '');
   if (outputFile) {
-    await fs.outputFile(outputFile, body);
+    // 0600: a debug log can carry org data, and --output is often pointed at a
+    // shared dir (/tmp). Default 0644 would leave it world-readable there.
+    await fs.outputFile(outputFile, body, { mode: 0o600 });
   }
   return { org: orgAlias, id: logId, lengthBytes: Buffer.byteLength(body, 'utf8'), log: body, outputFile: outputFile ?? null };
 }

--- a/test/lib/apex-runner.test.js
+++ b/test/lib/apex-runner.test.js
@@ -250,10 +250,10 @@ describe('getLog', () => {
     expect(out).toMatchObject({ id: 'L1', log: 'BODY', lengthBytes: 4, outputFile: null });
     expect(execa).toHaveBeenCalledWith('sf', ['apex', 'get', 'log', '--log-id', 'L1', '--target-org', 'dev', '--json']);
   });
-  it('handles the object result shape and writes --output raw', async () => {
+  it('handles the object result shape and writes --output raw, owner-only', async () => {
     execa.mockResolvedValueOnce(envelope({ log: 'BODY' }));
     const out = await getLog('dev', 'L1', { outputFile: '/tmp/x.log' });
-    expect(fs.outputFile).toHaveBeenCalledWith('/tmp/x.log', 'BODY');
+    expect(fs.outputFile).toHaveBeenCalledWith('/tmp/x.log', 'BODY', { mode: 0o600 });
     expect(out.outputFile).toBe('/tmp/x.log');
   });
   it('requires a log id', async () => {


### PR DESCRIPTION
Closes CodeQL alert [124](https://github.com/scoobydrew83/sfdt/security/code-scanning/124) (`js/insecure-temporary-file`, **high**), raised against release PR #300.

## The finding

`src/lib/apex-runner.js:278` — `sfdt apex logs get --output <file>` wrote the raw debug-log body via `fs.outputFile(outputFile, body)`, which uses fs-extra's default `0644`.

CodeQL's rule title ("insecure creation of file in the os temp dir") is not quite right — `--output` is a user-supplied CLI path and there is no `os.tmpdir()` anywhere in that flow. But the underlying concern holds: a debug log can carry org data, and `--output` is commonly pointed at a shared directory such as `/tmp`, where `0644` leaves it world-readable to every user on the box.

## The change

```diff
-    await fs.outputFile(outputFile, body);
+    // 0600: a debug log can carry org data, and --output is often pointed at a
+    // shared dir (/tmp). Default 0644 would leave it world-readable there.
+    await fs.outputFile(outputFile, body, { mode: 0o600 });
```

Two lines plus the comment. No behaviour change beyond the permission bits — the path, the body, and the return envelope are untouched.

## Scope

`getLog()` is the only writer of this file, reached from exactly one place (`src/commands/apex.js:184`), so the guard sits where all callers route through. The sibling temp-file writers (`runAnonymous`, the MCP `sfdt_apex_run` handler) already use `fs.mkdtemp`, which creates its directory `0700` — they were never exposed and are unchanged.

## Verification

- `test/lib/apex-runner.test.js` asserts the exact call, so it is the regression check; updated to expect `{ mode: 0o600 }` and it fails without the fix.
- `npm test` — 4486 passed (284 files)
- `npm run lint` — clean
- `npm run check:all-contracts` — clean

## The other three alerts

125/126/127 (`js/http-to-file-access`, medium) on `/api/manifest/save` are being dismissed as false positives rather than fixed. Writing a `package.xml` the user assembled in the GUI *is* that route's purpose, and the traversal risk the rule implies is already closed at `src/lib/gui-server/index.js:2588-2660` — CSRF token, rate limiter, `mode` allowlist, 20k item cap, name regex, `path.basename()`, `path.resolve()` containment under `manifestBase`, and a `deployed/` read-only guard.