### PR TITLE
chore(deps): npm audit fix — clear 3 high-severity advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2280,9 +2280,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "1.19.17",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.17.tgz",
+      "integrity": "sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -4099,6 +4099,12 @@
       "engines": {
         "node": ">=22.15.0"
       }
+    },
+    "node_modules/@sfdt/cli/node_modules/@sfdt/flow-core": {
+      "version": "0.9.7",
+      "resolved": "https://registry.npmjs.org/@sfdt/flow-core/-/flow-core-0.9.7.tgz",
+      "integrity": "sha512-6Vv8+8Qvj3mMEnQN5ANq+jd+9jwsuVv1CdNMAtfw7zbxc6ihlFTtt/1xRHznWkf+6ooZQBmF2m0PzMWmtq5VNA==",
+      "license": "Apache-2.0"
     },
     "node_modules/@sfdt/cli/node_modules/chalk": {
       "version": "5.6.2",
@@ -6107,9 +6113,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -8698,9 +8704,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -9566,9 +9572,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.31",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
-      "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.0.tgz",
+      "integrity": "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -9959,9 +9965,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -13500,9 +13506,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.22",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
-      "integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -15803,9 +15809,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Why

`test (22)` has been **failing on `develop` since 2026-08-01** — the `npm audit --audit-level=high --omit=dev` step. It is not caused by any code change: the last two runs on `develop` failed, including [#315](https://github.com/scoobydrew83/sfdt/pull/315), a Dependabot bump that touched only `.github/workflows/stale.yml`. New advisories were simply published after the last green run (2026-07-31).

This blocks the extension v0.12.0 release PR (#316), whose only other red is this same inherited check.

## What

`npm audit fix` — **non-breaking**, no `--force`. The diff is `package-lock.json` only; **no direct dependency in `package.json` changed**.

### Advisories cleared (all HIGH)

| Package | Advisory |
|---|---|
| `brace-expansion` 4.0.0–5.0.8 | DoS via unbounded intermediate arrays, bypassing the CVE-2026-14257 mitigation ([GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895)) |
| `fast-uri` 3.0.0–3.1.4 | Host confusion via backslash authority introducer ([GHSA-7p8r-x3mc-p8w7](https://github.com/advisories/GHSA-7p8r-x3mc-p8w7)) |
| `ip-address` ≤10.3.0 | Leading-zero octets decoded as decimal → SSRF / trust-boundary bypass ([GHSA-mwp4-54f8-5fhr](https://github.com/advisories/GHSA-mwp4-54f8-5fhr)); CIDR suffix suppresses special-use classification ([GHSA-4xrf-jv44-h6hh](https://github.com/advisories/GHSA-4xrf-jv44-h6hh)); IPv4-mapped/NAT64 misclassification ([GHSA-22jq-vg5j-6vgg](https://github.com/advisories/GHSA-22jq-vg5j-6vgg)) |

### Deliberately NOT fixed

Moderate advisories in `hono` / `@hono/node-server` (reached via `@modelcontextprotocol/sdk`) remain. `npm audit fix --force` would resolve them by installing **`@sfdt/cli@0.11.0`** — a downgrade of ten minor versions presented as a "fix". They are below the CI gate's `--audit-level=high` threshold and are the MCP SDK's transitive problem to bump. Not worth a forced downgrade of our own package.

## Verification

Run locally on this branch after the change:

- `npm audit --audit-level=high --omit=dev` → **exit 0** (the exact gate CI runs)
- `npm ci` → lockfile resolves cleanly
- `npm run lint` → clean
- `npm test` → **5162/5162** passing (309 files)
- `npm run test:flow-core` → **401/401**
- `npm run test:extension` → **1878/1878** (108 files)
- `npm run check:all-contracts` → all 5 checks OK

## Follow-up

Once merged, `ext/release-0.12.0` (#316) rebases onto this and its `test (22)` should go green.