### PR TITLE
fix(extension): renderSfError() — one path for a Salesforce error, plus the sweep that keeps it one (C-FIX-4)

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to `@sfdt/extension` are documented here. Format follows [Ke
 
 ## [Unreleased]
 
+### Fixed
+
+- **A Salesforce error is announced to screen readers, on every surface.** Sixteen features built the org-error panel by hand — `createElement('div')`, `classList.add('sfdt-console', 'sfdt-error')`, `textContent = err.message` — and every one of them set the classes and left off `role="alert"`. A failed query, retrieve or test run was a red box to a sighted user and complete silence to anyone using a screen reader. All sixteen now come from one builder, which cannot forget the role. The panes that are *reused* (the debug-log console, the Execute Anonymous result pane) also give the role back when they stop carrying an error, or the next successful run would be announced as a failure.
+
+### Changed
+
+- **`renderSfError()` — one helper renders a Salesforce error, and nothing else may.** The previous shared builder took a single string, which was the affordance behind the sixteen one-by-one fixes in the last release: with the org's own text and our "what to do" line joined into one string, keeping them apart was a `white-space` rule each surface had to remember, and several instead resolved the ambiguity by throwing the org's real error away. `renderSfError()` / `setSfError()` emit the two as separate element nodes, so a block box cannot run into the one above it whatever CSS the host page brings, and a caller can no longer keep the wrong half because it no longer does the joining. The split (`splitUserFacingMessage`) now lives beside the join (`buildUserFacingMessage`) in `lib/sf-error-guidance.ts`: the newline between the org's records is a separator, not formatting, and a producer and consumer that agree about that by coincidence eventually stop agreeing. Our guidance also stops rendering in the org's alarm colour — advice in the same red as the failure reads as more of the failure rather than as the way out of it.
+- **The destructive-manifest banner is a callout, not an error console.** It carries our own warning prose, not an org error, which `lib/ui-styles.ts` has always distinguished at `.sfdt-callout`; wearing the error console's classes made the one *static* banner in the extension look like a live Salesforce failure and dragged it into every sweep aimed at the org-error path.
+
+### Added
+
+- **A contract sweep (`test/sf-error-panel-contract.test.ts`) that fails the seventeenth hand-roll.** The two guards that came out of the last release pin what a correct error panel *looks* like; a brand-new hand-rolled panel that happens to satisfy both still passes them, which is exactly how sixteen of them accumulated. This one pins the code *path*: `.sfdt-console` + `.sfdt-error` on one element is the Salesforce error block, and only `ui/panels.ts` may build it. The rule is the class **pair**, not `.sfdt-error` alone — that is also the red `.sfdt-pill`, which several features legitimately apply to a status chip. Per golden principle #12 the sweep excludes the artifacts that define it: the helper, the stylesheet declaring the classes, and this file, each listed by name with the reason it cannot be a violation, plus a test that fails a stale exclusion.
+
 ## [0.12.0] - 2026-08-03
 
 ### Added

--- a/extension/UI-SYSTEM.md
+++ b/extension/UI-SYSTEM.md
@@ -22,7 +22,7 @@ to.
 | 1. Tokens | `lib/tokens.ts` | Colour, spacing, radius, type, shadow — as CSS custom properties | Everything |
 | 2. Components | `lib/ui-styles.ts` | 107 reusable classes | every UI file |
 | 3. Icons | `lib/icons.ts` | 53 inline SVGs + feature-id → glyph map | 8 files |
-| 4. Controls | `lib/ui-controls.ts`, `lib/code-editor.ts`, `ui/panels.ts`, `ui/confirm-dialog.ts`, `ui/meter-card.ts`, `ui/node-graph.ts`, `ui/apex-limit-tiles.ts`, `ui/apex-log-console.ts` | `button()`, `field()`, `glyph()`, `setLabel()`, `setTone()`, `toolbar()`, `createCodeEditor()`, `errorPanel()`, `loadingPanel()`, `emptyPanel()`, `busyOverlay()`, `confirmDialog()`, `meterCard()`, `buildNodeGraphSvg()`, `createLimitTiles()`, `renderApexLogBody()` | every UI file |
+| 4. Controls | `lib/ui-controls.ts`, `lib/code-editor.ts`, `ui/panels.ts`, `ui/confirm-dialog.ts`, `ui/meter-card.ts`, `ui/node-graph.ts`, `ui/apex-limit-tiles.ts`, `ui/apex-log-console.ts` | `button()`, `field()`, `glyph()`, `setLabel()`, `setTone()`, `toolbar()`, `createCodeEditor()`, `renderSfError()`, `setSfError()`, `loadingPanel()`, `emptyPanel()`, `busyOverlay()`, `confirmDialog()`, `meterCard()`, `buildNodeGraphSvg()`, `createLimitTiles()`, `renderApexLogBody()` | every UI file |
 | 5. Behaviour | `ui/menu.ts`, `ui/shadow-host.ts`, `ui/present-view.ts` | Dismissal, **focus trap**, focus restore, mounting | Menus, injected UI, every feature view |
 
 **Layers 2 and 4 are not the same thing, and layer 2 alone did not work.** The
@@ -157,6 +157,47 @@ Guarded by `test/ui-controls.test.ts` (12 tests) and a drift guard in
 `test/ui-styles.test.ts`: a **migrated** file may not contain a cssText string
 with `padding` + `border-radius` + `cursor: pointer` — the hand-rolled-button
 signature. Files join `BUTTON_MIGRATED` in the same commit that converts them.
+
+#### Layer 4, continued — the Salesforce error panel (`ui/panels.ts`)
+
+```
+renderSfError(error, { doc?, guidance? })   →  a new panel
+setSfError(el, error, { doc?, guidance? })  →  fill a panel the caller owns
+clearSfError(el)                            →  empty it, and drop role="alert"
+```
+
+The same lesson as `button()`, learned the same way. `.sfdt-console.sfdt-error`
+had existed since the design-system pass and **sixteen** features still built
+the block by hand, because `createElement('div')` + `classList.add(…)` +
+`.textContent = err.message` was the shorter path. All sixteen omitted
+`role="alert"`, so a failure was a red box to a sighted user and silence to a
+screen reader; PR #308 then had to fix each of them individually for a
+*separate* defect — collapsing our guidance line into the org's own text, and in
+several cases discarding the org's error entirely.
+
+Two things these enforce that a class cannot:
+
+- **`role="alert"` is not optional.** It comes with the block, including on
+  `setSfError`, which is what a long-lived pane (the debug-log console, the
+  Execute Anonymous result pane) uses when it turns into an error surface.
+  `clearSfError` takes the role back off, or the pane announces the *next*
+  thing rendered into it as a failure.
+- **The org's text and our guidance are separate NODES.** The joining happens in
+  `lib/sf-error-guidance.ts` (`buildUserFacingMessage`) and the splitting in the
+  same file (`splitUserFacingMessage`), so producer and consumer of the newline
+  contract sit next to each other. A caller no longer composes the string, so it
+  can no longer keep the wrong half — and a block box cannot run into the one
+  above it whatever `white-space` the surface carries.
+
+`.sfdt-console.sfdt-error` is for the **org's** text. Our own prose — a
+destructive-mode caution, a truncation warning — is `.sfdt-callout`; the comment
+at that rule in `lib/ui-styles.ts` draws the line. The destructive-manifest
+banner in `metadata-retrieve` was on the wrong side of it and moved.
+
+Guarded by `test/sf-error-panel-contract.test.ts`: **no file outside
+`ui/panels.ts` may apply the class pair.** That is the piece the two behavioural
+guards (`error-render-newlines`, `sf-error-guidance`) could not supply — they
+pin what a correct panel looks like, and a fresh hand-roll can satisfy both.
 
 ### Layer 5 — behaviour (`ui/menu.ts`)
 

--- a/extension/features/ai-assistant.ts
+++ b/extension/features/ai-assistant.ts
@@ -5,6 +5,7 @@ import { getSalesforceApi, type SalesforceApiClient } from '../lib/salesforce-ap
 import { loadSettings } from '../lib/settings.js';
 import { createBridgeClient, LONG_RUNNING_TIMEOUT_MS } from '../lib/sfdt-bridge.js';
 import { presentView, type ViewHandle } from '../ui/present-view.js';
+import { renderSfError } from '../ui/panels.js';
 import type { SfdtRequest, SfdtResponse } from '@sfdt/flow-core/bridge-contract';
 import { button } from '../lib/ui-controls.js';
 import { copyToClipboard } from '../ui/clipboard.js';
@@ -204,11 +205,7 @@ export function createAiAssistantFeature(options: AiAssistantOptions = {}): Feat
       resultArea.style.cssText = 'margin-top: 12px;';
 
       const renderResultError = (message: string): void => {
-        while (resultArea.firstChild) resultArea.removeChild(resultArea.firstChild);
-        const panel = doc.createElement('div');
-        panel.classList.add('sfdt-console', 'sfdt-error');
-        panel.textContent = message;
-        resultArea.appendChild(panel);
+        resultArea.replaceChildren(renderSfError(message, { doc }));
       };
 
       const renderResult = (responseText: string, provider: string): void => {

--- a/extension/features/apex-anonymous.ts
+++ b/extension/features/apex-anonymous.ts
@@ -18,6 +18,7 @@ import { loadSettings, registerSettingsShape } from '../lib/settings.js';
 import { showToast } from '../ui/toast.js';
 import { recordActivity } from '../lib/activity-log.js';
 import { presentView, type ViewHandle } from '../ui/present-view.js';
+import { clearSfError, setSfError } from '../ui/panels.js';
 import { parseApexLog } from '../lib/apex-log/index.js';
 import type { ParsedLog } from '../lib/apex-log/types.js';
 import { presentApexLogAnalyzer } from '../ui/apex-log-analyzer.js';
@@ -498,6 +499,9 @@ export function createApexAnonymousFeature(options: ApexAnonymousOptions = {}): 
       limits.render(null);
       resultPane.style.display = 'none';
       resultPane.className = 'sfdt-console';
+      // Reused pane: drop the role="alert" a previous failure left on it, or
+      // this run's output is announced as an error.
+      clearSfError(resultPane);
       setStatus('', 'Running');
 
       // Trace-flag setup is best-effort: failing to arm log capture must never
@@ -618,9 +622,8 @@ export function createApexAnonymousFeature(options: ApexAnonymousOptions = {}): 
         }
       } catch (err) {
         setStatus('error', 'Failed');
-        resultPane.textContent = err instanceof Error ? err.message : String(err);
+        setSfError(resultPane, err, { doc });
         resultPane.style.display = 'block';
-        resultPane.className = 'sfdt-console sfdt-error';
       } finally {
         runBtn.disabled = false;
         analyzeBtn.disabled = false;

--- a/extension/features/apex-test-runner.ts
+++ b/extension/features/apex-test-runner.ts
@@ -11,6 +11,7 @@ import {
 } from '../lib/salesforce-api.js';
 import { showToast } from '../ui/toast.js';
 import { presentView, type ViewHandle } from '../ui/present-view.js';
+import { renderSfError } from '../ui/panels.js';
 import { button, toolbar } from '../lib/ui-controls.js';
 
 // ---------------------------------------------------------------------------
@@ -106,10 +107,7 @@ export function createApexTestRunnerFeature(options: ApexTestRunnerOptions = {})
   }
 
   function renderError(results: HTMLElement, status: HTMLSpanElement, message: string): void {
-    const panel = doc.createElement('div');
-    panel.classList.add('sfdt-console', 'sfdt-error');
-    panel.textContent = message;
-    results.appendChild(panel);
+    results.appendChild(renderSfError(message, { doc }));
     status.textContent = 'Failed';
   }
 

