### PR TITLE
feat(mcp): support explicit per-call project roots

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -279,6 +279,11 @@ catalog-derived, see `generated/summary.json`). Design rules:
 - **Envelope unwrapping**: the server shells out to the CLI with `--json` and its
   `#parseCliJson` unwraps the sf-native `{ status, result }` envelope — it is the only stdout
   consumer; everything else reads snapshot files.
+- **Multi-project routing**: every tool schema exposes optional `projectRoot`. A server started
+  inside an initialized project preserves legacy cwd-bound behavior; a neutral server requires
+  `projectRoot` per call. `loadConfig(projectRoot)` validates the target before execution, and
+  `AsyncLocalStorage` keeps config, CLI cwd, logs, and parked results isolated across concurrent
+  requests. Never replace this with mutable shared request state.
 - Two tools are transport-internal, not command-backed: `sfdt_logs` and
   `sfdt_get_parked_result` (`MCP_INTERNAL_TOOLS`).
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -14,6 +14,24 @@ sfdt mcp start
 
 This starts a JSON-RPC 2.0 stdio stream on standard input and output. All operational logs are routed to standard error (`stderr`) to keep the RPC channel clean.
 
+### Project routing
+
+The server supports both project-bound and multi-project clients:
+
+- When started inside an initialized Salesforce DX project, calls may omit `projectRoot`; SFDT uses the project containing both `sfdx-project.json` and `.sfdt/`.
+- When started outside a project, the server remains available for tool discovery and each tool call must provide `projectRoot`.
+- A call may always provide `projectRoot` to override the startup project. SFDT validates that path through the normal config loader before executing anything.
+
+`projectRoot` is available on every tool schema:
+
+```json
+{
+  "projectRoot": "/absolute/path/to/initialized-salesforce-project"
+}
+```
+
+Configuration is isolated per request, so concurrent calls can safely target different projects. The project must already contain `sfdx-project.json` and a valid `.sfdt/` configuration; otherwise the call returns an error before invoking a command. This routes the local project only—it does not authorize or implicitly select a Salesforce org.
+
 ---
 
 ## Config Options

--- a/generated/mcp-tools.json
+++ b/generated/mcp-tools.json
@@ -6,6 +6,7 @@
       "confirmExecution": false,
       "internal": false,
       "inputProperties": [
+        "projectRoot",
         "strict"
       ]
     },
@@ -15,6 +16,7 @@
       "confirmExecution": false,
       "internal": false,
       "inputProperties": [
+        "projectRoot",
         "org"
       ]
     },
@@ -24,6 +26,7 @@
       "confirmExecution": false,
       "internal": false,
       "inputProperties": [
+        "projectRoot",
         "source",
         "target"
       ]
@@ -34,6 +37,7 @@
       "confirmExecution": false,
       "internal": false,
       "inputProperties": [
+        "projectRoot",
         "generateStubs",
         "fixPlan",
         "apexGuru",
@@ -46,6 +50,7 @@
       "confirmExecution": false,
       "internal": true,
       "inputProperties": [
+        "projectRoot",
         "type"
       ]
     },
