### PR TITLE
chore(ext): describe the extension by what it does, not one feature

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sfdt/extension",
   "version": "0.11.0",
-  "description": "Chrome MV3 extension for Salesforce Flow Builder and other Salesforce tools. WXT + TypeScript.",
+  "description": "Chrome MV3 extension for Salesforce admin and developer tools. WXT + TypeScript.",
   "license": "Apache-2.0",
   "private": true,
   "type": "module",


### PR DESCRIPTION
One-line change to `extension/package.json#description`.

```diff
- "Chrome MV3 extension for Salesforce Flow Builder and other Salesforce tools. WXT + TypeScript."
+ "Chrome MV3 extension for Salesforce admin and developer tools. WXT + TypeScript."
```

The old text described the extension as being for **Flow Builder and other tools** — a Flow-first framing that stopped being accurate somewhere around the 45-feature mark, and the same framing `af30abf` moved away from when it renamed "SFDT SF Helper" → "SFDT for Salesforce".

## Scope: repo-internal metadata only

Checked rather than assumed, because a package description *can* reach users:

- **`extension/package.json` is `private: true`** — it is never published to npm, so the description has no registry page.
- **The Chrome manifest description does not come from here.** `wxt.config.ts:13` sets it explicitly, and a build confirms it: the packed manifest reads *"Productivity tools for Salesforce admins & developers — Flow, Setup, Object Manager, record pages, SOQL/REST/SOAP & AI."*, which is unchanged by this PR.
- **Not consumed by `generated/`** — `generated/packages.json` carries `path`/`name`/`version`/`license`/`private`/`engines` and no description field, so no catalog regeneration is required and none was done.

Nothing user-facing moves, so there is **no changelog entry** — this would be noise in release notes.

## Why now

It is being landed ahead of the `develop` → `main` promotion for **0.11.0** so the released tree carries the corrected text rather than leaving it for the next cycle.

---
_Generated by [Claude Code](https://claude.ai/code)_