--- a/extension/features/bridge-tools.ts
+++ b/extension/features/bridge-tools.ts
@@ -23,6 +23,7 @@ import { loadSettings } from '../lib/settings.js';
 import { showToast } from '../ui/toast.js';
 import { recordActivity } from '../lib/activity-log.js';
 import { presentView, type ViewHandle } from '../ui/present-view.js';
+import { renderSfError } from '../ui/panels.js';
 import type { SfdtRequest, SfdtResponse } from '@sfdt/flow-core/bridge-contract';
 import { button, toolbar } from '../lib/ui-controls.js';
 
@@ -106,10 +107,7 @@ function createBridgeToolFeature(spec: ToolSpec, options: BridgeToolOptions): Fe
   }
 
   function renderError(results: HTMLElement, status: HTMLSpanElement, message: string): void {
-    const panel = doc.createElement('div');
-    panel.classList.add('sfdt-console', 'sfdt-error');
-    panel.textContent = message;
-    results.appendChild(panel);
+    results.appendChild(renderSfError(message, { doc }));
     status.textContent = 'Failed';
     // The single failure sink for runOnce — every early return routes through
     // here, so one call covers a bad request, a !ok bridge reply, and a throw.

--- a/extension/features/code-coverage.ts
+++ b/extension/features/code-coverage.ts
@@ -14,7 +14,7 @@ import {
 } from '@sfdt/flow-core';
 import { button, toolbar } from '../lib/ui-controls.js';
 import { meterCard, meterGrid, type MeterTone } from '../ui/meter-card.js';
-import { emptyPanel } from '../ui/panels.js';
+import { emptyPanel, renderSfError } from '../ui/panels.js';
 
 // Per-class coverage shaping/banding now lives in @sfdt/flow-core so the Chrome
 // viewer, the GUI Coverage page, and `sfdt coverage` band identically. These
@@ -118,10 +118,7 @@ export function createCodeCoverageFeature(options: CodeCoverageOptions = {}): Fe
       }
       results.appendChild(grid);
     } catch (err) {
-      const errorPanel = doc.createElement('div');
-      errorPanel.classList.add('sfdt-console', 'sfdt-error');
-      errorPanel.textContent = err instanceof Error ? err.message : String(err);
-      results.appendChild(errorPanel);
+      results.appendChild(renderSfError(err, { doc }));
       status.textContent = 'Failed';
     }
   }

--- a/extension/features/debug-log-viewer.ts
+++ b/extension/features/debug-log-viewer.ts
@@ -12,7 +12,7 @@ import { button, field, glyph, toolbar } from '../lib/ui-controls.js';
 import { createLimitTiles, pickLimitSnapshot } from '../ui/apex-limit-tiles.js';
 import { renderApexLogBody } from '../ui/apex-log-console.js';
 import { confirmDialog } from '../ui/confirm-dialog.js';
-import { errorPanel } from '../ui/panels.js';
+import { clearSfError, renderSfError, setSfError } from '../ui/panels.js';
 
 const DEBUG_LOG_SETTINGS_SCHEMA = z.object({
   pageSize: z.number().int().min(1).max(200).default(50),
@@ -240,7 +240,7 @@ export function createDebugLogViewerFeature(options: DebugLogViewerOptions = {})
     // Org-side failure (session, permissions, a bad query). A div rather than a
     // <pre> on purpose: the log pane below is the only <pre> in this view, and
     // tests — like a user's eye — reach for it by that.
-    const errPanel = errorPanel('', doc);
+    const errPanel = renderSfError(null, { doc });
     errPanel.style.display = 'none';
     main.appendChild(errPanel);
 
@@ -316,6 +316,9 @@ export function createDebugLogViewerFeature(options: DebugLogViewerOptions = {})
       tr.setAttribute('aria-current', 'true');
       logPane.style.display = 'block';
       logPane.className = 'sfdt-console';
+      // The pane is reused, so a previous failure's role="alert" would still be
+      // on it — announcing the next log body as an error.
+      clearSfError(logPane);
       logPane.textContent = 'Loading log…';
       limits.render(null);
       try {
@@ -326,8 +329,7 @@ export function createDebugLogViewerFeature(options: DebugLogViewerOptions = {})
         // costing a second fetch behind a second button.
         limits.render(pickLimitSnapshot(parseApexLog(raw).limits));
       } catch (err) {
-        logPane.className = 'sfdt-console sfdt-error';
-        logPane.textContent = err instanceof Error ? err.message : String(err);
+        setSfError(logPane, err, { doc });
       }
     }
 
@@ -447,6 +449,7 @@ export function createDebugLogViewerFeature(options: DebugLogViewerOptions = {})
       try {
         const result = await api.toolingQuery<ApexLogRow>(buildApexLogQuery(config.pageSize));
         loaded = result.records;
+        clearSfError(errPanel);
         errPanel.style.display = 'none';
         renderRows();
       } catch (err) {
@@ -454,7 +457,7 @@ export function createDebugLogViewerFeature(options: DebugLogViewerOptions = {})
         while (tbody.firstChild) tbody.removeChild(tbody.firstChild);
         selectedRow = null;
         status.textContent = '';
-        errPanel.textContent = err instanceof Error ? err.message : String(err);
+        setSfError(errPanel, err, { doc });
         errPanel.style.display = 'block';
       }
     }

--- a/extension/features/dependency-explorer.ts
+++ b/extension/features/dependency-explorer.ts
@@ -6,6 +6,7 @@ import {
 } from '../lib/salesforce-api.js';
 import { showToast } from '../ui/toast.js';
 import { presentView, type ViewHandle } from '../ui/present-view.js';
+import { renderSfError } from '../ui/panels.js';
 import {
   resolveQueryFor,
   referencesQuery,
@@ -144,10 +145,7 @@ export function createDependencyExplorerFeature(
       results.appendChild(renderSection('References (this → others)', refGroups));
       results.appendChild(renderSection('Referenced by (others → this)', refByGroups));
     } catch (err) {
-      const errorPanel = doc.createElement('div');
-      errorPanel.classList.add('sfdt-console', 'sfdt-error');
-      errorPanel.textContent = err instanceof Error ? err.message : String(err);
-      results.appendChild(errorPanel);
+      results.appendChild(renderSfError(err, { doc }));
       status.textContent = 'Failed';
     }
   }

--- a/extension/features/field-impact.ts
+++ b/extension/features/field-impact.ts
@@ -38,6 +38,7 @@ import {
   type WorkflowFieldUpdateCandidate,
 } from '../lib/field-impact.js';
 import { presentView, type ViewHandle } from '../ui/present-view.js';
+import { renderSfError } from '../ui/panels.js';
 import { escapeSoql } from '@sfdt/flow-core';
 import { button, toolbar } from '../lib/ui-controls.js';
 