@@ -55,6 +60,7 @@
       "confirmExecution": false,
       "internal": false,
       "inputProperties": [
+        "projectRoot",
         "base",
         "head",
         "package",
@@ -67,6 +73,7 @@
       "confirmExecution": false,
       "internal": false,
       "inputProperties": [
+        "projectRoot",
         "manifest",
         "targetOrg",
         "testLevel",
@@ -79,6 +86,7 @@
       "confirmExecution": true,
       "internal": false,
       "inputProperties": [
+        "projectRoot",
         "manifest",
         "targetOrg",
         "testLevel",
@@ -97,6 +105,7 @@
       "confirmExecution": true,
       "internal": false,
       "inputProperties": [
+        "projectRoot",
         "validationJobId",
         "targetOrg",
         "confirmExecution"
@@ -108,6 +117,7 @@
       "confirmExecution": true,
       "internal": false,
       "inputProperties": [
+        "projectRoot",
         "confirmExecution"
       ]
     },
@@ -117,6 +127,7 @@
       "confirmExecution": false,
       "internal": false,
       "inputProperties": [
+        "projectRoot",
         "org",
         "check"
       ]
@@ -127,6 +138,7 @@
       "confirmExecution": false,
       "internal": false,
       "inputProperties": [
+        "projectRoot",
         "org",
         "check",
         "backup"
@@ -138,6 +150,7 @@
       "confirmExecution": true,
       "internal": false,
       "inputProperties": [
+        "projectRoot",
         "source",
         "target",
         "metadata",
@@ -151,6 +164,7 @@
       "confirmExecution": false,
       "internal": false,
       "inputProperties": [
+        "projectRoot",
         "type",
         "pr"
       ]
@@ -161,6 +175,7 @@
       "confirmExecution": false,
       "internal": false,
       "inputProperties": [
+        "projectRoot",
         "type"
       ]
     },
@@ -170,6 +185,7 @@
       "confirmExecution": false,
       "internal": false,
       "inputProperties": [
+        "projectRoot",
         "ai"
       ]
     },
@@ -179,6 +195,7 @@
       "confirmExecution": false,
       "internal": false,
       "inputProperties": [
+        "projectRoot",
         "org"
       ]
     },
@@ -188,6 +205,7 @@
       "confirmExecution": false,
       "internal": false,
       "inputProperties": [
+        "projectRoot",
         "org"
       ]
     },
@@ -197,6 +215,7 @@
       "confirmExecution": false,
       "internal": false,
       "inputProperties": [
+        "projectRoot",
         "name",
         "org"
       ]
@@ -207,6 +226,7 @@
       "confirmExecution": false,
       "internal": false,
       "inputProperties": [
+        "projectRoot",
         "org"
       ]
     },
