### PR TITLE
chore(release): stop re-running the test suite inside npm publish

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -85,6 +85,31 @@ Then bump the Homebrew tap manually (`shasum -a 256` of the npm tarball → upda
 and dispatch `docker-publish.yml` with the version. Prefer letting CI self-heal on the next
 push to `main` over doing any of this by hand.
 
+### Why `prepublishOnly` does not run the test suite
+
+`prepublishOnly` is `npm run lint && npm run check:all-contracts` — deliberately **not**
+`npm test`.
+
+Both `publish` and `publish-beta` declare `needs: [test, gui-build]`, so the full suite is
+already a hard gate that must pass before either job starts. Re-running all ~5,200 tests inside
+`npm publish` added no new signal — it only added a second opportunity for an order-dependent
+test to flake, at the worst possible moment: *after* the version-bump commit has merged to
+`main`, where a failure leaves a tagged release with nothing on npm.
+
+That is not hypothetical. `test/lib/bridge-routes-extra.test.js` and
+`test/lib/gui-server-routes3.test.js` each fail intermittently under full-suite load (roughly 1
+run in 8), asserting a status code while a security guard legitimately returns 403. The product
+fails *safe* in both cases — these are test-isolation defects, not product defects — but either
+one could have failed a publish.
+
+What replaced it is deterministic and catches things the test job does not: `check:all-contracts`
+fails on catalog drift (which would otherwise ship a `generated/` snapshot that disagrees with
+the code), license-string inconsistency, Node-version claims, and package-internal path
+resolution. `prepack` still runs `build:gui`, so the tarball contents are unaffected.
+
+Do not "restore" `npm test` here without first fixing the flakes and explaining what new signal
+the second run provides.
+
 ## 2. Pre-release gates
 
 All on the release ref, before the release PR merges:

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "dev:ui": "npm run build:gui && npm link && echo '\\n✓ GUI built and linked. cd into your SF project and run: sfdt ui'",
     "postinstall": "node scripts/postinstall.js",
     "prepack": "npm run build:gui",
-    "prepublishOnly": "npm test && npm run lint"
+    "prepublishOnly": "npm run lint && npm run check:all-contracts"
   },
   "keywords": [
     "salesforce",


### PR DESCRIPTION
## The problem

`prepublishOnly` was `npm test && npm run lint` — it re-ran the entire ~5,200-test suite *inside* `npm publish`.

That run adds no new signal. Both publish jobs already declare it as a hard prerequisite:

```yaml
publish:       needs: [test, gui-build]
publish-beta:  needs: [test, gui-build]
```

So the suite has already passed before either job starts. The only thing the second run contributes is **another opportunity to flake — after the version-bump commit has merged to `main`**, which is the worst possible moment: you end up with a tagged release and nothing on npm.

## This is not hypothetical

While preparing the 0.22.0 release I hit it. Running the full suite repeatedly surfaced **two** order-dependent tests, each failing roughly 1 run in 8:

| Test | Symptom |
|---|---|
| `test/lib/bridge-routes-extra.test.js` → "reports REQUEST_INVALID when the provider is unavailable" | `res.body.ok` is `undefined` |
| `test/lib/gui-server-routes3.test.js` → "rejects path traversal attempts" | expected `400`, got `403` |

Both pass in isolation (3/3 and 26/26) and fail only under full-suite load. **Neither is a product defect** — in both cases a security guard legitimately returns 403 and the test asserts a different status. The product fails *safe*. They are test-isolation defects, and they are pre-existing: neither test nor its subject has changed since v0.21.0.

They are still tracked and worth fixing. But a flaky test should not be able to break a release, and fixing the tests does not fix that structural problem — this does.

## What replaces it

```
"prepublishOnly": "npm run lint && npm run check:all-contracts"
```

Deterministic, seconds not minutes, and it catches things the `test` job does **not**:

- **catalog drift** — would otherwise publish a `generated/` snapshot that disagrees with the shipped code
- license-string consistency across the 7 manifests
- Node-version claims
- auth-doc guidance
- package-internal path resolution (the `import.meta.url` invariant)

`prepack` still runs `build:gui`, so tarball contents are untouched.

## Verification

`npm publish --dry-run` on this branch runs `prepublishOnly` → `prepack` → packs cleanly:

- **300 files**, up exactly one from the pre-change run — `src/lib/config-trust.js`, the file added by #319. A full diff of the packed manifest against the earlier run shows that single addition and nothing dropped.
- All required assets present: `bin/`, `src/`, `scripts/`, `skills/`, `gui/dist/`, `host/installers/`, `host/src/`, `LICENSE`, `README.md`
- No `logs/`, `.sfdt/`, `pr-analysis/`, `generated/`, `tools/`, or `test/` leaked
- `npm run lint` clean, `npm run check:all-contracts` 5/5

## Documented

`RELEASING.md` gains a "Why `prepublishOnly` does not run the test suite" section naming both flaky tests and stating the rule plainly: do not restore `npm test` here without first fixing the flakes and explaining what new signal the second run provides. Otherwise this is exactly the kind of thing someone helpfully reverts.