@@ -873,10 +874,7 @@ export function createFieldImpactFeature(options: FieldImpactOptions = {}): Fiel
         results.appendChild(buildLegend());
       } catch (err) {
         status.textContent = 'Failed';
-        const errorPanel = doc.createElement('div');
-        errorPanel.classList.add('sfdt-console', 'sfdt-error');
-        errorPanel.textContent = message(err);
-        results.appendChild(errorPanel);
+        results.appendChild(renderSfError(message(err), { doc }));
       } finally {
         runBtn.disabled = false;
       }

--- a/extension/features/flow-quality.ts
+++ b/extension/features/flow-quality.ts
@@ -8,6 +8,7 @@ import type { Feature } from '../lib/feature-registry.js';
 import { getSalesforceApi, type SalesforceApiClient } from '../lib/salesforce-api.js';
 import { showToast } from '../ui/toast.js';
 import { presentView, type ViewHandle } from '../ui/present-view.js';
+import { renderSfError } from '../ui/panels.js';
 import { runFlowQuality, type FlowQualityReport } from '@sfdt/flow-core';
 import { button, toolbar } from '../lib/ui-controls.js';
 
@@ -254,10 +255,7 @@ export function createFlowQualityFeature(options: FlowQualityFeatureOptions = {}
         renderReport(results, runFlowQuality(metadata, { flowApiName: name }));
         status.textContent = 'Done';
       } catch (err) {
-        const panel = doc.createElement('div');
-        panel.classList.add('sfdt-console', 'sfdt-error');
-        panel.textContent = err instanceof Error ? err.message : String(err);
-        results.appendChild(panel);
+        results.appendChild(renderSfError(err, { doc }));
         status.textContent = 'Failed';
       } finally {
         runBtn.disabled = false;

--- a/extension/features/flow-trigger-explorer-enhancer.ts
+++ b/extension/features/flow-trigger-explorer-enhancer.ts
@@ -16,6 +16,7 @@ import { detectContext, CONTEXTS } from '../lib/context-detector.js';
 import type { Feature } from '../lib/feature-registry.js';
 import { getSalesforceApi, type SalesforceApiClient } from '../lib/salesforce-api.js';
 import { presentView, type ViewHandle } from '../ui/present-view.js';
+import { renderSfError } from '../ui/panels.js';
 import { button, toolbar } from '../lib/ui-controls.js';
 
 // FlowDefinitionView is a standard, read-only object queryable via the Data API.
@@ -237,10 +238,7 @@ export function createFlowTriggerExplorerEnhancerFeature(
       }
       renderGroups(doc, results, groups, win.location.origin);
     } catch (err) {
-      const panel = doc.createElement('div');
-      panel.classList.add('sfdt-console', 'sfdt-error');
-      panel.textContent = err instanceof Error ? err.message : String(err);
-      results.appendChild(panel);
+      results.appendChild(renderSfError(err, { doc }));
       status.textContent = 'Failed';
     }
   }

--- a/extension/features/metadata-retrieve.ts
+++ b/extension/features/metadata-retrieve.ts
@@ -1291,9 +1291,16 @@ export function createMetadataRetrieveFeature(options: {
     xmlDiv.appendChild(modeRow);
 
     // Destructive warning banner (P5-5): deploying the pair DELETES components.
+    //
+    // '.sfdt-callout.sfdt-bad', not the error console. It carries OUR prose, not
+    // an org error — the distinction lib/ui-styles.ts draws at '.sfdt-callout':
+    // the console is a monospace block for the org's own text. It had been
+    // wearing the error console's classes, which made it the one static banner
+    // that looked like a Salesforce failure and put it inside every sweep aimed
+    // at the org-error path.
     warningBannerEl = doc.createElement('div');
     warningBannerEl.setAttribute('role', 'alert');
-    warningBannerEl.classList.add('sfdt-console', 'sfdt-error');
+    warningBannerEl.classList.add('sfdt-callout', 'sfdt-bad');
     warningBannerEl.style.display = 'none';
     const warnStrong = doc.createElement('strong');
     warnStrong.textContent = 'Destructive manifest — deploying this pair DELETES the listed components from the org. ';

--- a/extension/features/org-limits.ts
+++ b/extension/features/org-limits.ts
@@ -8,6 +8,7 @@ import { showToast } from '../ui/toast.js';
 import { presentView, type ViewHandle } from '../ui/present-view.js';
 import { button, toolbar } from '../lib/ui-controls.js';
 import { meterCard, meterGrid, type MeterTone } from '../ui/meter-card.js';
+import { renderSfError } from '../ui/panels.js';
 import { copyToClipboard } from '../ui/clipboard.js';
 
 export interface LimitRow {
@@ -118,10 +119,7 @@ export function createOrgLimitsFeature(options: OrgLimitsOptions = {}): Feature 
       body.appendChild(grid);
       return raw;
     } catch (err) {
-      const errorPanel = doc.createElement('div');
-      errorPanel.classList.add('sfdt-console', 'sfdt-error');
-      errorPanel.textContent = err instanceof Error ? err.message : String(err);
-      body.appendChild(errorPanel);
+      body.appendChild(renderSfError(err, { doc }));
       status.textContent = 'Failed';
       return null;
     }

--- a/extension/features/rest-explore.ts
+++ b/extension/features/rest-explore.ts
@@ -12,7 +12,7 @@ import { showToast } from '../ui/toast.js';
 import { presentView, type ViewHandle } from '../ui/present-view.js';
 import { button, toolbar } from '../lib/ui-controls.js';
 import { openMenu } from '../ui/menu.js';
-import { errorPanel as buildErrorPanel } from '../ui/panels.js';
+import { clearSfError, renderSfError, setSfError } from '../ui/panels.js';
 import { createHistory } from '../lib/history.js';
 import { copyToClipboard } from '../ui/clipboard.js';
 
@@ -136,7 +136,7 @@ export function createRestExploreFeature(options: RestExploreOptions = {}): Feat
     status.className = 'sfdt-muted';
     main.appendChild(status);
 
-    const errorPanel = buildErrorPanel('', doc);
+    const errorPanel = renderSfError(null, { doc });
     errorPanel.style.display = 'none';
     main.appendChild(errorPanel);
 
@@ -216,14 +216,14 @@ export function createRestExploreFeature(options: RestExploreOptions = {}): Feat
     });
 
     function showError(message: string): void {
-      errorPanel.textContent = message;
+      setSfError(errorPanel, message, { doc });
       errorPanel.style.display = 'block';
       responsePane.style.display = 'none';
       copyBtn.style.display = 'none';
     }
 
     function clearError(): void {
-      errorPanel.textContent = '';
+      clearSfError(errorPanel);
       errorPanel.style.display = 'none';
     }
 

--- a/extension/features/schema-browser.ts
+++ b/extension/features/schema-browser.ts
@@ -28,7 +28,7 @@ import { SF_API_VERSION } from '../lib/api-version.js';
 import { escapeSoql } from '../lib/escape.js';
 import { button, field, glyph, toolbar } from '../lib/ui-controls.js';
 import { buildNodeGraphSvg } from '../ui/node-graph.js';
-import { errorPanel, loadingPanel } from '../ui/panels.js';
+import { loadingPanel, renderSfError } from '../ui/panels.js';
 import { openMenu } from '../ui/menu.js';
 import { triggerDownload, exportFilename } from '../lib/download.js';
 import { recordsToCsv, recordsToJson } from './soql-runner.js';
