### PR TITLE
test: retry the CSRF token fetch instead of failing open

### DIFF
--- a/test/setup-supertest-origin.js
+++ b/test/setup-supertest-origin.js
@@ -81,13 +81,44 @@ Test.prototype.end = function patchedEnd(fn) {
     req.set('Authorization', `Bearer ${launchToken}`);
   }
 
+  // A failed token fetch used to fall through silently, sending the real
+  // request with no `X-SFDT-CSRF` header. The server then correctly answered
+  // 403 — and the test failed asserting some unrelated status, with nothing
+  // pointing at the token fetch. That turned any transient hiccup here into a
+  // mystery flake (seen intermittently in bridge-routes-extra, gui-server-routes3
+  // and gui-server-manifest-builder). `/api/csrf-token` is itself rate-limited
+  // (10/min), so a burst of cache misses against one app is a plausible trigger.
+  //
+  // So: retry once, and if it still fails, say so loudly instead of letting the
+  // request go out unauthenticated and fail somewhere confusing.
+  const attach = (token) => {
+    if (key) tokenCache.set(key, token);
+    self.set('X-SFDT-CSRF', token);
+  };
+
   req.end((err, tokenRes) => {
     const token = tokenRes?.body?.token;
     if (!err && token) {
-      if (key) tokenCache.set(key, token);
-      self.set('X-SFDT-CSRF', token);
+      attach(token);
+      return originalEnd.call(self, fn);
     }
-    originalEnd.call(self, fn);
+
+    const retry = request(self.app).get('/api/csrf-token');
+    if (launchToken) retry.set('Authorization', `Bearer ${launchToken}`);
+    retry.end((retryErr, retryRes) => {
+      const retryToken = retryRes?.body?.token;
+      if (!retryErr && retryToken) {
+        attach(retryToken);
+      } else {
+        console.error(
+          `[setup-supertest-origin] could not obtain a CSRF token for ${self.method} ${self.url} — ` +
+            `the request will be sent without one and the server will answer 403. ` +
+            `first attempt: status=${tokenRes?.status} err=${err?.message}; ` +
+            `retry: status=${retryRes?.status} err=${retryErr?.message}`,
+        );
+      }
+      originalEnd.call(self, fn);
+    });
   });
   return self;
 };


### PR DESCRIPTION
## What

`test/setup-supertest-origin.js` transparently fetches a CSRF token for the app under test and attaches `X-SFDT-CSRF`. When that fetch failed it **fell through silently**:

```js
if (!err && token) { /* attach header */ }
originalEnd.call(self, fn);   // sends the request regardless
```

The real request then went out with no CSRF header, the server correctly answered **403**, and the test failed asserting some unrelated status — with nothing in the output pointing at the token fetch. Any transient hiccup in this helper became an unattributable flake.

Now it retries once, and if it still fails it logs exactly what happened (both attempts' status and error) before proceeding.

## Honest scope

**This does not fix the suite instability, and I'm not claiming it does.**

While preparing the 0.22.0 release I saw **four** distinct gui-server route tests flake across ~20 full-suite runs, roughly 1 run in 3–4, a different test each time:

- `bridge-routes-extra.test.js` → "reports REQUEST_INVALID when the provider is unavailable" (`res.body.ok` undefined)
- `gui-server-routes3.test.js` → "rejects path traversal attempts" (403 vs 400)
- `gui-server-manifest-builder.test.js` → "batch-adds items into an existing manifest via relPath"
- `gui-server-routes.test.js` → two `GET /api/check-updates` cases

All pass in isolation. The CSRF fail-open above is a plausible mechanism for the 403-shaped ones — `/api/csrf-token` is itself rate-limited at 10/min, so a burst of cache misses against one app could trip it — but I could **not** reproduce it under instrumentation (6 clean runs with a diagnostic in place), and the `check-updates` failures printed no diagnostic at all, so that hypothesis does not cover them.

What this PR buys is that the **next** occurrence of the 403-shaped variant names itself instead of surfacing as a mystery status assertion.

These are pre-existing — none of the tests or their subjects have changed since v0.21.0 — and none are product defects: in every case diagnosed, the server returned a correct, *stricter* response than the test expected. They also can no longer fail a publish (#320). Tracked for a proper fix.

## Verification

`npm test` run 4× on this branch: 5193/5193 on three, and one run failed the pre-existing `check-updates` pair (unrelated to this change, no diagnostic emitted).