@@ -216,6 +236,7 @@
       "confirmExecution": true,
       "internal": false,
       "inputProperties": [
+        "projectRoot",
         "version",
         "package",
         "name",
@@ -228,6 +249,7 @@
       "confirmExecution": true,
       "internal": false,
       "inputProperties": [
+        "projectRoot",
         "alias",
         "days",
         "confirmExecution"
@@ -239,6 +261,7 @@
       "confirmExecution": true,
       "internal": false,
       "inputProperties": [
+        "projectRoot",
         "target",
         "confirmExecution"
       ]
@@ -249,6 +272,7 @@
       "confirmExecution": true,
       "internal": false,
       "inputProperties": [
+        "projectRoot",
         "action",
         "size",
         "confirmExecution"
@@ -260,6 +284,7 @@
       "confirmExecution": false,
       "internal": false,
       "inputProperties": [
+        "projectRoot",
         "set",
         "org"
       ]
@@ -270,6 +295,7 @@
       "confirmExecution": true,
       "internal": false,
       "inputProperties": [
+        "projectRoot",
         "set",
         "org",
         "confirmExecution"
@@ -281,6 +307,7 @@
       "confirmExecution": true,
       "internal": false,
       "inputProperties": [
+        "projectRoot",
         "set",
         "org",
         "confirmExecution"
@@ -292,6 +319,7 @@
       "confirmExecution": false,
       "internal": false,
       "inputProperties": [
+        "projectRoot",
         "org",
         "logId",
         "limit"
@@ -303,6 +331,7 @@
       "confirmExecution": true,
       "internal": false,
       "inputProperties": [
+        "projectRoot",
         "action",
         "org",
         "user",
@@ -318,6 +347,7 @@
       "confirmExecution": true,
       "internal": false,
       "inputProperties": [
+        "projectRoot",
         "org",
         "file",
         "apexCode",
@@ -330,6 +360,7 @@
       "confirmExecution": false,
       "internal": false,
       "inputProperties": [
+        "projectRoot",
         "classNames"
       ]
     },
@@ -339,6 +370,7 @@
       "confirmExecution": false,
       "internal": false,
       "inputProperties": [
+        "projectRoot",
         "type",
         "limit"
       ]
@@ -349,6 +381,7 @@
       "confirmExecution": false,
       "internal": false,
       "inputProperties": [
+        "projectRoot",
         "org",
         "localOnly"
       ]
@@ -359,6 +392,7 @@
       "confirmExecution": false,
       "internal": false,
       "inputProperties": [
+        "projectRoot",
         "term",
         "category",
         "limit",
@@ -371,6 +405,7 @@
       "confirmExecution": false,
       "internal": false,
       "inputProperties": [
+        "projectRoot",
         "sobject",
         "filter",
         "tooling",
@@ -383,6 +418,7 @@
       "confirmExecution": false,
       "internal": false,
       "inputProperties": [
+        "projectRoot",
         "query",
         "org"
       ]
@@ -393,6 +429,7 @@
       "confirmExecution": false,
       "internal": false,
       "inputProperties": [
+        "projectRoot",
         "query",
         "org"
       ]
@@ -403,6 +440,7 @@
       "confirmExecution": false,
       "internal": false,
       "inputProperties": [
+        "projectRoot",
         "query",
         "limit",
         "tooling",
@@ -415,6 +453,7 @@
       "confirmExecution": false,
       "internal": true,
       "inputProperties": [
+        "projectRoot",
         "ref"
       ]
     }

--- a/src/lib/mcp-server.js
+++ b/src/lib/mcp-server.js
@@ -10,6 +10,7 @@ import os from 'os';
 import path from 'path';
 import fs from 'fs-extra';
 import { fileURLToPath } from 'url';
+import { AsyncLocalStorage } from 'node:async_hooks';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -632,6 +633,21 @@ export const TOOLS = [
   }
 ];
 
+const PROJECT_ROOT_SCHEMA = {
+  type: 'string',
+  description: 'Absolute or relative path to an initialized Salesforce DX project containing sfdx-project.json and .sfdt/. Required when the MCP server was launched outside a configured project.',
+};
+
+// projectRoot is request routing metadata shared by every tool. It remains
+// optional for backward compatibility with servers launched from an initialized
+// project; neutral servers require it at call time.
+for (const tool of TOOLS) {
+  tool.inputSchema.properties = {
+    projectRoot: PROJECT_ROOT_SCHEMA,
+    ...(tool.inputSchema.properties ?? {}),
+  };
+}
+
 // SEP-2549 cache metadata for tools/list: the catalog is a static module
 // constant that cannot change within a process, so clients may cache it
 // long-lived and share it across users.
@@ -669,13 +685,16 @@ function extractTraceContext(meta) {
 export class SfdtMcpServer {
   #server;
   #config;
+  #callConfig = new AsyncLocalStorage();
 
   async start() {
     try {
       this.#config = await loadConfig();
     } catch (err) {
-      console.error(`MCP Server start failed: Config not found. ${err.message}`);
-      process.exit(1);
+      // Neutral startup lets clients route each request with projectRoot while
+      // preserving legacy cwd-bound behavior when a default config is found.
+      this.#config = null;
+      console.error(`sfdt MCP starting without a default project: ${err.message}`);
     }
 
     this.#server = new Server(
@@ -711,9 +730,15 @@ export class SfdtMcpServer {
       console.error(`MCP Call: ${name} argKeys=[${argKeys.join(',')}] argBytes=${argBytes}${traceSuffix}`);
 
       try {
-        const result = await this.#executeTool(name, args ?? {});
-        // Automatically check if results exceed context budgets and park them
-        const processed = await parkIfNeeded(result, this.#config);
+        const callArgs = args ?? {};
+        const config = await this.#resolveCallConfig(callArgs.projectRoot);
+        const toolArgs = { ...callArgs };
+        delete toolArgs.projectRoot;
+        const processed = await this.#callConfig.run(config, async () => {
+          const result = await this.#executeTool(name, toolArgs);
+          // Automatically check if results exceed context budgets and park them.
+          return parkIfNeeded(result, config);
+        });
 
         return {
           ...(trace && { _meta: trace }),
@@ -740,9 +765,21 @@ export class SfdtMcpServer {
     });
   }
 
+  async #resolveCallConfig(projectRoot) {
+    if (projectRoot !== undefined) {
+      if (typeof projectRoot !== 'string' || projectRoot.trim() === '') {
+        throw new Error('projectRoot must be a non-empty path to an initialized Salesforce DX project.');
+      }
+      return loadConfig(projectRoot);
+    }
+    if (this.#config) return this.#config;
+    throw new Error('No default Salesforce project is configured. Pass projectRoot for this tool call.');
+  }
+
   async #executeTool(name, args) {
-    const projectRoot = this.#config._projectRoot;
-    const logDir = this.#config.logDir ?? path.join(projectRoot, 'logs');
+    const config = this.#callConfig.getStore() ?? this.#config;
+    const projectRoot = config._projectRoot;
+    const logDir = config.logDir ?? path.join(projectRoot, 'logs');
 
     // Handle standard tool calls
     switch (name) {
@@ -1178,7 +1215,7 @@ export class SfdtMcpServer {
       }
 
       case 'sfdt_get_parked_result': {
-        return await getParkedResult(args.ref, this.#config);
+        return await getParkedResult(args.ref, config);
       }
 
       default:
@@ -1203,7 +1240,8 @@ export class SfdtMcpServer {
   }
 
   async #runCliCommand(args, envOverrides = {}) {
-    const projectRoot = this.#config._projectRoot;
+    const config = this.#callConfig.getStore() ?? this.#config;
+    const projectRoot = config._projectRoot;
     
     // Explicitly run with stdout/stderr captured (never inherit)
     // so we do not corrupt standard stdio channels of the parent MCP process.

--- a/test/lib/mcp-server.test.js
+++ b/test/lib/mcp-server.test.js
@@ -58,6 +58,7 @@ vi.mock('../../src/lib/mcp-parking.js', () => ({
 
 import { execa } from 'execa';
 import fs from 'fs-extra';
+import { loadConfig } from '../../src/lib/config.js';
 import { SfdtMcpServer, TOOLS } from '../../src/lib/mcp-server.js';
 import { parkIfNeeded, getParkedResult } from '../../src/lib/mcp-parking.js';
 
@@ -86,6 +87,28 @@ describe('SfdtMcpServer', () => {
     expect(result.cacheScope).toBe('global');
   });
 
+  it('advertises optional projectRoot on every tool schema', () => {
+    for (const tool of TOOLS) {
+      expect(tool.inputSchema.properties.projectRoot, tool.name).toEqual(
+        expect.objectContaining({ type: 'string' })
+      );
+    }
+  });
+
+  it('starts without a default project so clients can provide projectRoot per call', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined);
+    loadConfig.mockRejectedValueOnce(new Error('no configured project in cwd'));
+    mockRegisteredHandlers.clear();
+
+    const neutralServer = new SfdtMcpServer();
+    await neutralServer.start();
+
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(mockRegisteredHandlers.has('list-tools')).toBe(true);
+    expect(mockRegisteredHandlers.has('call-tool')).toBe(true);
+    exitSpy.mockRestore();
+  });
+
   describe('call-tool actions', () => {
     let callHandler;
 
@@ -96,6 +119,63 @@ describe('SfdtMcpServer', () => {
     const callTool = (name, args = {}) => {
       return callHandler({ params: { name, arguments: args } });
     };
+
+    it('routes a call through configuration loaded from explicit projectRoot', async () => {
+      loadConfig.mockResolvedValueOnce({
+        _projectRoot: '/workspace/customer-project',
+        _configDir: '/workspace/customer-project/.sfdt',
+        defaultOrg: 'customer-dev',
+        logDir: '/workspace/customer-project/logs',
+      });
+      execa.mockResolvedValueOnce({ exitCode: 0, stdout: 'preflight pass', stderr: '' });
+
+      await callTool('sfdt_preflight', {
+        projectRoot: '/workspace/customer-project',
+        strict: true,
+      });
+
+      expect(loadConfig).toHaveBeenCalledWith('/workspace/customer-project');
+      expect(execa).toHaveBeenCalledWith(
+        'node',
+        expect.arrayContaining(['preflight', '--strict']),
+        expect.objectContaining({ cwd: '/workspace/customer-project' })
+      );
+    });
+
+    it('rejects an invalid explicit projectRoot without executing a command', async () => {
+      loadConfig.mockRejectedValueOnce(new Error('project is not initialized with .sfdt'));
+
+      const result = await callTool('sfdt_preflight', {
+        projectRoot: '/workspace/not-a-project',
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('project is not initialized');
+      expect(execa).not.toHaveBeenCalled();
+    });
+
+    it('isolates concurrent calls routed to different project roots', async () => {
+      loadConfig.mockImplementation(async (root) => ({
+        _projectRoot: root || '/project',
+        _configDir: `${root || '/project'}/.sfdt`,
+        logDir: `${root || '/project'}/logs`,
+      }));
+      execa.mockImplementation(async (_command, _args, options) => {
+        await new Promise((resolve) => setTimeout(resolve, options.cwd.endsWith('one') ? 10 : 1));
+        return { exitCode: 0, stdout: options.cwd, stderr: '' };
+      });
+
+      const [one, two] = await Promise.all([
+        callTool('sfdt_preflight', { projectRoot: '/workspace/one' }),
+        callTool('sfdt_preflight', { projectRoot: '/workspace/two' }),
+      ]);
+
+      expect(one.content[0].text).toContain('/workspace/one');
+      expect(two.content[0].text).toContain('/workspace/two');
+      expect(execa.mock.calls.map((call) => call[2].cwd)).toEqual(
+        expect.arrayContaining(['/workspace/one', '/workspace/two'])
+      );
+    });
 
     it('executes sfdt_preflight tool', async () => {
       execa.mockResolvedValueOnce({ exitCode: 0, stdout: 'preflight pass', stderr: '' });
@@ -534,7 +614,9 @@ describe('MCP tool examples (advanced tool use)', () => {
   // where JSON schema alone under-specifies parameter conventions.
   const isInScope = (tool) => {
     const props = tool.inputSchema?.properties ?? {};
-    const names = Object.keys(props);
+    // projectRoot is common request-routing metadata, not an operation-specific
+    // parameter that makes an otherwise simple tool require examples.
+    const names = Object.keys(props).filter((name) => name !== 'projectRoot');
     if (names.length >= 2) return true;
     return names.some((n) => Array.isArray(props[n].enum) || props[n].type === 'array');
   };


### PR DESCRIPTION
## Summary

- allow the SFDT MCP server to start outside an initialized Salesforce project
- expose optional `projectRoot` routing metadata on every MCP tool
- load and validate project configuration per call while preserving cwd-based compatibility
- isolate concurrent project contexts with `AsyncLocalStorage`
- document the multi-project contract and regenerate the MCP tool catalog

## Why

Repository-backed agent profiles can operate across multiple Salesforce DX projects while their MCP server runs from a neutral control-plane directory. Previously SFDT loaded one project configuration at startup and exited when the process cwd was not an initialized SFDT project.

## Safety and compatibility

- Existing clients launched inside an initialized project may continue omitting `projectRoot`.
- Neutral servers require `projectRoot` before executing a tool.
- Invalid roots fail through the existing config loader before command execution.
- `projectRoot` chooses local project configuration; it does not authorize a live-org mutation.
- Existing `confirmExecution` gates remain unchanged.
- Request-local config prevents concurrent calls from leaking project cwd, logs, or parked results.

## Verification

- `npx vitest run test/lib/mcp-server.test.js` — 46 passed
- `npm test -- --run` — 5,557 passed across 321 files
- `npm run lint` — passed
- `npm run generate:catalogs` — 11 catalogs regenerated
- `npm run check:all-contracts` — passed
- real stdio MCP smoke — 39 tools discovered; explicit `projectRoot` call returned configured API version 66.0 without a live-org operation
- Hermes SFAOS model smoke — `gpt-5.6-sol` routed a read-only target-project audit through `sfdt_api_versions` successfully