@@ -662,9 +662,9 @@ export function createSchemaBrowserFeature(options: SchemaBrowserOptions = {}): 
         }
         if (entry.status === 'error' || !entry.data) {
           canvas.appendChild(
-            errorPanel(
+            renderSfError(
               entry.error ? `Could not load ${root} — ${entry.error}` : `Could not load ${root}.`,
-              doc,
+              { doc },
             ),
           );
           return;
@@ -751,11 +751,11 @@ export function createSchemaBrowserFeature(options: SchemaBrowserOptions = {}): 
       }
       if (describe.status === 'error' || !describe.data) {
         fieldCountLine.textContent = '';
-        const err = errorPanel(
+        const err = renderSfError(
           describe.error
             ? `Failed to load object describe — ${describe.error}`
             : 'Failed to load object describe.',
-          doc,
+          { doc },
         );
 
         detailScroll.appendChild(err);

--- a/extension/features/soap-explore.ts
+++ b/extension/features/soap-explore.ts
@@ -11,6 +11,7 @@ import { presentView, type ViewHandle } from '../ui/present-view.js';
 import { SF_API_VERSION } from '../lib/api-version.js';
 import { button, toolbar } from '../lib/ui-controls.js';
 import { openMenu } from '../ui/menu.js';
+import { clearSfError, renderSfError, setSfError } from '../ui/panels.js';
 import { createHistory } from '../lib/history.js';
 import { copyToClipboard } from '../ui/clipboard.js';
 
@@ -204,8 +205,7 @@ export function createSoapExploreFeature(options: {
     statusPanel.className = 'sfdt-muted';
     main.appendChild(statusPanel);
 
-    const errorPanel = doc.createElement('div');
-    errorPanel.classList.add('sfdt-console', 'sfdt-error');
+    const errorPanel = renderSfError(null, { doc });
     errorPanel.style.display = 'none';
     main.appendChild(errorPanel);
 
@@ -284,14 +284,14 @@ export function createSoapExploreFeature(options: {
     });
 
     function showError(message: string): void {
-      errorPanel.textContent = message;
+      setSfError(errorPanel, message, { doc });
       errorPanel.style.display = 'block';
       responsePane.style.display = 'none';
       copyBtn.style.display = 'none';
     }
 
     function clearError(): void {
-      errorPanel.textContent = '';
+      clearSfError(errorPanel);
       errorPanel.style.display = 'none';
     }
 

--- a/extension/features/soql-runner.ts
+++ b/extension/features/soql-runner.ts
@@ -18,6 +18,7 @@ import { recordActivity } from '../lib/activity-log.js';
 import { showToast } from '../ui/toast.js';
 import { presentView, type ViewHandle } from '../ui/present-view.js';
 import { openMenu, type MenuAction } from '../ui/menu.js';
+import { clearSfError, renderSfError, setSfError } from '../ui/panels.js';
 import { button, setLabel, toolbar } from '../lib/ui-controls.js';
 import { createHistory } from '../lib/history.js';
 import { copyToClipboard } from '../ui/clipboard.js';
@@ -956,9 +957,7 @@ export function createSoqlRunnerFeature(options: SoqlRunnerOptions = {}): SoqlRu
     runRow.appendChild(status);
     main.appendChild(runRow);
 
-    const errorPanel = doc.createElement('div');
-    errorPanel.setAttribute('role', 'alert');
-    errorPanel.classList.add('sfdt-console', 'sfdt-error');
+    const errorPanel = renderSfError(null, { doc });
     errorPanel.style.display = 'none';
     main.appendChild(errorPanel);
 
@@ -1136,7 +1135,7 @@ export function createSoqlRunnerFeature(options: SoqlRunnerOptions = {}): SoqlRu
 
     function showError(message: string): void {
       abortExport();
-      errorPanel.textContent = message;
+      setSfError(errorPanel, message, { doc });
       errorPanel.style.display = 'block';
       resultsWrap.style.display = 'none';
       explainPanel.style.display = 'none';
@@ -1144,7 +1143,7 @@ export function createSoqlRunnerFeature(options: SoqlRunnerOptions = {}): SoqlRu
     }
 
     function clearError(): void {
-      errorPanel.textContent = '';
+      clearSfError(errorPanel);
       errorPanel.style.display = 'none';
     }
 

--- a/extension/features/trace-flags.ts
+++ b/extension/features/trace-flags.ts
@@ -22,6 +22,7 @@ import { SF_API_VERSION } from '../lib/api-version.js';
 import { loadSettings, registerSettingsShape } from '../lib/settings.js';
 import { showToast } from '../ui/toast.js';
 import { presentView, type ViewHandle } from '../ui/present-view.js';
+import { renderSfError } from '../ui/panels.js';
 import { setTone, button } from '../lib/ui-controls.js';
 import { storageGet, storageSet } from '../lib/storage.js';
 
@@ -600,10 +601,7 @@ export function createTraceFlagsFeature(options: TraceFlagsOptions = {}): Featur
         tick = setInterval(refreshCountdowns, 1000);
       } catch (err) {
         status.textContent = '';
-        const errPanel = doc.createElement('div');
-        errPanel.classList.add('sfdt-console', 'sfdt-error');
-        errPanel.textContent = err instanceof Error ? err.message : String(err);
-        table.appendChild(errPanel);
+        table.appendChild(renderSfError(err, { doc }));
       }
     }
 

--- a/extension/lib/sf-error-guidance.ts
+++ b/extension/lib/sf-error-guidance.ts
@@ -174,3 +174,45 @@ export function buildUserFacingMessage(
 
   return lines.join('\n');
 }
+
+/** The two halves of a composed message: the org's own text, then our notes. */
+export interface SplitUserFacingMessage {
+  /** The org's own wording — line one, never ours, never truncated. */
+  orgText: string;
+  /** Everything buildUserFacingMessage appended: codes, fields, advice, `Also:` records. */
+  notes: string[];
+}
+
+/**
+ * The inverse of `buildUserFacingMessage`, and the reason it lives here rather
+ * than in the renderer: the newline is a RECORD SEPARATOR, not formatting, and
+ * a producer and consumer that agree about that by coincidence eventually stop
+ * agreeing. Both halves of the contract are now in one file.
+ *
+ * Every renderer that shows a Salesforce error splits here and emits each part
+ * as its own node, so the guidance cannot run into the org's own text no matter
+ * what CSS the surface happens to carry. Collapsing the two was the defect
+ * behind the 16 one-by-one fixes in PR #308.
+ */
+export function splitUserFacingMessage(message: unknown): SplitUserFacingMessage {
+  const text = typeof message === 'string' ? message : '';
+  const [head = '', ...rest] = text.split('\n');
+  // A blank line carries no record. Dropping it here rather than in the
+  // renderer keeps every surface's node count identical for the same error.
+  return { orgText: head, notes: rest.filter((line) => line.trim() !== '') };
+}
+
+/**
+ * Normalises whatever a `catch` caught into the string a panel renders.
+ *
+ * Fourteen features had their own `err instanceof Error ? err.message :
+ * String(err)`, which is how one of them ends up rendering `[object Object]`
+ * and nobody notices. `null`/`undefined` render as nothing rather than as the
+ * words "null"/"undefined".
+ */
+export function errorText(error: unknown): string {
+  if (error === null || error === undefined) return '';
+  if (error instanceof Error) return error.message;
+  if (typeof error === 'string') return error;
+  return String(error);
+}

--- a/extension/lib/ui-styles.ts
+++ b/extension/lib/ui-styles.ts
@@ -856,6 +856,32 @@ export const SFDT_COMPONENT_CSS = `
 }
 .sfdt-console.sfdt-error { color: var(--sfdt-color-error-text); }
 
+/* The two parts of a rendered Salesforce error, emitted by renderSfError() in
+   ui/panels.ts. They are separate BLOCKS rather than one pre-wrapped string
+   because the newline between the org's text and our "what to do" line was
+   only ever preserved by a white-space rule, and 16 surfaces each hand-rolled
+   that rule until one of them didn't (PR #308). A block box cannot collapse
+   into the sibling above it whatever CSS the host page throws at us.
+
+   Both keep 'white-space: pre-wrap' anyway: an org message can be multi-line
+   inside a single record (Apex stack traces are), and the guard in
+   test/error-render-newlines.test.ts reads the property out of this sheet.
+
+   The note is body text, not error text: the red belongs to the org's wording,
+   and our advice sitting in the same alarm colour reads as more of the failure
+   rather than as the way out of it. Both tokens are theme-resolved, so this is
+   correct in light and dark without a special case. */
+.sfdt-sf-error-text {
+  display: block;
+  white-space: pre-wrap;
+}
+.sfdt-sf-error-note {
+  display: block;
+  white-space: pre-wrap;
+  margin-top: var(--sfdt-space-2);
+  color: var(--sfdt-color-text);
+}
+
 /* Per-line tinting for a raw Apex debug log. A log is line-oriented rather than
    token-oriented, so classification is by event type and the class goes on the
    whole line — there is nothing to highlight inside it.

--- a/extension/test/error-render-newlines.test.ts
+++ b/extension/test/error-render-newlines.test.ts
@@ -64,7 +64,18 @@ function rendersAnErrorValue(expression: string): boolean {
 // identifier, and why it cannot carry a multiline error; and a test below
 // asserts every entry still matches real source, so a stale exemption fails
 // loudly instead of quietly widening the hole it was cut for.
-const EXEMPT: { file: string; name: string; because: string }[] = [];
+const EXEMPT: { file: string; name: string; because: string }[] = [
+  {
+    file: 'ui/panels.ts',
+    name: 'el',
+    because:
+      "loadingPanel()'s `el.textContent = message` — a caller-supplied 'Loading …' line, never a " +
+      'thrown error; the error builder in the same file emits its parts as separate nodes and ' +
+      'assigns no textContent at all. This entry only became necessary when that builder stopped ' +
+      "reusing the name `el`: until then loadingPanel passed on the error panel's class, which is " +
+      'the same-name blind spot the guard warns about two comments up.',
+  },
+];
 
 function isExempt(relFile: string, name: string): boolean {
   return EXEMPT.some((e) => e.file === relFile && e.name === name);
@@ -114,7 +125,8 @@ const WHITE_SPACE_CLASSES: ReadonlySet<string> = (() => {
 // an element assigned from one is covered by construction — and the guard has
 // to know that, or centralising the panel makes this check MORE likely to fire.
 // Named builders only, not any call: `const p = renderThing()` says nothing.
-const PANEL_BUILDERS = /\b(?:build)?(?:errorPanel|loadingPanel|emptyPanel|ErrorPanel|LoadingPanel|EmptyPanel)\s*\(/;
+const PANEL_BUILDERS =
+  /\b(?:build)?(?:renderSfError|errorPanel|loadingPanel|emptyPanel|ErrorPanel|LoadingPanel|EmptyPanel)\s*\(/;
 
 function fromPanelBuilder(source: string, name: string): boolean {
   const pattern = new RegExp(`\\b(?:const|let|var)\\s+${name}\\s*=\\s*[^;]*`, 'g');
@@ -191,20 +203,26 @@ describe('a rendered Salesforce error keeps its newlines', () => {
     // point is that the guard now HOLDS them to it, so dropping the rule fails
     // here rather than shipping.
     //
-    // HOW they satisfy it differs now, and that is the whole point of asserting
-    // the union rather than the cssText: rest-explore takes its panel from
-    // ui/panels.ts, the others still declare the rule locally. A test that
-    // insisted on cssText would have made migrating them look like a
-    // regression.
+    // HOW they satisfy it has now changed twice, which is the whole point of
+    // asserting the union rather than one mechanism. They first declared the
+    // rule locally; rest-explore then took its panel from ui/panels.ts; all
+    // three now route the message through `setSfError`, which emits the org's
+    // text and the guidance as separate NODES so there is no newline left to
+    // collapse. A test pinned to `errorPanel.textContent = message` would have
+    // read the strongest of those three states as a regression.
     for (const rel of [
       'features/soql-runner.ts',
       'features/rest-explore.ts',
       'features/soap-explore.ts',
     ]) {
       const source = readFileSync(path.join(ROOT, rel), 'utf8');
-      expect(source, rel).toMatch(/errorPanel\.textContent\s*=\s*message/);
+      const fills = /setSfError\(errorPanel, message/.test(source);
+      expect(source, `${rel}: the org error must still reach a shared panel`).toMatch(
+        /errorPanel\.textContent\s*=\s*message|setSfError\(errorPanel, message/,
+      );
       const css = cssTextFor(source, 'errorPanel');
       const covered =
+        fills ||
         (css !== null && HAS_WHITE_SPACE.test(css)) ||
         setsWhiteSpaceDirectly(source, 'errorPanel') ||
         setsWhiteSpaceByClass(source, 'errorPanel') ||
@@ -268,6 +286,7 @@ describe('a rendered Salesforce error keeps its newlines', () => {
     // Centralising the error panel must not make this guard fire on every file
     // that adopted it — and must not become a blanket pass for any assignment.
     expect(fromPanelBuilder("const p = errorPanel(msg, doc);\n", 'p')).toBe(true);
+    expect(fromPanelBuilder("const p = renderSfError(err, { doc });\n", 'p')).toBe(true);
     expect(fromPanelBuilder("const p = loadingPanel();\n", 'p')).toBe(true);
     expect(fromPanelBuilder("const p = doc.createElement('div');\n", 'p')).toBe(false);
     expect(fromPanelBuilder("const p = renderSomething();\n", 'p')).toBe(false);

--- a/extension/test/org-limits.test.ts
+++ b/extension/test/org-limits.test.ts
@@ -103,4 +103,32 @@ describe('org-limits — modal', () => {
 
     expect(document.body.textContent).toContain('boom');
   });
+
+  it('announces the failure to a screen reader', async () => {
+    // This feature was one of fifteen that hand-rolled the error block and set
+    // the classes without `role="alert"` — visually a red panel, silence to
+    // assistive tech. It now comes from ui/panels.ts, which cannot forget.
+    setSalesforceUrl();
+    const api = fakeApi({
+      limits: vi.fn(async () => {
+        throw new Error(
+          "REQUEST_LIMIT_EXCEEDED\nCheck Setup › Company Information › 'API Requests, Last 24 Hours'.",
+        );
+      }) as unknown as SalesforceApiClient['limits'],
+    });
+    await createOrgLimitsFeature({ api }).onActivate?.();
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+
+    const panel = document.querySelector('.sfdt-console.sfdt-error');
+    expect(panel?.getAttribute('role')).toBe('alert');
+    // …and the org's text and the guidance are separate nodes, so neither can
+    // collapse into the other whatever CSS the surface carries.
+    expect(panel?.querySelector('.sfdt-sf-error-text')?.textContent).toBe(
+      'REQUEST_LIMIT_EXCEEDED',
+    );
+    expect(panel?.querySelector('.sfdt-sf-error-note')?.textContent).toContain(
+      'API Requests, Last 24 Hours',
+    );
+  });
 });

--- a/extension/test/panels.test.ts
+++ b/extension/test/panels.test.ts
@@ -5,7 +5,14 @@
 // used doc.body, which on a Salesforce page is OUTSIDE our closed shadow root.
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { errorPanel, loadingPanel, emptyPanel, busyOverlay } from '../ui/panels.js';
+import {
+  renderSfError,
+  setSfError,
+  clearSfError,
+  loadingPanel,
+  emptyPanel,
+  busyOverlay,
+} from '../ui/panels.js';
 import { setContentRoot } from '../ui/content-root.js';
 
 beforeEach(() => {
@@ -16,25 +23,112 @@ afterEach(() => {
   setContentRoot(null);
 });
 
-describe('errorPanel()', () => {
+// A Salesforce error's `.message` is multi-line by construction since
+// lib/sf-error-guidance.ts: the org's own text, then everything we appended.
+const ORG_TEXT = "No such column 'Invoice_Statuss__c' on entity 'Invoice__c'.";
+const NOTE = 'INVALID_FIELD · field: Invoice_Statuss__c — That field is not on the object.';
+const COMPOSED = `${ORG_TEXT}\n${NOTE}`;
+
+describe('renderSfError()', () => {
   it('announces itself as an alert', () => {
-    const el = errorPanel('INVALID_FIELD: No such column');
+    // The a11y half of the item: 15 hand-rolled copies of this block set the
+    // classes and forgot the role, so a screen reader never announced a
+    // failure. A builder cannot forget.
+    const el = renderSfError(new Error(ORG_TEXT));
     expect(el.getAttribute('role')).toBe('alert');
-    expect(el.textContent).toBe('INVALID_FIELD: No such column');
+    expect(el.textContent).toBe(ORG_TEXT);
   });
 
   it('wears the class that preserves newlines', () => {
-    // Since lib/sf-error-guidance.ts a Salesforce error message is multi-line —
-    // the org's text, then the "what to do" line. Without a white-space rule the
-    // guidance runs into the org's own text; that shipped once, which is why
-    // test/error-render-newlines.test.ts exists.
-    expect(errorPanel('a\nb').className).toContain('sfdt-console');
+    expect(renderSfError(COMPOSED).className).toContain('sfdt-console');
+  });
+
+  it('renders the org text and the guidance as SEPARATE nodes', () => {
+    // The root cause of PR #308's 16 one-by-one fixes: with the two halves in
+    // one text node, whether they stayed apart depended on a `white-space` rule
+    // each surface had to remember. Separate element nodes cannot collapse.
+    const el = renderSfError(new Error(COMPOSED));
+    const parts = [...el.children].map((c) => c.textContent);
+    expect(parts).toEqual([ORG_TEXT, NOTE]);
+    expect(el.querySelector('.sfdt-sf-error-text')?.textContent).toBe(ORG_TEXT);
+    expect(el.querySelector('.sfdt-sf-error-note')?.textContent).toBe(NOTE);
+  });
+
+  it('never drops the org’s own text in favour of ours', () => {
+    // The other half of what #308 fixed: several surfaces kept the guidance and
+    // threw the org's real error away. The org's wording is always node one.
+    const el = renderSfError(new Error(COMPOSED), { guidance: 'Check field-level security.' });
+    expect(el.firstElementChild?.textContent).toBe(ORG_TEXT);
+    expect(el.textContent).toContain('Check field-level security.');
+  });
+
+  it('appends caller guidance as its own node, below the org’s', () => {
+    const el = renderSfError(ORG_TEXT, { guidance: 'Reload the tab and retry.' });
+    expect([...el.children].map((c) => c.textContent)).toEqual([
+      ORG_TEXT,
+      'Reload the tab and retry.',
+    ]);
+  });
+
+  it('takes whatever `catch` produced', () => {
+    expect(renderSfError('a plain string').textContent).toBe('a plain string');
+    expect(renderSfError(new Error('boom')).textContent).toBe('boom');
+    expect(renderSfError({ toString: () => 'weird' }).textContent).toBe('weird');
+    // null renders nothing rather than the word "null" — the pre-built,
+    // still-hidden panels four features mount at open() pass exactly this.
+    expect(renderSfError(null).textContent).toBe('');
+    expect(renderSfError(null).children).toHaveLength(0);
+  });
+
+  it('drops blank lines rather than emitting empty nodes', () => {
+    expect(renderSfError('a\n\nb').children).toHaveLength(2);
   });
 
   it('never interprets the org text as markup', () => {
-    const el = errorPanel('<img src=x onerror=alert(1)>');
-    expect(el.children).toHaveLength(0);
+    const el = renderSfError('<img src=x onerror=alert(1)>');
+    expect(el.querySelector('img')).toBeNull();
     expect(el.textContent).toBe('<img src=x onerror=alert(1)>');
+  });
+});
+
+describe('setSfError() / clearSfError()', () => {
+  it('turns a plain console pane into a real alert', () => {
+    // The debug-log and Execute Anonymous panes are a `<pre class="sfdt-console">`
+    // that renders output until it has to render a failure. Re-classing it by
+    // hand was the hand-roll; the role was what got left off.
+    const pane = document.createElement('pre');
+    pane.className = 'sfdt-console';
+    setSfError(pane, new Error(COMPOSED));
+    expect(pane.getAttribute('role')).toBe('alert');
+    expect(pane.classList.contains('sfdt-error')).toBe(true);
+    expect([...pane.children].map((c) => c.textContent)).toEqual([ORG_TEXT, NOTE]);
+  });
+
+  it('replaces the previous failure rather than appending to it', () => {
+    const pane = document.createElement('div');
+    setSfError(pane, 'first');
+    setSfError(pane, 'second');
+    expect(pane.textContent).toBe('second');
+  });
+
+  it('clears the alert role with the content', () => {
+    // A reused pane that keeps role="alert" announces the NEXT thing rendered
+    // into it as a failure — the success path's log body, in three of the four
+    // surfaces that reuse a pane.
+    const pane = document.createElement('div');
+    setSfError(pane, new Error('boom'));
+    clearSfError(pane);
+    expect(pane.getAttribute('role')).toBeNull();
+    expect(pane.classList.contains('sfdt-error')).toBe(false);
+    expect(pane.textContent).toBe('');
+  });
+
+  it('builds into a `<pre>` without nesting block elements inside it', () => {
+    // `<pre>` takes phrasing content; the parts are spans laid out as blocks by
+    // the shared sheet, not divs.
+    const pane = document.createElement('pre');
+    setSfError(pane, new Error(COMPOSED));
+    expect([...pane.children].every((c) => c.tagName === 'SPAN')).toBe(true);
   });
 });
 

--- a/extension/test/sf-error-panel-contract.test.ts
+++ b/extension/test/sf-error-panel-contract.test.ts
@@ -1,0 +1,216 @@
+// One code path renders a Salesforce error. This is the check that keeps it one.
+//
+// PR #308 fixed sixteen surfaces, ONE AT A TIME, that were mis-rendering an org
+// error — collapsing our guidance line into the org's own text, and in several
+// cases discarding the org's error entirely. Every one of those sixteen was a
+// separate hand-roll of the same six lines:
+//
+//     const panel = doc.createElement('div');
+//     panel.classList.add('sfdt-console', 'sfdt-error');
+//     panel.textContent = err instanceof Error ? err.message : String(err);
+//
+// Fixing them individually left the cause untouched: nothing stopped the
+// seventeenth. The two behavioural guards that came out of #308 —
+// `error-render-newlines.test.ts` and `sf-error-guidance.test.ts` — pin what a
+// correct panel LOOKS like, but a brand-new hand-roll that happens to satisfy
+// both still passes them. This one pins the code PATH, which is the only thing
+// that makes the next regression unavailable rather than merely unlikely.
+//
+// The rule: `.sfdt-console` + `.sfdt-error` on the same element is the
+// Salesforce-error block, and only `ui/panels.ts` may build it. Everything else
+// calls `renderSfError()` / `setSfError()`.
+//
+// It is deliberately NOT a rule about `.sfdt-error` alone: that class is also
+// the red variant of `.sfdt-pill`, which several features legitimately apply to
+// a status chip. The PAIR is what identifies the panel.
+//
+// Golden principle #12 — a check excludes the artifacts that define it. The
+// helper's own implementation, the stylesheet that declares the classes, this
+// file, and the docs describing the fix are all excluded below, by name and
+// with a reason.
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { SFDT_COMPONENT_CSS } from '../lib/ui-styles.js';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(HERE, '..');
+
+// Every directory that ships DOM-building code. `test/` is not scanned: a test
+// asserting on the rendered class pair is describing the contract, not
+// violating it (principle #12), and this file is itself the proof.
+const SCANNED_DIRS = ['features', 'ui', 'entrypoints', 'lib'];
+
+// The artifacts that DEFINE the rule, each with the reason it cannot be a
+// violation. Anything not on this list that names the pair is one.
+const DEFINING_ARTIFACTS: { file: string; because: string }[] = [
+  {
+    file: 'ui/panels.ts',
+    because: 'the implementation — this is the one place allowed to build the block',
+  },
+  {
+    file: 'lib/ui-styles.ts',
+    because: 'the stylesheet that declares `.sfdt-console.sfdt-error`, and the comment at ' +
+      '`.sfdt-callout` that tells a caller which of the two to reach for',
+  },
+];
+
+const CONSOLE_CLASS = 'sfdt-console';
+const ERROR_CLASS = 'sfdt-error';
+
+/**
+ * The class pair applied to one element, in either shape the codebase uses:
+ *
+ *     el.className = 'sfdt-console sfdt-error'
+ *     el.classList.add('sfdt-console', 'sfdt-error')
+ *
+ * Read as a single assignment rather than as two loose occurrences of the class
+ * names, so a file that puts `.sfdt-console` on an output pane and `.sfdt-error`
+ * on a status pill — which several legitimately do — is not flagged.
+ */
+const CLASS_APPLICATION = /\.(?:className\s*=\s*(['"`][^'"`]*['"`])|classList\.add\(([^)]*)\))/g;
+
+export function appliesSfErrorPair(source: string): boolean {
+  for (const m of source.matchAll(CLASS_APPLICATION)) {
+    const args = m[1] ?? m[2] ?? '';
+    const classes = new Set<string>();
+    for (const quoted of args.matchAll(/['"`]([^'"`]*)['"`]/g)) {
+      for (const cls of quoted[1]!.trim().split(/\s+/)) classes.add(cls);
+    }
+    if (classes.has(CONSOLE_CLASS) && classes.has(ERROR_CLASS)) return true;
+  }
+  return false;
+}
+
+function sourceFiles(): string[] {
+  const out: string[] = [];
+  const walk = (abs: string): void => {
+    for (const name of readdirSync(abs)) {
+      const full = path.join(abs, name);
+      if (statSync(full).isDirectory()) walk(full);
+      else if (full.endsWith('.ts') && !full.endsWith('.d.ts')) out.push(full);
+    }
+  };
+  for (const dir of SCANNED_DIRS) walk(path.join(ROOT, dir));
+  return out;
+}
+
+const isDefining = (rel: string): boolean => DEFINING_ARTIFACTS.some((a) => a.file === rel);
+
+describe('only ui/panels.ts builds the Salesforce error panel', () => {
+  it('no feature, entrypoint or lib module hand-rolls the error block', () => {
+    const offenders = sourceFiles()
+      .map((abs) => path.relative(ROOT, abs))
+      .filter((rel) => !isDefining(rel))
+      .filter((rel) => appliesSfErrorPair(readFileSync(path.join(ROOT, rel), 'utf8')));
+
+    expect(
+      offenders,
+      'these build the Salesforce error panel themselves instead of calling ' +
+        `renderSfError()/setSfError() from ui/panels.ts:\n${offenders.join('\n')}\n\n` +
+        'If the text is OUR prose rather than an org error, `.sfdt-callout` is the right ' +
+        'target — see the comment at `.sfdt-callout` in lib/ui-styles.ts.',
+    ).toEqual([]);
+  });
+
+  it('scans the files it claims to', () => {
+    // A file-scan assertion that silently matched nothing stays green forever.
+    // These four are the surfaces #308 had to fix one at a time.
+    const scanned = new Set(sourceFiles().map((abs) => path.relative(ROOT, abs)));
+    for (const rel of [
+      'features/soql-runner.ts',
+      'features/apex-anonymous.ts',
+      'features/org-limits.ts',
+      'entrypoints/content.ts',
+    ]) {
+      expect(scanned.has(rel), `${rel} must be in the scan`).toBe(true);
+    }
+    expect(scanned.size).toBeGreaterThan(60);
+  });
+
+  it('the guard actually detects a hand-roll', () => {
+    // Both shapes the sixteen used, verbatim.
+    expect(appliesSfErrorPair("panel.classList.add('sfdt-console', 'sfdt-error');")).toBe(true);
+    expect(appliesSfErrorPair("logPane.className = 'sfdt-console sfdt-error';")).toBe(true);
+    // …and the shape a migrated file has instead.
+    expect(appliesSfErrorPair('results.appendChild(renderSfError(err, { doc }));')).toBe(false);
+  });
+
+  it('does not flag the class pair spread across two different elements', () => {
+    // `.sfdt-error` is also the red `.sfdt-pill`. A file with an output console
+    // and a failure chip names both classes and hand-rolls nothing — flagging
+    // it would mean editing correct code to satisfy a check.
+    const legitimate = [
+      "logPane.className = 'sfdt-console';",
+      "pill.className = row.ok ? 'sfdt-pill sfdt-success' : 'sfdt-pill sfdt-error';",
+    ].join('\n');
+    expect(appliesSfErrorPair(legitimate)).toBe(false);
+  });
+
+  it('every migrated surface reaches the helper by import', () => {
+    // The negative rule above is satisfiable by rendering no error at all. This
+    // is the positive half: the surfaces that DO show an org error must be
+    // importing the shared builder.
+    for (const rel of [
+      'features/soql-runner.ts',
+      'features/soap-explore.ts',
+      'features/rest-explore.ts',
+      'features/apex-anonymous.ts',
+      'features/apex-test-runner.ts',
+      'features/debug-log-viewer.ts',
+      'features/trace-flags.ts',
+      'features/dependency-explorer.ts',
+      'features/ai-assistant.ts',
+      'features/field-impact.ts',
+      'features/flow-quality.ts',
+      'features/flow-trigger-explorer-enhancer.ts',
+      'features/bridge-tools.ts',
+      'features/code-coverage.ts',
+      'features/org-limits.ts',
+      'features/schema-browser.ts',
+    ]) {
+      const source = readFileSync(path.join(ROOT, rel), 'utf8');
+      expect(source, `${rel} must render org errors through ui/panels.ts`).toMatch(
+        /import \{[^}]*(?:renderSfError|setSfError)[^}]*\} from '\.\.\/ui\/panels\.js'/s,
+      );
+    }
+  });
+
+  it('every defining artifact still exists and still defines something', () => {
+    // Stops the exclusion list rotting into a hole: an entry that no longer
+    // names the pair is an exclusion nobody needs, and one whose file has moved
+    // silently widens the scan's blind spot.
+    for (const entry of DEFINING_ARTIFACTS) {
+      const source = readFileSync(path.join(ROOT, entry.file), 'utf8');
+      expect(
+        source.includes(CONSOLE_CLASS) && source.includes(ERROR_CLASS),
+        `stale exclusion: ${entry.file} no longer names the error-panel classes`,
+      ).toBe(true);
+      expect(entry.because.length, `${entry.file} exclusion needs a reason`).toBeGreaterThan(30);
+    }
+  });
+});
+
+describe('the rendered parts are styled by the shared sheet', () => {
+  // The helper emits `<span>`s, which are inline by default. Without these two
+  // rules the org's text and the guidance sit on one line — the exact defect,
+  // reintroduced from the other end.
+  it('both parts are laid out as blocks and keep their own newlines', () => {
+    for (const cls of ['sfdt-sf-error-text', 'sfdt-sf-error-note']) {
+      const rule = new RegExp(`\\.${cls}\\s*\\{([^}]*)\\}`).exec(SFDT_COMPONENT_CSS);
+      expect(rule, `${cls} must be declared in lib/ui-styles.ts`).not.toBeNull();
+      expect(rule![1], `${cls} must be a block`).toMatch(/display:\s*block/);
+      expect(rule![1], `${cls} must keep newlines`).toMatch(/white-space:\s*pre-wrap/);
+    }
+  });
+
+  it('the note is body text, not more error text', () => {
+    // Our advice in the same alarm colour as the org's message reads as more of
+    // the failure. Both are theme tokens, so this is right in light and dark.
+    const rule = /\.sfdt-sf-error-note\s*\{([^}]*)\}/.exec(SFDT_COMPONENT_CSS)![1]!;
+    expect(rule).toContain('var(--sfdt-color-text)');
+    expect(rule).not.toContain('#');
+  });
+});

--- a/extension/ui/panels.ts
+++ b/extension/ui/panels.ts
@@ -10,14 +10,24 @@
 // glyph, which spacing) and the caller owns the WORDS. If you find yourself
 // wanting a variant, add a parameter — do not copy the function.
 //
+// The error block is the one that owns more than chrome. `renderSfError()` also
+// owns the SHAPE of a Salesforce failure — the org's own text and every line we
+// appended to it, each as its own node. The single-string builder it replaces
+// left that composition to the caller, and 16 callers each got it slightly
+// wrong (PR #308). Nothing outside this file may build that block; the class
+// pair is a contract, enforced by test/sf-error-panel-contract.test.ts.
+//
 // DOM discipline (CLAUDE.md rule 1): createElement + textContent throughout.
 
+import { errorText, splitUserFacingMessage } from '../lib/sf-error-guidance.js';
 import { glyph } from '../lib/ui-controls.js';
 import { ensureComponentStyles } from '../lib/ui-styles.js';
 import { getContentRoot } from './content-root.js';
 
 /**
- * A failure block carrying an org error.
+ * The chrome of the Salesforce-error block. Declared once, applied by the
+ * builders below and by nothing else — `test/sf-error-panel-contract.test.ts`
+ * fails any other file that names this class pair.
  *
  * `.sfdt-console` is not a stylistic choice: it brings `white-space: pre-wrap`,
  * and since lib/sf-error-guidance.ts a Salesforce error's `.message` is
@@ -25,13 +35,88 @@ import { getContentRoot } from './content-root.js';
  * white-space rule the guidance runs into the org's own text —
  * `test/error-render-newlines.test.ts` exists because that shipped once.
  */
-export function errorPanel(message: string, doc: Document = document): HTMLElement {
+const SF_ERROR_CLASSES = ['sfdt-console', 'sfdt-error'] as const;
+
+export interface SfErrorOptions {
+  doc?: Document;
+  /**
+   * Our own "what to do" prose, appended as its own node below whatever the org
+   * said. Use it for surface-specific advice; the guidance keyed off the org's
+   * `errorCode` is already inside the error's message and needs no help here.
+   */
+  guidance?: string;
+}
+
+/**
+ * Render a Salesforce error as a panel: the org's own text in one node, every
+ * line we appended to it in a node of its own.
+ *
+ * This is the helper whose absence caused PR #308. The builder it replaces took
+ * ONE string, so each of 16 surfaces had to keep the org's text and the
+ * guidance line apart by itself — via a `white-space` rule that several of them
+ * omitted and several more resolved by discarding the org's message entirely.
+ * Separate element nodes make that class of mistake unavailable: a block box
+ * cannot run into the one above it, and a caller can no longer choose which
+ * half to keep because it no longer does the joining.
+ *
+ * Accepts whatever `catch` produced — an `Error`, a string, anything — because
+ * that is what the call sites have. DOM discipline: `createElement` +
+ * `textContent`, so an org message is never markup.
+ */
+export function renderSfError(error: unknown, opts: SfErrorOptions = {}): HTMLElement {
+  const doc = opts.doc ?? document;
   ensureComponentStyles(doc);
   const el = doc.createElement('div');
-  el.className = 'sfdt-console sfdt-error';
+  return setSfError(el, error, opts);
+}
+
+/**
+ * The same rendering, into an element the caller already owns.
+ *
+ * Four surfaces keep one long-lived pane and swap its contents (the SOQL and
+ * SOAP explorers hide/show a pre-built panel; the debug-log and Execute
+ * Anonymous panes re-purpose the console they render output into). Rebuilding
+ * the node would break their layout and their show/hide state, and leaving them
+ * to re-apply the classes by hand is exactly the hand-roll this item removes —
+ * so the fill step is its own export rather than a second copy at each site.
+ *
+ * Applies the panel's classes and `role="alert"` too: a pane that was a plain
+ * console a moment ago must become a real alert when it starts carrying a
+ * failure, or a screen reader never announces it.
+ */
+export function setSfError(el: HTMLElement, error: unknown, opts: SfErrorOptions = {}): HTMLElement {
+  const doc = opts.doc ?? el.ownerDocument ?? document;
+  ensureComponentStyles(doc);
+  el.classList.add(...SF_ERROR_CLASSES);
   el.setAttribute('role', 'alert');
-  el.textContent = message;
+  el.replaceChildren();
+
+  const { orgText, notes } = splitUserFacingMessage(errorText(error));
+  if (orgText !== '') el.appendChild(sfErrorLine(doc, 'sfdt-sf-error-text', orgText));
+  for (const note of notes) el.appendChild(sfErrorLine(doc, 'sfdt-sf-error-note', note));
+  if (opts.guidance) el.appendChild(sfErrorLine(doc, 'sfdt-sf-error-note', opts.guidance));
   return el;
+}
+
+/**
+ * Clear a panel filled by `setSfError` back to empty, dropping the alert role
+ * with it — an empty `role="alert"` region left in the tree is a live
+ * announcement point for whatever lands in it next.
+ */
+export function clearSfError(el: HTMLElement): void {
+  el.replaceChildren();
+  el.classList.remove('sfdt-error');
+  el.removeAttribute('role');
+}
+
+// `<span>`, not `<div>`: two of the panes this fills are `<pre>` elements,
+// whose content model is phrasing content. The block layout comes from the
+// class.
+function sfErrorLine(doc: Document, className: string, text: string): HTMLElement {
+  const line = doc.createElement('span');
+  line.className = className;
+  line.textContent = text;
+  return line;
 }
 
 /** Inline "working on it" line. `role="status"` so it is announced, not silent. */


### PR DESCRIPTION
Backlog item **C-FIX-4** (Chrome ext, size S; depends on C-FIX-3 / #308).

PR #308 fixed sixteen surfaces **one at a time**. This removes what made sixteen possible.

## The residual scope, verified against the code

The row was written before extension v0.12.0 and part of its wording was already done. I checked each claim; the spec was accurate on all three points, with one correction and one addition.

| Spec said | Code says |
|---|---|
| "hoist the duplicated error-panel cssText" — **already done** | Confirmed. `lib/ui-styles.ts:845` defines `.sfdt-console` with `white-space: pre-wrap` at :853 and `.sfdt-console.sfdt-error` at :857. Not redone. |
| `ui/panels.ts:28` already exports `errorPanel(message, doc)` with `role="alert"` | Confirmed. |
| "~7 features import `../ui/panels.js`, ~15 still hand-roll the block, silently omitting `role="alert"`" | Confirmed, and it is **16**, not 15 — the spec's list missed `features/rest-explore.ts`. It was not a hand-roll (it already took its panel from `errorPanel()`), but it is the third `showError()` funnel and was left with the single-string affordance, so it is migrated with the other two. |
| "no helper renders the SALESFORCE-ERROR shape … `errorPanel()` takes a single string, which is exactly the affordance that let the collapse happen" | Confirmed, and it is the crux. See below. |
| "the existing guards pin the BEHAVIOUR but do not force the single code path" | Confirmed. A fresh hand-roll that happens to satisfy both passes both. |

**Correction to the spec's file list.** `features/metadata-retrieve.ts:1296` is *not* an org-error site — it is the static destructive-manifest banner, which carries **our own prose**. Per the item's own instruction (and the comment at `.sfdt-callout` in `lib/ui-styles.ts:599`) it moved to `.sfdt-callout.sfdt-bad`, not to the helper. So: **15 sites routed through the helper, 1 to the callout, plus `rest-explore` = 16 call sites touched.**

**One thing I did that the spec did not ask for, and why.** I deleted `errorPanel()` rather than keeping it beside `renderSfError()`. Two error builders with different DOM shapes is the duplication this item exists to remove, and the single-string signature *is* the named root cause — leaving it in place leaves the next author the shorter wrong path. Its two remaining callers (`schema-browser`, `debug-log-viewer`) are migrated; `UI-SYSTEM.md`'s layer-4 table is updated to match.

## What landed

**`ui/panels.ts` — `renderSfError()` / `setSfError()` / `clearSfError()`**

The org's own text and every line we appended render as **separate element nodes**, laid out as blocks. A block box cannot run into the one above it whatever CSS the host page brings, and a caller can no longer keep the wrong half because it no longer does the joining. `setSfError(el, …)` fills a pane the caller already owns — the SOQL/SOAP/REST explorers hide-and-show a pre-built panel, and the debug-log and Execute Anonymous panes re-purpose the console they render output into; rebuilding those nodes would break their layout, and leaving them to re-apply the classes is exactly the hand-roll being removed. `clearSfError()` takes `role="alert"` back off, because a reused pane that keeps it announces the *next* successful render as a failure.

**`lib/sf-error-guidance.ts` — `splitUserFacingMessage()` beside `buildUserFacingMessage()`**

The newline between the org's records is a **separator, not formatting**. Producer and consumer of that contract now sit in one file rather than agreeing by coincidence. `errorText()` also replaces the fourteen copies of `err instanceof Error ? err.message : String(err)`.

**A11y — the load-bearing part**

All 16 hand-rolls set the classes and omitted `role="alert"`. A failed query, retrieve or test run was a red box to a sighted user and silence to a screen reader. The builder cannot forget. Covered by `test/panels.test.ts` at the unit level and by a new end-to-end assertion in `test/org-limits.test.ts` that drives a real feature to failure and reads the role off the rendered panel.

**Both themes.** The two new classes use `var(--sfdt-color-text)` and inherit the rest; no literal, no theme special-case. The note deliberately stops rendering in the org's alarm colour — advice in the same red as the failure reads as more of the failure rather than as the way out of it. A test asserts the rule contains a token and no `#`.

**`test/sf-error-panel-contract.test.ts` — the missing piece**

No file outside `ui/panels.ts` may apply `.sfdt-console` + `.sfdt-error` to one element. Deliberately the **pair**, not `.sfdt-error` alone — that is also the red `.sfdt-pill`, which several features legitimately put on a status chip; a test asserts the guard does *not* flag a file that uses both classes on two different elements.

Per **golden principle #12** the sweep excludes the artifacts that define it — `ui/panels.ts` (the implementation) and `lib/ui-styles.ts` (the stylesheet declaring the classes), each listed by name **with the reason it cannot be a violation**, plus a test that fails a stale exclusion. `test/` is not scanned at all: a test asserting on the rendered pair describes the contract rather than violating it, and this file is the proof.

I verified the sweep actually fails rather than merely passing: re-adding a `classList.add('sfdt-console', 'sfdt-error')` to `features/org-limits.ts` produced
```
× no feature, entrypoint or lib module hand-rolls the error block
  expected [ 'features/org-limits.ts' ] to deeply equal []
```
and the probe was reverted.

**Existing guards updated, not weakened.** `error-render-newlines.test.ts` learns `renderSfError` as a panel builder, and its "holds the `showError()` funnels" case now asserts the **union** (`errorPanel.textContent = message` OR `setSfError(errorPanel, message`) — which is the lesson that file's own comments record twice: assert the union, not the mechanism. Pinned to the old shape it would have read the *strongest* of the three states as a regression. One `EXEMPT` entry was added for `loadingPanel()`'s `el.textContent = message`: it had been passing only because the error builder in the same file reused the variable name `el`, which is the same-name blind spot that file warns about — now it is a reviewed exemption instead of an accident.

## Call sites migrated

Through the helper (15): `trace-flags`, `debug-log-viewer` (×3 incl. the reused `logPane`), `dependency-explorer`, `ai-assistant`, `field-impact`, `apex-anonymous` (reused `resultPane`), `flow-quality`, `bridge-tools`, `code-coverage`, `soql-runner`, `flow-trigger-explorer-enhancer`, `soap-explore`, `apex-test-runner`, `org-limits`, `schema-browser` (×2), `rest-explore`.
To `.sfdt-callout.sfdt-bad` (1): `metadata-retrieve`'s destructive banner.

`grep -rn "sfdt-error" features/ ui/ entrypoints/ lib/` now returns only pill usages and the two defining artifacts.

## Global DoD

- **Zero `innerHTML`** — `createElement` + `textContent` throughout; a test asserts an org message is never interpreted as markup.
- **No new runtime dependencies, no new manifest permissions.** Neither was needed.
- **Vitest, happy-dom, per-feature pattern** — `panels.test.ts` rewritten for the new API (13 cases), new `sf-error-panel-contract.test.ts` (8 cases), one new end-to-end a11y case in `org-limits.test.ts`.
- **A11y checklist** — item 10 (labelling) / 11 (state exposed, not styled) are the load-bearing ones here and are MET by construction. Items 1–9 and 13 are **N/A**: this adds no overlay, no keyboard path and no new mount point; it changes the contents of panels that existing overlays already present.
- **Both themes** — MET, tokens only.
- **CHANGELOG** — entry under `[Unreleased]` in `extension/CHANGELOG.md`.
- **Docs site** — **no change needed, stated explicitly rather than skipped.** This is an internal refactor plus an a11y fix: no new command, subcommand, flag, config key, feature gate, MCP tool, or page. I grepped `sfdt-site/content/chrome-extension/` for "error panel", `role="alert"`, "screen reader" and "accessib" — nothing documents error-panel rendering, so there is nothing to bring in sync.
- **`generated/`** — untouched; `check:catalog-drift` reports "Catalogs up to date (11 files)".
- **`FEATURES.json`** — not touched.

## Gates — actual output

From `extension/`:

```
$ npx vitest run
 Test Files  109 passed (109)
      Tests  1896 passed (1896)
   Duration  28.80s

$ npx tsc --noEmit
tsc OK          # no output

$ npx eslint .
eslint OK       # no output

$ npx wxt build
√ Built extension in 2.699 s
Σ Total size: 1.36 MB
√ Finished in 3.248 s
```

From the repo root:

```
$ npm test
 Test Files  313 passed (313)
      Tests  5252 passed (5252)
   Duration  80.72s

$ npm run check:all-contracts
EXIT=0
Catalogs up to date (11 files).
License policy OK (7 manifests, 2 license files, 18 prose files).
Node version policy OK (>=22.15.0 everywhere).
Auth docs OK (53 files scanned).
FEATURES.json OK (1 entries, structure checked).
Package-internal path resolution OK (118 files scanned).
```

Baseline on `origin/develop` before any change was 108 files / 1878 tests (after `npm install` at the repo root and `npm run build:flow-core` — the extension suite cannot resolve `@sfdt/flow-core` without it).

## Not verified

- **No manual browser run.** Everything here is happy-dom; I did not load `.output/chrome-mv3` against a real org, so the *visual* result of the org-text/guidance split (block spacing, the note's colour against the console surface) is asserted by CSS-rule tests rather than seen. Worth a look in both themes before release.
- **Clipboard behaviour across the new block boundary.** Chrome inserts a newline when copying across `display: block` elements, so selecting a panel should still yield the org text and the guidance on separate lines — but `element.textContent` no longer contains the newline, which is a real semantic change for any future code reading a panel's text back. Nothing does today.

## Defects spotted and deliberately left out of this PR

1. `ui/health-modal.ts` and `features/debug-log-viewer.ts:417` use `sfdt-error` as a *pill* variant while `severityPillClass()` returns bare class strings — correct, but the naming makes the pill and the panel look related when they are not. A rename to `.sfdt-pill-danger` would make the sweep's rule self-evident.
2. `features/ai-assistant.ts:204` still sets `resultArea.style.cssText = 'margin-top: 12px;'` — a magic pixel that should be a spacing token.
3. `features/metadata-retrieve.ts:1281-1288` builds two bare `<button>` elements with `createElement('button')` rather than `button()` from `lib/ui-controls.ts` — the hand-rolled-button pattern `UI-SYSTEM.md` calls out, in the file I touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VB79Rk4ncg7UNGD4Y9JYFJ)_